### PR TITLE
[Tests] Update error message with where/how to download test vectors

### DIFF
--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -681,10 +681,10 @@ mod tests {
         if !testvecfile.is_file() {
             return skerror!(
                 "Required GPS SP3 File: \"{}\" does not exist
-                clone test vectors repo at
-                https://github.com/StevenSamirMichael/satkit-testvecs.git
-                from root of repo or set \"SATKIT_TESTVEC_ROOT\"
-                to point to directory",
+                clone test vectors from:
+                <https://storage.googleapis.com/satkit-testvecs/>
+                using python script in satkit repo: `python/test/download-testvecs.py`
+                or set \"SATKIT_TESTVEC_ROOT\" to point to directory",
                 testvecfile.to_string_lossy()
             );
         }


### PR DESCRIPTION
To prevent breaking again tests due to missing test vectors on my side  i now installed them and here a little update on how to download them. Mostly copied over from `sgp4/sgp4_impl.rs` that has the proper instructions.