### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,9 @@ name = "satkit"
 [dependencies]
 nalgebra = { version = "0.34.0", features = ["serde-serialize"] }
 ndarray = "0.16.1"
-libc = "0.2"
-chrono = "0.4"
 cty = "0.2.2"
 num-traits = "0.2.19"
 thiserror = "2.0"
-simba = "0.9"
 once_cell = "1.21"
 numpy = { version = "0.25", optional = true }
 pyo3 = { version = "0.25.1", features = [


### PR DESCRIPTION
In trying to cross-compile `satkit` recently we ran into some known issues related to `chrono` cross-compiling for mac. But we noticed that `chrono` isn't actually required past build-time and have been able to work around it. This change might make things easier for other users in the future