### PR TITLE
Fix TLE::from_lines() producing unexpected output

### DIFF
--- a/src/tle.rs
+++ b/src/tle.rs
@@ -113,19 +113,17 @@ impl TLE {
             if line.len() < 2 {
                 continue;
             }
-            if line.chars().nth(0).unwrap() == '0' {
-                line0 = line;
-            }
             if line.chars().nth(0).unwrap() == '1' {
                 line1 = line;
-            }
-            if line.chars().nth(0).unwrap() == '2' {
+            } else if line.chars().nth(0).unwrap() == '2' {
                 line2 = line;
                 if line0.is_empty() {
                     tles.push(TLE::load_2line(line1, line2)?);
                 } else {
                     tles.push(TLE::load_3line(line0, line1, line2)?);
                 }
+            } else {
+                line0 = line;
             }
         }
 

--- a/src/tle.rs
+++ b/src/tle.rs
@@ -105,8 +105,9 @@ pub struct TLE {
 impl TLE {
     pub fn from_lines(lines: &Vec<String>) -> SKResult<Vec<TLE>> {
         let mut tles: Vec<TLE> = Vec::<TLE>::new();
-        let mut line0: &String = &String::new();
-        let mut line1: &String = &String::new();
+        let empty: &String = &String::new();
+        let mut line0: &String = empty;
+        let mut line1: &String = empty;
         let mut line2: &String;
 
         for line in lines {
@@ -122,6 +123,8 @@ impl TLE {
                 } else {
                     tles.push(TLE::load_3line(line0, line1, line2)?);
                 }
+                line0 = empty;
+                line1 = empty;
             } else {
                 line0 = line;
             }


### PR DESCRIPTION
First off: thank you for this comprehensive library, which I'm likely to use for a number of tools.

Unfortunately, `TLE::from_lines()` produces unexpected output on some inputs:
- The satellite name is not parsed, if it isn't preceded by a `0`-character.
- Once a satellite name has been parsed, it will be used for all following TLEs, if they don't contain a satellite name (or it is not preceded by a `0`-character). While mixing two- and three-line elements may be uncommon, I see no reason to exclude the possibility.

`TLE::load_3line()` handles satellite names without a leading 0 correctly.

Consider the following example:
```rust
fn main() {
    let response = vec![
        "GSAT0101 (GALILEO-PFM)  ",
        "1 37846U 11060A   24247.73900373 -.00000105  00000+0  00000+0 0  9992",
        "2 37846  57.1274 359.4123 0001042  74.3951 285.6259  1.70476006 80016",
        "0 GSAT0102 (GALILEO-FM2)  ",
        "1 37847U 11060B   24246.48938021 -.00000109  00000+0  00000+0 0  9999",
        "2 37847  57.1284 359.4462 0001451 327.1104  31.5305  1.70475484 80128",
        "GSAT0103 (GALILEO-FM3)  ",
        "1 38857U 12055A   24248.95167632  .00000014  00000+0  00000+0 0  9996",
        "2 38857  55.4390 119.4124 0003293 279.2604  80.8075  1.70473845 73926",
        "1 38858U 12055B   24245.11677202 -.00000005  00000+0  00000+0 0  9992",
        "2 38858  55.4454 119.8447 0001570  77.7555 282.3550  1.64592253  2367",
        "",
    ];

    let lines = response
        .into_iter()
        .map(|line| line.to_owned())
        .collect::<Vec<String>>();
    let tles: Vec<satkit::TLE> = satkit::TLE::from_lines(lines.as_ref()).unwrap();

    for tle in tles {
        println!("'{}'", tle.name)
    }
}
```

Currently the output is:
```
'none'
'GSAT0102 (GALILEO-FM2)  '
'GSAT0102 (GALILEO-FM2)  '
'GSAT0102 (GALILEO-FM2)  '
```

With the changes in this PR, the output becomes:
```
'GSAT0101 (GALILEO-PFM)  '
'GSAT0102 (GALILEO-FM2)  '
'GSAT0103 (GALILEO-FM3)  '
'none'
```