### PR TITLE
17 code cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,3 +84,19 @@
 ### No panic if TLE lines are too short
  - Return error rather than panic if not enough characters in TLE
  - Contribution by "DeflateAwning"
+
+
+## Python 0.8.0.  Rust 0.8.0 (not yet released)
+  
+### TLE export to lines
+  - functions for generating 69-character TLE lines from a TLE object
+
+### Python use of "anyhow::Result"
+  - Use "anyhow::Result" where appropriate in python bindings, as it is used in main code branch and compatible with pyo3
+
+### Code Cleanup
+  - Remove "clippy" warnings, mainly in comment indentation and a few inefficient code idioms
+
+### Error Checking on from_datetime
+  - Bounds checking on month, day, hour, minute, second
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "satkit"
 
 
 [dependencies]
-nalgebra = { version = "0.33.2", features = ["serde-serialize"] }
+nalgebra = { version = "0.34.0", features = ["serde-serialize"] }
 ndarray = "0.16.1"
 libc = "0.2"
 chrono = "0.4"
@@ -40,6 +40,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde-pickle = "1.2.0"
 itertools = "0.14.0"
 anyhow = "1"
+webpki-roots = "1.0.2"
+
 
 [build-dependencies]
 cc = { version = "1.2", features = ["parallel"] }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Also includes python bindings for *all* functions via via [pyo3](https://pyo3.rs
   - High-order Earth gravity with multiple models
   - Solar gravity
   - Lunar gravity
-  - Drag (NRL MISE-00 density model)
+  - Drag: NRL MISE-00 density model
   - Radiation pressure
 
 ## ODE Solvers

--- a/src/earthgravity.rs
+++ b/src/earthgravity.rs
@@ -82,7 +82,7 @@ pub fn gravhash() -> &'static HashMap<GravityModel, &'static Gravity> {
 /// * `pos` - nalgebra 3-vector representing ITRF position in meters
 ///
 /// * `order` - The order of the gravity model to use.
-///             Maximum is 16
+///   Maximum is 16
 ///
 /// * `model` - The gravity model to use, of type "GravityModel"
 ///
@@ -111,7 +111,7 @@ pub fn accel(pos_itrf: &Vec3, order: usize, model: GravityModel) -> Vec3 {
 /// * `pos` - nalgebra 3-vector representing ITRF position in meters
 ///
 /// * `order` - The order of the gravity model to use.
-///               Maximum is 16
+///   Maximum is 16
 ///
 /// * `model` - The gravity model to use, of type "GravityModel"
 ///
@@ -158,7 +158,7 @@ type Mat3 = na::Matrix3<f64>;
 /// # Inputs Arguments
 ///
 /// * `pos` - Position as ITRF coordinate (satkit.itrfcoord) or numpy
-///                3-vector representing ITRF position in meters
+///   3-vector representing ITRF position in meters
 ///
 /// * `order` - Order of the gravity model, up to 40
 ///
@@ -480,12 +480,12 @@ impl Gravity {
 
                     accel[1] += 0.5
                         * ((n - m + 2) as f64 * (n - m + 1) as f64).mul_add(
-                            (-1.0 * cnm).mul_add(w[(n + 1, m - 1)], snm * v[(n + 1, m - 1)]),
+                            (-cnm).mul_add(w[(n + 1, m - 1)], snm * v[(n + 1, m - 1)]),
                             (-cnm).mul_add(w[(n + 1, m + 1)], snm * v[(n + 1, m + 1)]),
                         );
                 }
-                accel[2] += (n - m + 1) as f64
-                    * (-1.0 * cnm).mul_add(v[(n + 1, m)], -(snm * w[(n + 1, m)]));
+                accel[2] +=
+                    (n - m + 1) as f64 * (-cnm).mul_add(v[(n + 1, m)], -(snm * w[(n + 1, m)]));
             }
         }
 

--- a/src/frametransform/mod.rs
+++ b/src/frametransform/mod.rs
@@ -448,7 +448,7 @@ mod tests {
     #[test]
     fn test_gmst() {
         // Vallado example 3-5
-        let mut tm = Instant::from_datetime(1992, 8, 20, 12, 14, 0.0);
+        let mut tm = Instant::from_datetime(1992, 8, 20, 12, 14, 0.0).unwrap();
         // Spoof this as UT1 value
         let tdiff = tm.as_mjd_with_scale(TimeScale::UT1) - tm.as_mjd_with_scale(TimeScale::UTC);
         tm -= Duration::from_days(tdiff);
@@ -463,7 +463,7 @@ mod tests {
         // Example 3-14 from Vallado
         // With verification fo intermediate calculations
         // Input time
-        let tm = &Instant::from_datetime(2004, 4, 6, 7, 51, 28.386009);
+        let tm = &Instant::from_datetime(2004, 4, 6, 7, 51, 28.386009).unwrap();
         // Input terrestrial location
         let pitrf = Vec3::new(-1033.4793830, 7901.2952754, 6380.3565958);
         let t_tt = (tm.as_jd_with_scale(TimeScale::TT) - 2451545.0) / 36525.0;

--- a/src/frametransform/mod.rs
+++ b/src/frametransform/mod.rs
@@ -360,13 +360,13 @@ pub fn qtod2mod_approx(tm: &Instant) -> Quat {
 ///    applications, the approximate rotation will work just fine
 ///
 /// * This computatation **does not** include impact of the
-///       Earth solid tides, but it does include polar motion,
-///       precession, and nutation
+///   Earth solid tides, but it does include polar motion,
+///   precession, and nutation
 ///
 /// * This function requires use of the Earth orientation parameters
-///       (EOP) to compute the rotation. If the EOP are not outside of the
-///       valid range of EOP data (1962 to current, predicts to current + ~ 4 months)
-///       they will be set to zero, and a warning will be printed to stderr.
+///   (EOP) to compute the rotation. If the EOP are not outside of the
+///   valid range of EOP data (1962 to current, predicts to current + ~ 4 months)
+///   they will be set to zero, and a warning will be printed to stderr.
 ///
 pub fn qitrf2gcrf(tm: &Instant) -> Quat {
     // w is rotation from international terrestrial reference frame

--- a/src/frametransform/qcirs2gcrs.rs
+++ b/src/frametransform/qcirs2gcrs.rs
@@ -136,8 +136,7 @@ pub fn qcirs2gcrs_dxdy(tm: &Instant, dxdy: Option<(f64, f64)>) -> Quat {
     let mut x = xsums.mul_add(1.0e-6, x0) * ASEC2RAD;
     let mut y = ysums.mul_add(1.0e-6, y0) * ASEC2RAD;
     // If dX and dY are passed in, they are in milli-arcsecs
-    if dxdy.is_some() {
-        let (dx, dy) = dxdy.unwrap();
+    if let Some((dx, dy)) = dxdy {
         x += dx * 1e-3 * ASEC2RAD;
         y += dy * 1e-3 * ASEC2RAD;
     }

--- a/src/jplephem.rs
+++ b/src/jplephem.rs
@@ -112,7 +112,7 @@ impl JPLEphem {
     /// use satkit::Instant;
     ///
     /// // Construct time: March 1 2021 12:00pm UTC
-    /// let t = Instant::from_datetime(2021, 3, 1, 12, 0, 0.0);
+    /// let t = Instant::from_datetime(2021, 3, 1, 12, 0, 0.0).unwrap();
     ///
     /// // Find geocentric moon position at this time in the GCRF frame
     /// let p = jplephem::geocentric_pos(SolarSystem::Moon, &t).unwrap();

--- a/src/kepler.rs
+++ b/src/kepler.rs
@@ -23,18 +23,18 @@ impl<T> From<KeplerError> for Result<T> {
 /// These are:
 ///
 /// * `True Anomaly` - Denoted ν, is the Periapsis-Earth-Satellite
-///    angle in the orbital plane
+///   angle in the orbital plane
 ///
 /// * `Mean Anomaly` - Denoted M, this does not have a great geographical
-///    representation, but is an angle that increases monotonically in time
-///    between 0 and 2π over the course of a single orbit.
+///   representation, but is an angle that increases monotonically in time
+///   between 0 and 2π over the course of a single orbit.
 ///
 /// * `Eccentric Anomaly` - Denoted E, is the Periaps-C-B
-///    angle in the orbital plane, wehre "C" is the center of the orbital
-///    ellipse, and "B" is a point on the auxilliary circle (the circle
-///    bounding the orbital ellipse) along a line from the satellite
-///    and perpendicular to the semimajor axis.  The eccentric anomaly is
-///    a useful prerequisite to compute the mean anomaly
+///   angle in the orbital plane, wehre "C" is the center of the orbital
+///   ellipse, and "B" is a point on the auxilliary circle (the circle
+///   bounding the orbital ellipse) along a line from the satellite
+///   and perpendicular to the semimajor axis.  The eccentric anomaly is
+///   a useful prerequisite to compute the mean anomaly
 ///
 pub enum Anomaly {
     Mean(f64),
@@ -115,7 +115,7 @@ impl Kepler {
     /// * `raan` - Right Ascension of the Ascending Node, radians
     /// * `argp` - Argument of Perigee, radians
     /// * `anomaly` - Anomaly type representing location of satellite along the
-    ///               orbital plane
+    ///   orbital plane
     ///
     /// # Returns
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ## Downloading the data files
 //! ```no_run
-//! // Print the directoyr where data will be stored
+//! // Print the directory where data will be stored
 //! println!("Data directory: {:?}", satkit::utils::datadir());
 //! // Update the data files (download those that are missing; refresh those that are out of date)
 //! // This will always download the most-recent space weather data and Earth Orientation Parameters
@@ -55,7 +55,7 @@
 //! ```
 
 #![warn(clippy::all, clippy::use_self, clippy::cargo)]
-
+#![allow(clippy::multiple_crate_versions)]
 // Type definitions
 pub mod types;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,13 @@
 //! * Keplerian orbit propagation
 //! * JPL planetary ephemerides
 //! * High-order gravity models
-//! * High-precision, high-speed numerical satellite orbit propagation with high-order (9/8) efficient Runga-Kutta solvers, ability to solve for state transition matrix for covariance propagation, and inclusion following forces:
+//! * High-precision, high-speed numerical satellite orbit propagation with high-order (9/8)
+//!   efficient Runga-Kutta solvers, ability to solve for state transition matrix for covariance propagation,
+//!   and inclusion following forces:
 //!   * High-order Earth gravity with multiple models
 //!   * Solar gravity
 //!   * Lunar gravity
-//!   * Dra, with NRL MISE-00 density model and inclusion of space weather data
+//!   * Drag, with NRL MISE-00 density model and inclusion of space weather data
 //!   * Radiation pressure
 //!
 //! # Language Bindings

--- a/src/lpephem/moon.rs
+++ b/src/lpephem/moon.rs
@@ -32,16 +32,55 @@ pub fn pos_gcrf(time: &Instant) -> na::Vector3<f64> {
     const deg2rad: f64 = std::f64::consts::PI / 180.;
 
     let lambda_ecliptic: f64 = deg2rad
-        * 0.11f64.mul_add(-f64::sin(deg2rad * 966404.05f64.mul_add(t, 186.6)), 0.19f64.mul_add(-f64::sin(deg2rad * 35999.05f64.mul_add(t, 357.5)), 0.21f64.mul_add(f64::sin(deg2rad * 954397.70f64.mul_add(t, 269.9)), 0.66f64.mul_add(f64::sin(deg2rad * 890534.23f64.mul_add(t, 235.7)), 1.27f64.mul_add(-f64::sin(deg2rad * 413335.38f64.mul_add(-t, 259.2)), 6.29f64.mul_add(f64::sin(deg2rad * 477198.85f64.mul_add(t, 134.9)), 481267.8813f64.mul_add(t, 218.32)))))));
+        * 0.11f64.mul_add(
+            -f64::sin(deg2rad * 966404.05f64.mul_add(t, 186.6)),
+            0.19f64.mul_add(
+                -f64::sin(deg2rad * 35999.05f64.mul_add(t, 357.5)),
+                0.21f64.mul_add(
+                    f64::sin(deg2rad * 954397.70f64.mul_add(t, 269.9)),
+                    0.66f64.mul_add(
+                        f64::sin(deg2rad * 890534.23f64.mul_add(t, 235.7)),
+                        1.27f64.mul_add(
+                            -f64::sin(deg2rad * 413335.38f64.mul_add(-t, 259.2)),
+                            6.29f64.mul_add(
+                                f64::sin(deg2rad * 477198.85f64.mul_add(t, 134.9)),
+                                481267.8813f64.mul_add(t, 218.32),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
 
     let phi_ecliptic: f64 = deg2rad
-        * 0.17f64.mul_add(-f64::sin(deg2rad * 407332.20f64.mul_add(-t, 217.6)), 0.28f64.mul_add(-f64::sin(deg2rad * 6003.18f64.mul_add(t, 318.3)), 5.13f64.mul_add(f64::sin(deg2rad * 483202.03f64.mul_add(t, 93.3)), 0.28 * f64::sin(deg2rad * 960400.87f64.mul_add(t, 228.2)))));
+        * 0.17f64.mul_add(
+            -f64::sin(deg2rad * 407332.20f64.mul_add(-t, 217.6)),
+            0.28f64.mul_add(
+                -f64::sin(deg2rad * 6003.18f64.mul_add(t, 318.3)),
+                5.13f64.mul_add(
+                    f64::sin(deg2rad * 483202.03f64.mul_add(t, 93.3)),
+                    0.28 * f64::sin(deg2rad * 960400.87f64.mul_add(t, 228.2)),
+                ),
+            ),
+        );
 
     let hparallax: f64 = deg2rad
-        * 0.0028f64.mul_add(f64::cos(deg2rad * 954397.70f64.mul_add(t, 269.9)), 0.0078f64.mul_add(f64::cos(deg2rad * 890534.23f64.mul_add(t, 235.7)), 0.0095f64.mul_add(f64::cos(deg2rad * 413335.38f64.mul_add(-t, 259.2)), 0.0518f64.mul_add(f64::cos(deg2rad * 477198.85f64.mul_add(t, 134.9)), 0.9508))));
+        * 0.0028f64.mul_add(
+            f64::cos(deg2rad * 954397.70f64.mul_add(t, 269.9)),
+            0.0078f64.mul_add(
+                f64::cos(deg2rad * 890534.23f64.mul_add(t, 235.7)),
+                0.0095f64.mul_add(
+                    f64::cos(deg2rad * 413335.38f64.mul_add(-t, 259.2)),
+                    0.0518f64.mul_add(f64::cos(deg2rad * 477198.85f64.mul_add(t, 134.9)), 0.9508),
+                ),
+            ),
+        );
 
-    let epsilon: f64 =
-        deg2rad * (5.04E-7 * t * t).mul_add(t, (1.64e-7 * t).mul_add(-t, 0.0130042f64.mul_add(-t, 23.439291)));
+    let epsilon: f64 = deg2rad
+        * (5.04E-7 * t * t).mul_add(
+            t,
+            (1.64e-7 * t).mul_add(-t, 0.0130042f64.mul_add(-t, 23.439291)),
+        );
 
     // Convert values above from degrees to radians
     // for remainder of computations
@@ -50,8 +89,14 @@ pub fn pos_gcrf(time: &Instant) -> na::Vector3<f64> {
 
     rmag * na::Vector3::<f64>::new(
         f64::cos(phi_ecliptic) * f64::cos(lambda_ecliptic),
-        (f64::cos(epsilon) * f64::cos(phi_ecliptic)).mul_add(f64::sin(lambda_ecliptic), -(f64::sin(epsilon) * f64::sin(phi_ecliptic))),
-        (f64::sin(epsilon) * f64::cos(phi_ecliptic)).mul_add(f64::sin(lambda_ecliptic), f64::cos(epsilon) * f64::sin(phi_ecliptic)),
+        (f64::cos(epsilon) * f64::cos(phi_ecliptic)).mul_add(
+            f64::sin(lambda_ecliptic),
+            -(f64::sin(epsilon) * f64::sin(phi_ecliptic)),
+        ),
+        (f64::sin(epsilon) * f64::cos(phi_ecliptic)).mul_add(
+            f64::sin(lambda_ecliptic),
+            f64::cos(epsilon) * f64::sin(phi_ecliptic),
+        ),
     )
 }
 
@@ -62,7 +107,7 @@ mod tests {
     #[test]
     fn moonpos() {
         //! This is Vallado example 5-3
-        let t0 = Instant::from_date(1994, 4, 28);
+        let t0 = Instant::from_date(1994, 4, 28).unwrap();
         // Approximate this UTC as TDB to match example...
         let t = Instant::from_mjd_with_scale(t0.as_mjd_with_scale(TimeScale::UTC), TimeScale::TDB);
 

--- a/src/lpephem/planets.rs
+++ b/src/lpephem/planets.rs
@@ -64,7 +64,7 @@ type Quat = na::UnitQuaternion<f64>;
 /// use satkit::SolarSystem;
 /// use satkit::Instant;
 ///
-/// let time = Instant::from_date(2000, 1, 1);
+/// let time = Instant::from_date(2000, 1, 1).unwrap();
 /// let pos = heliocentric_pos(SolarSystem::Mars, &time).unwrap();
 /// println!("Position of Mars: {}", pos);
 /// ```
@@ -72,10 +72,10 @@ type Quat = na::UnitQuaternion<f64>;
 pub fn heliocentric_pos(body: SolarSystem, time: &Instant) -> Result<Vec3> {
     // Keplerian elements are provided separately and more accurately
     // for times in range of years 1800AD to 2050AD
-    let tm0: Instant = Instant::from_date(-3000, 1, 1);
-    let tm1: Instant = Instant::from_date(3000, 1, 1);
-    let tmp0: Instant = Instant::from_date(1800, 1, 1);
-    let tmp1: Instant = Instant::from_date(2050, 12, 31);
+    let tm0: Instant = Instant::from_date(-3000, 1, 1)?;
+    let tm1: Instant = Instant::from_date(3000, 1, 1)?;
+    let tmp0: Instant = Instant::from_date(1800, 1, 1)?;
+    let tmp1: Instant = Instant::from_date(2050, 12, 31)?;
     let jcen = (time.as_jd_with_scale(TimeScale::TT) - 2451545.0) / 36525.0;
 
     #[allow(non_snake_case)]
@@ -530,7 +530,7 @@ mod test {
 
         for planet in planets {
             //let time = Instant::from_date(2000, 1, 1);
-            let time = Instant::from_datetime(2010, 1, 1, 12, 0, 0.0);
+            let time = Instant::from_datetime(2010, 1, 1, 12, 0, 0.0).unwrap();
             let psun = jplephem::barycentric_pos(SolarSystem::Sun, &time).unwrap();
             let p2 = jplephem::barycentric_pos(planet, &time).unwrap() - psun;
             let p1 = heliocentric_pos(planet, &time).unwrap();

--- a/src/lpephem/sun.rs
+++ b/src/lpephem/sun.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn sunpos_mod() {
         // Example 5-1 in Vallado
-        let t0: Instant = Instant::from_date(2006, 4, 2);
+        let t0: Instant = Instant::from_date(2006, 4, 2).unwrap();
         // Approximate this UTC as TDB to match example...
         let t = Instant::from_mjd_with_scale(t0.as_mjd_with_scale(TimeScale::UTC), TimeScale::TDB);
 
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn sunpos_gcrf() {
         // Example 5-1 in Vallado
-        let t0: Instant = Instant::from_date(2006, 4, 2);
+        let t0: Instant = Instant::from_date(2006, 4, 2).unwrap();
         // Approximate this UTC as TDB to match example...
         let t = Instant::from_mjd_with_scale(t0.as_mjd(), TimeScale::TDB);
 
@@ -277,7 +277,7 @@ mod tests {
     fn sunriseset() {
         // Example 5-2 from Vallado
         let itrf = ITRFCoord::from_geodetic_deg(40.0, 0.0, 0.0);
-        let tm = Instant::from_datetime(1996, 3, 23, 0, 0, 0.0);
+        let tm = Instant::from_datetime(1996, 3, 23, 0, 0, 0.0).unwrap();
         let (sunrise, sunset) = riseset(&tm, &itrf, None).unwrap();
         let (ryear, rmon, rday, rhour, rmin, rsec) = sunrise.as_datetime();
         assert!(ryear == 1996);
@@ -296,7 +296,7 @@ mod tests {
 
         // Check for error returned on 24-hour sunlight condition
         let itrf2 = ITRFCoord::from_geodetic_deg(85.0, 30.0, 0.0);
-        let tm2 = Instant::from_date(2020, 6, 20);
+        let tm2 = Instant::from_date(2020, 6, 20).unwrap();
         let r = riseset(&tm2, &itrf2, None);
         assert!(r.is_err());
     }
@@ -304,14 +304,14 @@ mod tests {
     #[test]
     fn test_webexample() {
         let coord = ITRFCoord::from_geodetic_deg(42.4154, -71.1565, 0.0);
-        let time = &Instant::from_date(2024, 10, 14);
+        let time = &Instant::from_date(2024, 10, 14).unwrap();
 
         let (rise, set) = riseset(time, &coord, None).unwrap();
 
         // Check against web example
         // https://www.timeanddate.com/sun/@4929180
-        let rise_web = Instant::from_datetime(2024, 10, 14, 10, 57, 0.0);
-        let set_web = Instant::from_datetime(2024, 10, 14, 22, 4, 0.0);
+        let rise_web = Instant::from_datetime(2024, 10, 14, 10, 57, 0.0).unwrap();
+        let set_web = Instant::from_datetime(2024, 10, 14, 22, 4, 0.0).unwrap();
 
         assert!((rise - rise_web).as_seconds().abs() < 60.0);
         assert!((set - set_web).as_seconds().abs() < 60.0);

--- a/src/lpephem/sun.rs
+++ b/src/lpephem/sun.rs
@@ -40,7 +40,7 @@ pub fn pos_gcrf(time: &Instant) -> na::Vector3<f64> {
 /// # Returns
 ///
 /// * Vector representing sun position in MOD frame
-///    at given time.  Units are meters
+///   at given time.  Units are meters
 ///
 /// # Notes:
 ///
@@ -147,10 +147,10 @@ pub fn shadowfunc(psun: &Vec3, psat: &Vec3) -> f64 {
 /// * `time`  - Date at which to compute sunrise & sunset
 ///
 /// * `coord` - ITRFCoord representing location for which to compute
-///             sunrise & sunset
+///   sunrise & sunset
 ///
 /// * `sigma` - Angle in degrees between noon & rise/set
-///    Common Values:
+///   Common Values:
 ///    * "Standard": 90 deg, 50 arcmin (90.0+50.0/60.0)
 ///    * "Civil Twilight": 96 deg
 ///    * "Nautical Twilight": 102 deg

--- a/src/nrlmsise.rs
+++ b/src/nrlmsise.rs
@@ -113,7 +113,7 @@ pub fn nrlmsise(
 
     if let Some(time) = time_option {
         let (year, _mon, _day, dhour, dmin, dsec) = time.as_datetime();
-        let fday: f64 = (time - Instant::from_date(year, 1, 1)).as_days() + 1.0;
+        let fday: f64 = (time - Instant::from_date(year, 1, 1).unwrap()).as_days() + 1.0;
         day_of_year = fday.floor() as i32;
         sec_of_day = (dhour as f64).mul_add(3600.0, dmin as f64 * 60.0) + dsec;
 
@@ -174,8 +174,8 @@ mod tests {
 
     #[test]
     fn test_nrlmsise() {
-        let tm: Instant =
-            Instant::from_date(2010, 1, 1) + Duration::from_days(171.0 + 29000.0 / 86400.0);
+        let tm: Instant = Instant::from_date(2010, 1, 1).unwrap()
+            + Duration::from_days(171.0 + 29000.0 / 86400.0);
         let (_density, _temperature) = nrlmsise(400.0, Some(60.0), Some(-70.0), Some(tm), true);
     }
 }

--- a/src/nrlmsise.rs
+++ b/src/nrlmsise.rs
@@ -111,8 +111,7 @@ pub fn nrlmsise(
     let mut f107: f64 = 150.0;
     let mut ap: f64 = 4.0;
 
-    if time_option.is_some() {
-        let time = time_option.unwrap();
+    if let Some(time) = time_option {
         let (year, _mon, _day, dhour, dmin, dsec) = time.as_datetime();
         let fday: f64 = (time - Instant::from_date(year, 1, 1)).as_days() + 1.0;
         day_of_year = fday.floor() as i32;

--- a/src/ode/rk_adaptive.rs
+++ b/src/ode/rk_adaptive.rs
@@ -16,6 +16,8 @@ pub trait RKAdaptive<const N: usize, const NI: usize> {
 
     /// First Same as Last
     /// (first compute of next iteration is same as last compute of last iteration)
+    /// (I haven't implemented this yet...)
+    #[allow(dead_code)]
     const FSAL: bool;
 
     fn interpolate<S: ODEState>(xinterp: f64, sol: &ODESolution<S>) -> ODEResult<S> {

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -104,23 +104,23 @@ pub enum PropagationError {
 ///
 /// * `state` - The satellite state, represented as:
 ///    * `SimpleState` - a 6x1 matrix where the 1st three elements represent GCRF position in meters,
-///       and the 2nd three elements represent GCRF velocity in meters / second
+///      nd the 2nd three elements represent GCRF velocity in meters / second
 ///    * `CovState` - a 6x7 matrix where the first column is the same as SimpleState above, and columns
-///       2-7 represent the 6x6 state transition matrix, dS/dS0
-///       The state transition matrix should be initialized to identity when running
-///       The output of the state transition matrix can be used to compute the evolution of the
-///       state covariance  (see Montenbruck and Gill for details)
+///      2-7 represent the 6x6 state transition matrix, dS/dS0
+///      The state transition matrix should be initialized to identity when running
+///      The output of the state transition matrix can be used to compute the evolution of the
+///      state covariance  (see Montenbruck and Gill for details)
 ///  * `start` - The time at the initial state
 ///  * `stop` - The time at which to propagate for computing new states
 ///  * `step_seconds` - An optional value representing intervals between `start` and `stop` at which
-///     the new state will be computed
+///    the new state will be computed
 ///  * `settings` - Settings for the Runga-Kutta propagator
 ///  * `satprops` - Properties of the satellite, such as ballistic coefficient & susceptibility to
-///     radiation pressure
+///    radiation pressure
 ///
 /// # Returns
 /// * `PropagationResult` object with details of the propagation compute, the final state, and intermediate states if step size
-///    is set
+///   is set
 ///
 /// # Example:
 ///
@@ -700,8 +700,8 @@ mod tests {
                 let min: i32 = lvals[5].parse()?;
                 let sec: f64 = lvals[6].parse()?;
                 Ok(Instant::from_datetime(year, mon, day, hour, min, sec))
-            }).collect::<Result<Vec<crate::Instant>, _>>()?;
-        
+            })
+            .collect::<Result<Vec<crate::Instant>, _>>()?;
 
         let file: File = File::open(testvecfile)?;
 

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -138,7 +138,7 @@ pub enum PropagationError {
 /// settings.gravity_order = 4;
 ///
 /// // Pick an arbitrary start time
-/// let starttime = satkit::Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+/// let starttime = satkit::Instant::from_datetime(2015, 3, 20, 0, 0, 0.0).unwrap();
 /// // Propagate to 1/2 day ahead
 /// let stoptime = starttime + satkit::Duration::from_days(0.5);
 ///
@@ -176,7 +176,7 @@ pub enum PropagationError {
 /// settings.gravity_order = 4;
 ///
 /// // Pick an arbitrary start time
-/// let starttime = satkit::Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+/// let starttime = satkit::Instant::from_datetime(2015, 3, 20, 0, 0, 0.0).unwrap();
 /// // Propagate to 1/2 day ahead
 /// let stoptime = starttime + satkit::Duration::from_days(0.5);
 ///
@@ -459,7 +459,7 @@ mod tests {
 
     #[test]
     fn test_short_propagate() -> Result<()> {
-        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0)?;
         let stoptime = starttime + Duration::from_seconds(0.1);
 
         let mut state: SimpleState = SimpleState::zeros();
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_propagate() -> Result<()> {
-        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0)?;
         let stoptime = starttime + Duration::from_days(0.25);
 
         let mut state: SimpleState = SimpleState::zeros();
@@ -510,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_interp() -> Result<()> {
-        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0)?;
         let stoptime = starttime + Duration::from_days(1.0);
 
         let mut state: SimpleState = SimpleState::zeros();
@@ -554,7 +554,7 @@ mod tests {
         // Note also: drag partials are very small relative to other terms,
         // making it difficult to confirm that calculations are correct.
 
-        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0)?;
         let stoptime = starttime + Duration::from_days(0.5);
 
         let mut state: CovState = CovState::zeros();
@@ -614,7 +614,7 @@ mod tests {
         // set a fininte cdaoverm value so that there is drag
         // and we can check drag partials
 
-        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0);
+        let starttime = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0)?;
         let stoptime = starttime + crate::Duration::from_days(0.2);
 
         let mut state: CovState = CovState::zeros();
@@ -699,7 +699,7 @@ mod tests {
                 let hour: i32 = lvals[4].parse()?;
                 let min: i32 = lvals[5].parse()?;
                 let sec: f64 = lvals[6].parse()?;
-                Ok(Instant::from_datetime(year, mon, day, hour, min, sec))
+                Instant::from_datetime(year, mon, day, hour, min, sec)
             })
             .collect::<Result<Vec<crate::Instant>, _>>()?;
 

--- a/src/orbitprop/satstate.rs
+++ b/src/orbitprop/satstate.rs
@@ -265,7 +265,7 @@ mod test {
     #[test]
     fn test_qgcrf2lvlh() -> Result<()> {
         let satstate = SatState::from_pv(
-            &Instant::from_datetime(2015, 3, 20, 0, 0, 0.0),
+            &Instant::from_datetime(2015, 3, 20, 0, 0, 0.0).unwrap(),
             &na::vector![consts::GEO_R, 0.0, 0.0],
             &na::vector![0.0, (consts::MU_EARTH / consts::GEO_R).sqrt(), 0.0],
         );
@@ -288,7 +288,7 @@ mod test {
     #[test]
     fn test_satstate() -> Result<()> {
         let mut satstate = SatState::from_pv(
-            &Instant::from_datetime(2015, 3, 20, 0, 0, 0.0),
+            &Instant::from_datetime(2015, 3, 20, 0, 0, 0.0).unwrap(),
             &na::vector![consts::GEO_R, 0.0, 0.0],
             &na::vector![0.0, (consts::MU_EARTH / consts::GEO_R).sqrt(), 0.0],
         );
@@ -320,7 +320,7 @@ mod test {
     #[test]
     fn test_satcov() -> Result<()> {
         let mut satstate = SatState::from_pv(
-            &Instant::from_datetime(2015, 3, 20, 0, 0, 0.0),
+            &Instant::from_datetime(2015, 3, 20, 0, 0, 0.0).unwrap(),
             &na::vector![consts::GEO_R, 0.0, 0.0],
             &na::vector![0.0, (consts::MU_EARTH / consts::GEO_R).sqrt(), 0.0],
         );

--- a/src/orbitprop/satstate.rs
+++ b/src/orbitprop/satstate.rs
@@ -61,8 +61,8 @@ impl SatState {
     /// # Arguments
     ///
     /// * `cov` -  Covariance matrix.  6x6 or larger if including terms like drag.
-    ///            Upper-left 6x6 is covariance for position & velocity, in units of
-    ///            meters and meters / second
+    ///   Upper-left 6x6 is covariance for position & velocity, in units of
+    ///   meters and meters / second
     ///
     pub fn set_cov(&mut self, cov: StateCov) {
         self.cov = cov;

--- a/src/orbitprop/settings.rs
+++ b/src/orbitprop/settings.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 /// * `rel_error` - the maximum relative error for the infinity norm of the state in Runga-Kutta integrator.  Default is 1e-8
 /// * `use_spaceweather` -  Do we use space weather when computing the atmospheric density.  Default is true
 /// * `enable_interp` - Do we enable interpolation of the state between start and stop times.  Default is true
-///                     slight comptuation savings if set to false
+///   slight computation savings if set to false
 ///
 #[derive(Debug, Clone)]
 pub struct PropSettings {

--- a/src/pybindings/pydensity.rs
+++ b/src/pybindings/pydensity.rs
@@ -73,7 +73,7 @@ fn pynrlmsise(args: &Bound<'_, PyTuple>) -> PyResult<(f64, f64)> {
             true,
         ))
     } else {
-        return Err(pyo3::exceptions::PyTypeError::new_err("Invalid arguments"));
+        Err(pyo3::exceptions::PyTypeError::new_err("Invalid arguments"))
     }
 }
 

--- a/src/pybindings/pyframetransform.rs
+++ b/src/pybindings/pyframetransform.rs
@@ -3,6 +3,8 @@ use super::PyInstant;
 use crate::frametransform as ft;
 use pyo3::prelude::*;
 
+use anyhow::Result;
+
 /// Greenwich Mean Sidereal Time
 ///
 /// Notes:
@@ -14,7 +16,7 @@ use pyo3::prelude::*;
 /// Returns:
 ///     float|numpy.array: GMST at input time[s] in radians
 #[pyfunction]
-pub fn gmst(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn gmst(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_func_of_time_arr(ft::gmst, tm)
 }
 
@@ -22,7 +24,7 @@ pub fn gmst(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Equation of Equinoxes
 ///
 #[pyfunction]
-pub fn eqeq(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn eqeq(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_func_of_time_arr(ft::eqeq, tm)
 }
 
@@ -34,7 +36,7 @@ pub fn eqeq(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     float|numpy.array: GAST at input time[s] in radians
 #[pyfunction]
-pub fn gast(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn gast(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_func_of_time_arr(ft::gast, tm)
 }
 
@@ -57,7 +59,7 @@ pub fn gast(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// * ERA = 2𝜋 ((0.7790572732640 + f + 0.00273781191135448 * (t - 2451545.0))
 ///
 #[pyfunction]
-pub fn earth_rotation_angle(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn earth_rotation_angle(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_func_of_time_arr(ft::earth_rotation_angle, tm)
 }
 
@@ -69,7 +71,7 @@ pub fn earth_rotation_angle(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from ITRF to TIRS at input time[s]
 #[pyfunction]
-pub fn qitrf2tirs(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qitrf2tirs(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qitrf2tirs, tm)
 }
 
@@ -81,7 +83,7 @@ pub fn qitrf2tirs(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from TIRS to CIRS at input time[s]
 #[pyfunction]
-pub fn qtirs2cirs(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qtirs2cirs(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qtirs2cirs, tm)
 }
 
@@ -94,7 +96,7 @@ pub fn qtirs2cirs(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from CIRS to GCRF at input time[s]
 
 #[pyfunction]
-pub fn qcirs2gcrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qcirs2gcrf(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qcirs2gcrs, tm)
 }
 
@@ -111,7 +113,7 @@ pub fn qcirs2gcrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from ITRF to GCRF at input time[s]
 
 #[pyfunction]
-pub fn qitrf2gcrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qitrf2gcrf(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qitrf2gcrf, tm)
 }
 
@@ -127,7 +129,7 @@ pub fn qitrf2gcrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from GCRF to ITRF at input time[s]
 #[pyfunction]
-pub fn qgcrf2itrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qgcrf2itrf(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qgcrf2itrf, tm)
 }
 
@@ -142,7 +144,7 @@ pub fn qgcrf2itrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from GCRF to ITRF at input time[s]
 #[pyfunction]
-pub fn qgcrf2itrf_approx(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qgcrf2itrf_approx(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qgcrf2itrf_approx, tm)
 }
 
@@ -157,7 +159,7 @@ pub fn qgcrf2itrf_approx(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from ITRF to GCRF at input time[s]
 #[pyfunction]
-pub fn qitrf2gcrf_approx(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qitrf2gcrf_approx(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qitrf2gcrf_approx, tm)
 }
 
@@ -173,7 +175,7 @@ pub fn qitrf2gcrf_approx(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from TEME to ITRF at input time[s]
 #[pyfunction]
-pub fn qteme2itrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qteme2itrf(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qteme2itrf, tm)
 }
 
@@ -189,7 +191,7 @@ pub fn qteme2itrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
 /// Returns:
 ///    satkit.quaternion|list: Quaternion or list of quaternions representing rotation from TEME to GCRF at input time[s]
 #[pyfunction]
-pub fn qteme2gcrf(tm: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+pub fn qteme2gcrf(tm: &Bound<'_, PyAny>) -> Result<PyObject> {
     py_quat_from_time_arr(ft::qteme2gcrf, tm)
 }
 

--- a/src/pybindings/pyinstant.rs
+++ b/src/pybindings/pyinstant.rs
@@ -235,10 +235,10 @@ impl PyInstant {
 
             // Input is a string, first try rfc3339 format
             match Instant::from_rfc3339(s) {
-                Ok(v) => return Ok(Self(v)),
+                Ok(v) => Ok(Self(v)),
                 Err(_) => {
                     // Now try multiple formats
-                    return Self::from_string(s);
+                    Self::from_string(s)
                 }
             }
         } else {

--- a/src/pybindings/pyinstant.rs
+++ b/src/pybindings/pyinstant.rs
@@ -10,6 +10,8 @@ use crate::{Instant, TimeScale, Weekday};
 
 use super::pyduration::PyDuration;
 
+use anyhow::{bail, Result};
+
 use numpy as np;
 
 /// Specify time scale used to represent or convert between the "satkit.time"
@@ -210,7 +212,7 @@ impl PyInstant {
     ///     satkit.time: Time object representing input date and time, or if no arguments, the current date and time
     #[new]
     #[pyo3(signature=(*py_args))]
-    fn py_new(py_args: &Bound<'_, PyTuple>) -> PyResult<Self> {
+    fn py_new(py_args: &Bound<'_, PyTuple>) -> Result<Self> {
         if py_args.is_empty() {
             Ok(Self(Instant::now()))
         } else if py_args.len() == 3 {
@@ -228,7 +230,7 @@ impl PyInstant {
 
             Ok(Self(Instant::from_datetime(
                 year, month, day, hour, min, sec,
-            )))
+            )?))
         } else if py_args.len() == 1 {
             let item = py_args.get_item(0)?;
             let s = item.extract::<&str>()?;
@@ -242,9 +244,7 @@ impl PyInstant {
                 }
             }
         } else {
-            Err(pyo3::exceptions::PyTypeError::new_err(
-                "Must pass in year, month, day or year, month, day, hour, min, sec",
-            ))
+            bail!("Must pass in year, month, day or year, month, day, hour, min, sec");
         }
     }
 
@@ -260,15 +260,8 @@ impl PyInstant {
     ///   ValueError: If input string cannot be parsed
     ///
     #[staticmethod]
-    fn from_string(s: &str) -> PyResult<Self> {
-        Instant::from_string(s).map_or_else(
-            |_| {
-                Err(pyo3::exceptions::PyValueError::new_err(
-                    "Could not parse time string",
-                ))
-            },
-            |v| Ok(Self(v)),
-        )
+    fn from_string(s: &str) -> Result<Self> {
+        Instant::from_string(s).map(Self)
     }
 
     /// Create satkit.time object from string with given format
@@ -295,15 +288,8 @@ impl PyInstant {
     /// %b: Month as locale’s abbreviated name
     /// %B: Month as locale’s full name
     #[staticmethod]
-    fn strptime(s: &str, fmt: &str) -> PyResult<Self> {
-        Instant::strptime(s, fmt).map_or_else(
-            |_| {
-                Err(pyo3::exceptions::PyValueError::new_err(
-                    "Could not parse time string",
-                ))
-            },
-            |v| Ok(Self(v)),
-        )
+    fn strptime(s: &str, fmt: &str) -> Result<Self> {
+        Instant::strptime(s, fmt).map(Self)
     }
 
     /// Format time object as string
@@ -331,15 +317,10 @@ impl PyInstant {
     /// %B: Month as locale’s full name
     /// %w: Weekday as a decimal number, where 0 is Sunday and 6 is Saturday
     ///
-    fn strftime(&self, fmt: &str) -> PyResult<String> {
-        self.0.strftime(fmt).map_or_else(
-            |_| {
-                Err(pyo3::exceptions::PyValueError::new_err(
-                    "Could not format time string",
-                ))
-            },
-            Ok,
-        )
+    fn strftime(&self, fmt: &str) -> Result<String> {
+        self.0
+            .strftime(fmt)
+            .map_err(|e| anyhow::anyhow!("Could not format time string: {}", e))
     }
 
     /// Create satkit.time object from RFC3339 string
@@ -399,8 +380,8 @@ impl PyInstant {
     /// Returns:
     ///     satkit.time: Time object representing current time
     #[staticmethod]
-    fn now() -> PyResult<Self> {
-        Ok(Self(Instant::now()))
+    fn now() -> Self {
+        Self(Instant::now())
     }
 
     /// Return time object representing input date
@@ -413,8 +394,8 @@ impl PyInstant {
     /// Returns:
     ///     satkit.time: Time object representing instant of input date
     #[staticmethod]
-    fn from_date(year: i32, month: i32, day: i32) -> PyResult<Self> {
-        Ok(Self(Instant::from_date(year, month, day)))
+    fn from_date(year: i32, month: i32, day: i32) -> Result<Self> {
+        Ok(Self(Instant::from_date(year, month, day)?))
     }
 
     /// Return time object representing input modified Julian date and time scale
@@ -506,10 +487,8 @@ impl PyInstant {
         hour: i32,
         min: i32,
         sec: f64,
-    ) -> PyResult<Self> {
-        Ok(Self(Instant::from_datetime(
-            year, month, day, hour, min, sec,
-        )))
+    ) -> Result<Self> {
+        Instant::from_datetime(year, month, day, hour, min, sec).map(Self)
     }
 
     /// Convert from Python datetime object

--- a/src/pybindings/pyitrfcoord.rs
+++ b/src/pybindings/pyitrfcoord.rs
@@ -113,14 +113,14 @@ impl PyITRFCoord {
                 }
                 Ok(Self(ITRFCoord::from_slice(xv.as_slice().unwrap()).unwrap()))
             } else {
-                return Err(pyo3::exceptions::PyTypeError::new_err(
+                Err(pyo3::exceptions::PyTypeError::new_err(
                 "First input must be float, 3-element list of floats, or 3-element numpy array of float"
-            ));
+            ))
             }
         } else {
-            return Err(pyo3::exceptions::PyTypeError::new_err(
+            Err(pyo3::exceptions::PyTypeError::new_err(
                 "First input must be float, 3-element list of floats, or 3-element numpy array of float"
-            ));
+            ))
         }
     }
 

--- a/src/pybindings/pylpephem_sun.rs
+++ b/src/pybindings/pylpephem_sun.rs
@@ -71,7 +71,7 @@ pub fn rise_set(
 }
 
 #[pyfunction(signature=(sunpos, satpos))]
-pub fn shadowfunc(sunpos: Bound<'_, PyAny>, satpos: Bound<'_, PyAny>) -> PyResult<f64> {
+pub fn shadowfunc(sunpos: Bound<'_, PyAny>, satpos: Bound<'_, PyAny>) -> Result<f64> {
     let satpos = pyutils::py_to_smatrix::<3, 1>(&satpos)?;
     let sunpos = pyutils::py_to_smatrix::<3, 1>(&sunpos)?;
     Ok(sun::shadowfunc(&sunpos, &satpos))

--- a/src/pybindings/pynrlmsise.rs
+++ b/src/pybindings/pynrlmsise.rs
@@ -22,7 +22,10 @@ use crate::Instant;
 ///
 #[pyfunction]
 #[pyo3(signature=(alt_km, **option_kwds))]
-pub fn nrlmsise00(alt_km: f64, option_kwds: Option<&Bound<'_, PyDict>>) -> PyResult<(f64, f64)> {
+pub fn nrlmsise00(
+    alt_km: f64,
+    option_kwds: Option<&Bound<'_, PyDict>>,
+) -> anyhow::Result<(f64, f64)> {
     let mut lat: Option<f64> = None;
     let mut lon: Option<f64> = None;
     let mut tm: Option<Instant> = None;

--- a/src/pybindings/pynrlmsise.rs
+++ b/src/pybindings/pynrlmsise.rs
@@ -27,9 +27,7 @@ pub fn nrlmsise00(alt_km: f64, option_kwds: Option<&Bound<'_, PyDict>>) -> PyRes
     let mut lon: Option<f64> = None;
     let mut tm: Option<Instant> = None;
     let mut use_spaceweather: bool = true;
-    if option_kwds.is_some() {
-        let kwds = option_kwds.unwrap();
-
+    if let Some(kwds) = option_kwds {
         if let Some(kw) = kwds.get_item("latitude_deg")? {
             lat = Some(kw.extract::<f64>()?);
         }

--- a/src/pybindings/pyquaternion.rs
+++ b/src/pybindings/pyquaternion.rs
@@ -5,11 +5,13 @@ use numpy::PyArrayMethods;
 use numpy::PyUntypedArrayMethods;
 use numpy::ToPyArray;
 use pyo3::prelude::*;
-use pyo3::types::{PyTuple, PyBytes};
+use pyo3::types::{PyBytes, PyTuple};
 use pyo3::IntoPyObjectExt;
 
 type Quat = na::UnitQuaternion<f64>;
 type Vec3 = na::Vector3<f64>;
+
+use anyhow::{bail, Result};
 
 ///
 /// Quaternion representing rotation of 3D Cartesian axes
@@ -50,11 +52,10 @@ impl From<Quat> for Quaternion {
 impl Quaternion {
     #[new]
     #[pyo3(signature=(*args))]
-    fn py_new(args: &Bound<'_, PyTuple>) -> PyResult<Self> {
+    fn py_new(args: &Bound<'_, PyTuple>) -> Result<Self> {
         if args.len() == 0 {
             Ok(Quat::identity().into())
-        }
-        else if args.len() == 4 {
+        } else if args.len() == 4 {
             let w = args.get_item(0)?.extract::<f64>()?;
             let x = args.get_item(1)?.extract::<f64>()?;
             let y = args.get_item(2)?.extract::<f64>()?;
@@ -62,11 +63,8 @@ impl Quaternion {
             // Create a nalgebra quaternion from 4 input scalars
             let quat = na::Quaternion::<f64>::new(w, x, y, z);
             Ok(Quat::from_quaternion(quat).into())
-        }
-        else {
-            Err(pyo3::exceptions::PyValueError::new_err(
-                "Invalid input. Must be 4-element vector",
-            ))
+        } else {
+            bail!("Invalid input.  Must be empty or 4 floats");
         }
     }
 
@@ -82,7 +80,7 @@ impl Quaternion {
     ///     This is a right-handed rotation of the vector
     ///     e.g. rotation of +xhat 90 degrees by +zhat gives +yhat
     #[staticmethod]
-    fn rotx(theta_rad: f64) -> PyResult<Self> {
+    fn rotx(theta_rad: f64) -> Result<Self> {
         Ok(Quat::from_axis_angle(&Vec3::x_axis(), theta_rad).into())
     }
 
@@ -99,14 +97,14 @@ impl Quaternion {
     ///     e.g. rotation of +xhat by +yhat 90 degrees gives -zhat
     ///     
     #[staticmethod]
-    fn roty(theta_rad: f64) -> PyResult<Self> {
+    fn roty(theta_rad: f64) -> Result<Self> {
         Ok(Quat::from_axis_angle(&Vec3::y_axis(), theta_rad).into())
     }
 
     /// Quaternion representing rotation about
     /// zhat axis by `theta-rad` degrees
     #[staticmethod]
-    fn rotz(theta_rad: f64) -> PyResult<Self> {
+    fn rotz(theta_rad: f64) -> Result<Self> {
         Ok(Quat::from_axis_angle(&Vec3::z_axis(), theta_rad).into())
     }
 
@@ -117,20 +115,19 @@ impl Quaternion {
     ///     angle (float): Angle in radians to rotate about axis (right-handed rotation of vector)
     ///
     /// Returns:
-    ///     quaternion: Quaternion representing rotation about given axis by given angle
+    ///     quaternion: Quaternion representing rotation about given axis by given angle.  If axis norm is < 1e-9,
+    ///     unit quaternion is returned
     ///     
     #[staticmethod]
-    fn from_axis_angle(axis: np::PyReadonlyArray1<f64>, angle: f64) -> PyResult<Self> {
+    fn from_axis_angle(axis: np::PyReadonlyArray1<f64>, angle: f64) -> Result<Self> {
         let v = Vec3::from_row_slice(axis.as_slice()?);
         let u = na::UnitVector3::try_new(v, 1.0e-9);
-        u.map_or_else(
-            || {
-                Err(pyo3::exceptions::PyArithmeticError::new_err(
-                    "Axis norm is 0",
-                ))
-            },
-            |ax| Ok(Quat::from_axis_angle(&ax, angle).into()),
-        )
+        if let Some(unit_axis) = u {
+            Ok(Quat::from_axis_angle(&unit_axis, angle).into())
+        } else {
+            // If the axis is zero, return identity quaternion
+            Ok(Quat::identity().into())
+        }
     }
 
     /// Quaternion representing rotation from V1 to V2
@@ -145,11 +142,9 @@ impl Quaternion {
     fn rotation_between(
         v1: np::PyReadonlyArray1<f64>,
         v2: np::PyReadonlyArray1<f64>,
-    ) -> PyResult<Self> {
+    ) -> Result<Self> {
         if v1.len() != 3 || v2.len() != 3 {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "Invalid input. Must be 3-element vectors",
-            ));
+            bail!("Invalid input.  Must be two 3-element vectors");
         }
         let v1 = match v1.is_contiguous() {
             true => Vec3::from_row_slice(v1.as_slice().context("Cannot convert v1 to 3D vector")?),
@@ -181,11 +176,9 @@ impl Quaternion {
     /// Returns:
     ///     quaternion: Quaternion representing same rotation as input matrix
     #[staticmethod]
-    fn from_rotation_matrix(dcm: np::PyReadonlyArray2<f64>) -> PyResult<Self> {
+    fn from_rotation_matrix(dcm: np::PyReadonlyArray2<f64>) -> Result<Self> {
         if dcm.dims() != [3, 3] {
-            return Err(pyo3::exceptions::PyValueError::new_err(
-                "Invalid DCM. Must be 3x3",
-            ));
+            bail!("Invalid DCM.  Must be 3x3 matrix");
         }
         let dcm = dcm.as_array();
         let mat = na::Matrix3::from_iterator(dcm.iter().cloned());
@@ -221,7 +214,7 @@ impl Quaternion {
         self.0.euler_angles()
     }
 
-    fn __str__(&self) -> PyResult<String> {
+    fn __str__(&self) -> Result<String> {
         let ax: na::Unit<Vec3> = self
             .0
             .axis()
@@ -233,7 +226,7 @@ impl Quaternion {
         ))
     }
 
-    fn __repr__(&self) -> PyResult<String> {
+    fn __repr__(&self) -> Result<String> {
         self.__str__()
     }
 
@@ -266,8 +259,8 @@ impl Quaternion {
     /// Returns:
     ///     float: Angle of rotation in radians
     #[getter]
-    fn angle(&self) -> PyResult<f64> {
-        Ok(self.0.angle())
+    fn angle(&self) -> f64 {
+        self.0.angle()
     }
 
     /// Axis of rotation
@@ -289,8 +282,8 @@ impl Quaternion {
     /// Returns:
     ///     quaternion: Quaternion representing inverse rotation
     #[getter]
-    fn conj(&self) -> PyResult<Self> {
-        Ok(self.0.conjugate().into())
+    fn conj(&self) -> Self {
+        self.0.conjugate().into()
     }
 
     /// Quaternion representing inverse rotation
@@ -298,8 +291,8 @@ impl Quaternion {
     /// Returns:
     ///     quaternion: Quaternion representing inverse rotation
     #[getter]
-    fn conjugate(&self) -> PyResult<Self> {
-        Ok(self.0.conjugate().into())
+    fn conjugate(&self) -> Self {
+        self.0.conjugate().into()
     }
 
     /// Spherical linear interpolation between self and other quaternion
@@ -312,46 +305,40 @@ impl Quaternion {
     /// Returns:
     ///     quaternion: Quaterion represention fracional spherical interpolation between self and other    
     #[pyo3(signature=(other, frac,  epsilon=1.0e-6))]
-    fn slerp(&self, other: &Self, frac: f64, epsilon: f64) -> PyResult<Self> {
+    fn slerp(&self, other: &Self, frac: f64, epsilon: f64) -> Result<Self> {
         self.0.try_slerp(&other.0, frac, epsilon).map_or_else(
             || {
-                Err(pyo3::exceptions::PyRuntimeError::new_err(
-                    "Quaternions cannot be 180 deg apart",
-                ))
+                bail!("Quaternions cannot be 180 deg apart");
             },
             |v| Ok(v.into()),
         )
     }
 
-    fn __mul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+    fn __mul__(&self, other: &Bound<'_, PyAny>) -> Result<PyObject> {
         // Multiply quaternion by quaternion
         if other.is_instance_of::<Self>() {
             let q: PyRef<Self> = other.extract()?;
-            pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
+            Ok(pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
                 Self(self.0 * q.0).into_py_any(py)
-            })
+            })?)
         }
         // This incorrectly matches for all PyArray types
         else if let Ok(v) = other.downcast::<np::PyArray2<f64>>() {
             if v.dims()[1] != 3 {
-                return Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Invalid rhs. 2nd dimension must be 3 in size",
-                ));
+                bail!("Invalid rhs.  2nd dimension must be 3 in size");
             }
             let rot = self.0.to_rotation_matrix();
             let qmat = rot.matrix().conjugate();
 
-            pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
+            Ok(pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
                 let nd = unsafe { np::ndarray::ArrayView2::from_shape_ptr((3, 3), qmat.as_ptr()) };
                 let res = v.readonly().as_array().dot(&nd).to_pyarray(py);
 
                 res.into_py_any(py)
-            })
+            })?)
         } else if let Ok(v1d) = other.downcast::<np::PyArray1<f64>>() {
             if v1d.len() != 3 {
-                return Err(pyo3::exceptions::PyTypeError::new_err(
-                    "Invalid rhs.  1D array must be of length 3",
-                ));
+                bail!("Invalid rhs.  1D array must be of length 3");
             }
 
             let m = na::vector![
@@ -362,13 +349,12 @@ impl Quaternion {
 
             let vout = self.0 * m;
 
-            pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
+            Ok(pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
                 let vnd = np::PyArray1::<f64>::from_vec(py, vec![vout[0], vout[1], vout[2]]);
                 vnd.into_py_any(py)
-            })
+            })?)
         } else {
-            let s = format!("invalid type: {}", other.get_type());
-            Err(pyo3::exceptions::PyTypeError::new_err(s))
+            bail!("Invalid type: {}", other.get_type());
         }
     }
 }

--- a/src/pybindings/pysatstate.rs
+++ b/src/pybindings/pysatstate.rs
@@ -40,8 +40,7 @@ impl PySatState {
             &na::Vector3::<f64>::from_row_slice(unsafe { pos.as_slice().unwrap() }),
             &na::Vector3::<f64>::from_row_slice(unsafe { vel.as_slice().unwrap() }),
         );
-        if cov.is_some() {
-            let cov = cov.unwrap();
+        if let Some(cov) = cov {
             let dims = cov.dims();
             if dims[0] != 6 || dims[1] != 6 {
                 return Err(pyo3::exceptions::PyRuntimeError::new_err(

--- a/src/pybindings/pysgp4.rs
+++ b/src/pybindings/pysgp4.rs
@@ -133,8 +133,7 @@ pub fn sgp4(
     let mut output_err = false;
     let mut opsmode: OpsMode = OpsMode::afspc;
     let mut gravconst: GravConst = GravConst::wgs72;
-    if kwds.is_some() {
-        let kw = kwds.unwrap();
+    if let Some(kw) = kwds {
         if let Some(v) = kw.get_item("errflag")? {
             output_err = v.extract::<bool>()?;
         }

--- a/src/pybindings/pytle.rs
+++ b/src/pybindings/pytle.rs
@@ -36,7 +36,7 @@ impl PyTLE {
     /// * `tle` - a list of TLE objects or a single TLE if lines for
     ///           only 1 are passed in
     #[staticmethod]
-    fn from_file(filename: String) -> PyResult<PyObject> {
+    fn from_file(filename: String) -> Result<PyObject> {
         let file = File::open(std::path::PathBuf::from(filename))?;
 
         let lines: Vec<String> = io::BufReader::new(file)
@@ -66,50 +66,47 @@ impl PyTLE {
     /// * `tle` - a list of TLE objects or a single TLE if lines for
     ///           only 1 are passed in
     #[staticmethod]
-    fn from_lines(lines: Vec<String>) -> PyResult<PyObject> {
-        match TLE::from_lines(&lines) {
-            Ok(v) => pyo3::Python::with_gil(|py| -> PyResult<PyObject> {
+    fn from_lines(lines: Vec<String>) -> Result<PyObject> {
+        TLE::from_lines(&lines).and_then(|v| {
+            pyo3::Python::with_gil(|py| {
                 if v.len() > 1 {
                     v.into_py_any(py)
                 } else {
                     v[0].clone().into_py_any(py)
                 }
-            }),
-            Err(e) => {
-                let serr = format!("Error loading TLEs: {}", e);
-                Err(pyo3::exceptions::PyImportError::new_err(serr))
-            }
-        }
+            })
+            .map_err(|e| e.into())
+        })
     }
 
     /// Satellite NORAD Catalog Number
     #[getter]
-    const fn get_satnum(&self) -> PyResult<i32> {
-        Ok(self.0.sat_num)
+    const fn get_satnum(&self) -> i32 {
+        self.0.sat_num
     }
 
     /// Orbit eccentricity
     #[getter]
-    const fn get_eccen(&self) -> PyResult<f64> {
-        Ok(self.0.eccen)
+    const fn get_eccen(&self) -> f64 {
+        self.0.eccen
     }
 
     /// Mean anomaly in degrees
     #[getter]
-    const fn get_mean_anomaly(&self) -> PyResult<f64> {
-        Ok(self.0.mean_anomaly)
+    const fn get_mean_anomaly(&self) -> f64 {
+        self.0.mean_anomaly
     }
 
     /// Mean motion in revs / day
     #[getter]
-    const fn get_mean_motion(&self) -> PyResult<f64> {
-        Ok(self.0.mean_motion)
+    const fn get_mean_motion(&self) -> f64 {
+        self.0.mean_motion
     }
 
     /// inclination in degrees
     #[getter]
-    const fn get_inclination(&self) -> PyResult<f64> {
-        Ok(self.0.inclination)
+    const fn get_inclination(&self) -> f64 {
+        self.0.inclination
     }
 
     /// Epoch time of TLE
@@ -120,30 +117,30 @@ impl PyTLE {
 
     /// argument of perigee, degrees
     #[getter]
-    const fn get_arg_of_perigee(&self) -> PyResult<f64> {
-        Ok(self.0.arg_of_perigee)
+    const fn get_arg_of_perigee(&self) -> f64 {
+        self.0.arg_of_perigee
     }
 
     /// One half of 1st derivative of mean motion wrt time, in revs/day^2
     #[getter]
-    const fn get_mean_motion_dot(&self) -> PyResult<f64> {
-        Ok(self.0.mean_motion_dot)
+    const fn get_mean_motion_dot(&self) -> f64 {
+        self.0.mean_motion_dot
     }
 
     /// One sixth of 2nd derivative of mean motion wrt time, in revs/day^3
     #[getter]
-    const fn get_mean_motion_dot_dot(&self) -> PyResult<f64> {
-        Ok(self.0.mean_motion_dot_dot)
+    const fn get_mean_motion_dot_dot(&self) -> f64 {
+        self.0.mean_motion_dot_dot
     }
 
     /// Name of satellite
-    fn name(&self) -> PyResult<String> {
-        Ok(self.0.name.clone())
+    fn name(&self) -> String {
+        self.0.name.clone()
     }
 
     // Drag
-    const fn bstar(&self) -> PyResult<f64> {
-        Ok(self.0.bstar)
+    const fn bstar(&self) -> f64 {
+        self.0.bstar
     }
 
     fn __str__(&self) -> String {

--- a/src/sgp4/sgp4_impl.rs
+++ b/src/sgp4/sgp4_impl.rs
@@ -75,9 +75,9 @@ use super::{GravConst, OpsMode};
 /// # Arguments
 ///
 /// * `tle` - The TLE on which top operate.  Note that a mutable reference
-///           is passed, as SGP-4 metadata is stored after each propagation
+///   is passed, as SGP-4 metadata is stored after each propagation
 /// * `tm` -  The time at which to compute position and velocity
-///           Input as a slice for convenience.
+///   Input as a slice for convenience.
 ///
 ///
 /// # Return
@@ -142,9 +142,9 @@ pub fn sgp4(tle: &mut TLE, tm: &[Instant]) -> SGP4State {
 /// # Arguments
 ///
 /// * `tle` - The TLE on which top operate.  Note that a mutable reference
-///           is passed, as SGP-4 metadata is stored after each propagation
+///   is passed, as SGP-4 metadata is stored after each propagation
 /// * `tm` -  The time at which to compute position and velocity
-///           Input as a slice for convenience.
+///   Input as a slice for convenience.
 ///
 /// * `gravconst` - The gravitational constant to use.
 ///

--- a/src/spaceweather.rs
+++ b/src/spaceweather.rs
@@ -92,7 +92,7 @@ fn load_space_weather_csv() -> Result<Vec<SpaceWeatherRecord>> {
             let day: u32 = str2num(lvals[0], 8, 10).context("Cannot ready day of month")?;
 
             Ok(SpaceWeatherRecord {
-                date: (Instant::from_date(year as i32, mon as i32, day as i32)),
+                date: (Instant::from_date(year as i32, mon as i32, day as i32)?),
                 bsrn: lvals[1].parse().unwrap_or(-1),
                 nd: lvals[2].parse().unwrap_or(-1),
                 kp: {
@@ -190,7 +190,7 @@ mod tests {
 
     #[test]
     fn test_load() {
-        let tm: Instant = Instant::from_datetime(2023, 11, 14, 0, 0, 0.0);
+        let tm: Instant = Instant::from_datetime(2023, 11, 14, 0, 0, 0.0).unwrap();
         let r = get(tm);
         println!("r = {:?}", r);
         println!("rdate = {}", r.unwrap().date);

--- a/src/time/instantparse.rs
+++ b/src/time/instantparse.rs
@@ -270,14 +270,14 @@ impl Instant {
             second = 0;
             microsecond = 0;
         }
-        Ok(Self::from_datetime(
+        Self::from_datetime(
             year,
             month,
             day,
             hour,
             minute,
             second as f64 + microsecond as f64 / 1_000_000.0,
-        ))
+        )
     }
 
     /// Parse a string into an Instant object
@@ -417,7 +417,7 @@ impl Instant {
             hour,
             minute,
             second as f64 + microsecond as f64 / 1_000_000.0,
-        );
+        )?;
         if offset != 0 {
             instant += crate::Duration::from_minutes(offset as f64);
         }

--- a/src/time/tests.rs
+++ b/src/time/tests.rs
@@ -42,7 +42,7 @@ fn test_unixtime() {
     assert!(g.4 == 56);
     assert!(g.5 == 53.0);
 
-    let time = Instant::from_datetime(2016, 12, 31, 23, 59, 40.0);
+    let time = Instant::from_datetime(2016, 12, 31, 23, 59, 40.0).unwrap();
     assert!(time.as_unixtime() == 1483228780.0);
 
     let g = time.as_datetime();
@@ -100,42 +100,42 @@ fn test_leapsecond() {
 #[test]
 fn test_day_of_year() {
     // Following examples from google
-    let thedate = Instant::from_date(2025, 8, 16);
+    let thedate = Instant::from_date(2025, 8, 16).unwrap();
     assert_eq!(thedate.day_of_year(), 228);
 
-    let thedate = Instant::from_date(2024, 2, 29);
+    let thedate = Instant::from_date(2024, 2, 29).unwrap();
     assert_eq!(thedate.day_of_year(), 60);
 
-    let thedate = Instant::from_date(2023, 1, 1);
+    let thedate = Instant::from_date(2023, 1, 1).unwrap();
     assert_eq!(thedate.day_of_year(), 1);
 
     // Include a time component
-    let thetime = Instant::from_datetime(2024, 12, 31, 23, 59, 59.999999);
+    let thetime = Instant::from_datetime(2024, 12, 31, 23, 59, 59.999999).unwrap();
     assert_eq!(thetime.day_of_year(), 366);
 
     // Leap year test
-    let thedate = Instant::from_date(2024, 12, 31);
+    let thedate = Instant::from_date(2024, 12, 31).unwrap();
     assert_eq!(thedate.day_of_year(), 366);
 
     // Check year modulo 100, but not 400 (Not a leap year!)
-    let thedate = Instant::from_date(2100, 12, 31);
+    let thedate = Instant::from_date(2100, 12, 31).unwrap();
     assert_eq!(thedate.day_of_year(), 365);
 
     // Check year modulo 400 (Leap year!)
-    let thedate = Instant::from_date(2400, 12, 31);
+    let thedate = Instant::from_date(2400, 12, 31).unwrap();
     assert_eq!(thedate.day_of_year(), 366);
 }
 
 #[test]
 fn test_ops() {
-    let t1 = Instant::from_datetime(2024, 11, 13, 8, 0, 3.0);
-    let t2 = Instant::from_datetime(2024, 11, 13, 8, 0, 4.0);
+    let t1 = Instant::from_datetime(2024, 11, 13, 8, 0, 3.0).unwrap();
+    let t2 = Instant::from_datetime(2024, 11, 13, 8, 0, 4.0).unwrap();
     let dt = t2 - t1;
     assert!(dt.as_microseconds() == 1_000_000);
-    let t2 = Instant::from_datetime(2024, 11, 13, 8, 0, 2.0);
+    let t2 = Instant::from_datetime(2024, 11, 13, 8, 0, 2.0).unwrap();
     let dt = t2 - t1;
     assert!(dt.as_microseconds() == -1_000_000);
-    let t2 = Instant::from_datetime(2024, 11, 13, 8, 1, 3.0);
+    let t2 = Instant::from_datetime(2024, 11, 13, 8, 1, 3.0).unwrap();
     let dt = t2 - t1;
     assert!(dt.as_microseconds() == 60_000_000);
 
@@ -162,7 +162,7 @@ fn test_gps() {
 
 #[test]
 fn test_jd() {
-    let time = Instant::from_datetime(2024, 11, 24, 12, 0, 0.0);
+    let time = Instant::from_datetime(2024, 11, 24, 12, 0, 0.0).unwrap();
     assert!(time.as_jd() == 2_460_639.0);
     assert!(time.as_mjd() == 60_638.5);
 }

--- a/src/time/tests.rs
+++ b/src/time/tests.rs
@@ -199,6 +199,29 @@ fn test_rfc3339() {
 }
 
 #[test]
+fn test_bounds() {
+    let tm = Instant::from_date(2024, 13, 4);
+    assert!(tm.is_err());
+
+    let tm = Instant::from_date(2024, 2, 29);
+    assert!(tm.is_ok());
+
+    let tm = Instant::from_date(2024, 2, 30);
+    assert!(tm.is_err());
+
+    let tm = Instant::from_datetime(2024, 2, 29, 23, 59, 59.999999);
+    assert!(tm.is_ok());
+
+    // Should be error ... not in leap second
+    let tm = Instant::from_datetime(2024, 2, 29, 23, 59, 60.5);
+    assert!(tm.is_err());
+
+    // Should be OK ... within a leap second
+    let tm = Instant::from_datetime(2008, 12, 31, 23, 59, 60.5);
+    assert!(tm.is_ok());
+}
+
+#[test]
 fn test_strptime() {
     let time = Instant::strptime("2024-11-24T12:03:45.123456", "%Y-%m-%dT%H:%M:%S.%f").unwrap();
     let g = time.as_datetime();

--- a/src/tle.rs
+++ b/src/tle.rs
@@ -38,7 +38,7 @@ const ALPHA5_MATCHING: &str = "ABCDEFGHJKLMNPQRSTUVWXYZ";
 ///     "2 26900   0.0164 266.5378 0003319  86.1794 182.2590  1.00273847 16981   9300."];
 ///
 /// let mut tle = TLE::load_3line(lines[0], lines[1], lines[2]).unwrap();
-/// let tm = Instant::from_datetime(2006, 5, 1, 11, 0, 0.0);
+/// let tm = Instant::from_datetime(2006, 5, 1, 11, 0, 0.0).unwrap();
 ///
 /// // Use SGP4 to get position,
 /// let (pTEME, vTEME, errs) = sgp4(&mut tle, &[tm]);
@@ -326,7 +326,9 @@ impl TLE {
         // Note: day_of_year starts from 1, not zero,
         // also, go from Jan 2 to avoid leap-second
         // issues, hence the "-2" at end
-        let epoch = Instant::from_date(year as i32, 1, 2).add_utc_days(day_of_year - 2.0);
+        let epoch = Instant::from_date(year as i32, 1, 2)
+            .context("Invalid year, month, or day")?
+            .add_utc_days(day_of_year - 2.0);
 
         Ok(Self {
             name: "none".to_string(),

--- a/src/tle.rs
+++ b/src/tle.rs
@@ -755,7 +755,7 @@ mod tle_formatter {
         // TLE stores a single-digit exponent with sign: "±d"
         // e = e10 (we already accounted for mant being *1e5)
         let e = e10 + 1;
-        let mant_s = format!("{:0>5}", mant.max(0) as i64);
+        let mant_s = format!("{:0>5}", { mant.max(0) });
 
         // Clamp to displayable range [-9, 9]; real TLEs fit this for these fields
         let e_clamped = e.clamp(-9, 9);


### PR DESCRIPTION
* Remove clippy warnings, mostly by fixing comment indentation issues and using more-efficient rust syntax in code

* switch to `anyhow::Result' use in python bindings, as this is compatible with pyo3