### PR TITLE
Gate ureq behind a 'download' Cargo feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ## Unreleased
 
+### Breaking: `ureq` is now optional behind the `download` feature
+
+- **`ureq` moved off by default**, gated behind a new non-default `download` Cargo feature. `TLE::from_url`, `OMM::from_url`, `solar_cycle_forecast::update`, and the `satkit::utils::{download_file, download_file_async, download_to_string, download_if_not_exist, update_datafiles}` helpers now require building with `--features download`. Without the feature, `download_if_not_exist` will succeed if the file already exists and otherwise return an error; the other download helpers always return an error. Default Rust builds drop ~25 transitive crates (`ureq`, `rustls`, `ring`, `rustls-webpki`, `webpki-roots`, `flate2`, etc.), substantially shortening compile times for users who only need the offline computation.
+- **Python builds are unaffected.** The `satkit-python` crate enables `download` on its `satkit` path-dependency, so all `satkit.utils.update_datafiles`, `satkit.TLE.from_url`, and `satkit.omm_from_url` functions continue to work exactly as before from Python.
+
 ### Licensing
 
 - **Dual-licensed under MIT OR Apache-2.0.** Previously MIT-only. Apache-2.0 adds an explicit patent grant — important now that the project is taking external contributions, since it binds contributors to a patent peace clause that bare MIT does not. Matches the Rust ecosystem convention. `LICENSE` was renamed to `LICENSE-MIT` and a new `LICENSE-APACHE` was added; `Cargo.toml` and `pyproject.toml` `license` fields updated to `"MIT OR Apache-2.0"`. Downstream users may continue to use the project under either license at their option — no action required.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "satkit"
 [dependencies]
 numeris = { version = "0.5.7", features = ["serde", "estimate", "ode"] }
 thiserror = "2.0"
-ureq = "3.1.2"
+ureq = { version = "3.1.2", optional = true }
 process_path = "0.1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -41,6 +41,7 @@ rand_distr = "0.5.1"
 default = ["omm-xml"]
 omm-xml = ["dep:quick-xml"]
 chrono = ["dep:chrono"]
+download = ["dep:ureq"]
 
 [workspace.metadata.release]
 pre-release-replacements = [

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -9,7 +9,7 @@ name = "satkit"
 crate-type = ["cdylib"]
 
 [dependencies]
-satkit = { path = ".." }
+satkit = { path = "..", features = ["download"] }
 pyo3 = { version = "0.28.2", features = ["extension-module", "anyhow"] }
 numpy = "0.28"
 numeris = { version = "0.5.6", features = ["serde", "estimate"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@
 //!
 //! ### Downloading Data Files
 //!
+//! Requires building with the `download` Cargo feature.
+//!
 //! ```no_run
 //! // Print the directory where data will be stored
 //! println!("Data directory: {:?}", satkit::utils::datadir());
@@ -114,6 +116,7 @@
 //! // - Downloads missing files
 //! // - Updates space weather and Earth orientation parameters
 //! // - Skips files that already exist
+//! # #[cfg(feature = "download")]
 //! satkit::utils::update_datafiles(None, false);
 //! ```
 //!

--- a/src/omm/mod.rs
+++ b/src/omm/mod.rs
@@ -369,13 +369,17 @@ impl OMM {
     ///
     /// Works with CelesTrak and Space-Track API endpoints.
     ///
+    /// Requires the `download` Cargo feature.
+    ///
     /// # Example
     ///
     /// ```no_run
     /// use satkit::omm::OMM;
     ///
+    /// # #[cfg(feature = "download")]
     /// let omms = OMM::from_url("https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=json").unwrap();
     /// ```
+    #[cfg(feature = "download")]
     pub fn from_url(url: &str) -> Result<Vec<Self>> {
         let agent = ureq::Agent::new_with_defaults();
         let mut resp = agent.get(url).call()?;

--- a/src/solar_cycle_forecast.rs
+++ b/src/solar_cycle_forecast.rs
@@ -7,7 +7,9 @@
 //! Used as a fallback when historical space weather data is not
 //! available (i.e., for future propagation dates).
 
-use crate::utils::{datadir, download_to_string};
+use crate::utils::datadir;
+#[cfg(feature = "download")]
+use crate::utils::download_to_string;
 use crate::{Instant, TimeLike};
 use anyhow::{bail, Result};
 
@@ -114,6 +116,9 @@ pub fn get_predicted_f107<T: TimeLike>(tm: &T) -> Option<f64> {
 }
 
 /// Download the latest solar cycle forecast from NOAA/SWPC.
+///
+/// Requires the `download` Cargo feature.
+#[cfg(feature = "download")]
 pub fn update() -> Result<()> {
     let url = "https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json";
     let contents = download_to_string(url)?;
@@ -131,6 +136,11 @@ pub fn update() -> Result<()> {
     *forecast_singleton().write().unwrap() = Some(records);
 
     Ok(())
+}
+
+#[cfg(not(feature = "download"))]
+pub fn update() -> Result<()> {
+    bail!("satkit was built without the `download` feature")
 }
 
 #[cfg(test)]
@@ -169,6 +179,7 @@ mod tests {
         assert!(get_predicted_f107(&early).is_none());
     }
 
+    #[cfg(feature = "download")]
     #[test]
     fn test_download_and_parse() {
         let url = "https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json";

--- a/src/tle/mod.rs
+++ b/src/tle/mod.rs
@@ -221,6 +221,8 @@ impl TLE {
     /// Fetches the content at the given URL and parses it as TLE lines.
     /// Works with any URL that returns plain-text TLE data (2-line or 3-line format).
     ///
+    /// Requires the `download` Cargo feature.
+    ///
     /// # Arguments
     ///
     /// * `url` - URL to fetch TLE data from
@@ -234,8 +236,10 @@ impl TLE {
     /// ```no_run
     /// use satkit::TLE;
     ///
+    /// # #[cfg(feature = "download")]
     /// let tles = TLE::from_url("https://celestrak.org/NORAD/elements/gp.php?GROUP=stations&FORMAT=tle").unwrap();
     /// ```
+    #[cfg(feature = "download")]
     pub fn from_url(url: &str) -> Result<Vec<Self>> {
         let agent = ureq::Agent::new_with_defaults();
         let mut resp = agent.get(url).call()?;

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::path::Path;
 
+#[cfg(feature = "download")]
 pub fn download_if_not_exist(fname: &Path, seturl: Option<&str>) -> Result<()> {
     if fname.is_file() {
         return Ok(());
@@ -21,6 +22,19 @@ pub fn download_if_not_exist(fname: &Path, seturl: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(feature = "download"))]
+pub fn download_if_not_exist(fname: &Path, _seturl: Option<&str>) -> Result<()> {
+    if fname.is_file() {
+        Ok(())
+    } else {
+        anyhow::bail!(
+            "File {} not found and satkit was built without the `download` feature",
+            fname.display()
+        )
+    }
+}
+
+#[cfg(feature = "download")]
 pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -> Result<bool> {
     let fname = std::path::Path::new(url).file_name().unwrap();
     let fullpath = downloaddir.join(fname);
@@ -41,6 +55,12 @@ pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -
     }
 }
 
+#[cfg(not(feature = "download"))]
+pub fn download_file(_url: &str, _downloaddir: &Path, _overwrite_if_exists: bool) -> Result<bool> {
+    anyhow::bail!("satkit was built without the `download` feature")
+}
+
+#[cfg(feature = "download")]
 pub fn download_file_async(
     url: String,
     downloaddir: &Path,
@@ -52,9 +72,24 @@ pub fn download_file_async(
     std::thread::spawn(move || download_file(urlclone.as_str(), &dclone, overwriteclone))
 }
 
+#[cfg(not(feature = "download"))]
+pub fn download_file_async(
+    _url: String,
+    _downloaddir: &Path,
+    _overwrite_if_exists: bool,
+) -> std::thread::JoinHandle<Result<bool>> {
+    std::thread::spawn(|| anyhow::bail!("satkit was built without the `download` feature"))
+}
+
+#[cfg(feature = "download")]
 pub fn download_to_string(url: &str) -> Result<String> {
     let agent = ureq::Agent::new_with_defaults();
     let mut resp = agent.get(url).call()?;
     let thestring = std::io::read_to_string(resp.body_mut().as_reader())?;
     Ok(thestring)
+}
+
+#[cfg(not(feature = "download"))]
+pub fn download_to_string(_url: &str) -> Result<String> {
+    anyhow::bail!("satkit was built without the `download` feature")
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,7 +6,9 @@ pub use datadir::set_datadir;
 #[cfg(test)]
 pub mod test;
 
+#[cfg(feature = "download")]
 mod update_data;
+#[cfg(feature = "download")]
 pub use update_data::update_datafiles;
 
 mod download;


### PR DESCRIPTION
## Summary

Gates `ureq` (and ~25 transitive crates) behind a non-default `download` Cargo feature. Default builds drop from 60 → 32 crates.

Closes #80.

## What changed

- `Cargo.toml`: `ureq` is now `optional = true`; new `download = ["dep:ureq"]` feature (not in `default`)
- `python/Cargo.toml`: path-dep on satkit enables `download` so pip-installed wheels keep current behavior
- `src/utils/download.rs`: each helper has a real `#[cfg(feature = "download")]` impl + a `#[cfg(not(feature = "download"))]` stub. `download_if_not_exist` stub returns `Ok(())` when the file exists, error otherwise — preserves offline-data semantics for `spaceweather`, `earth_orientation_params`, `jplephem`, `earthgravity`, `frametransform/ierstable`. The other three stubs always error.
- `TLE::from_url`, `OMM::from_url`, `update_datafiles`, `solar_cycle_forecast::update` all gated
- Doctest examples for `from_url` updated with `# #[cfg(feature = "download")]` so they compile under both feature configurations
- CHANGELOG: new "Breaking" entry under `## Unreleased`

## Judgment calls worth a look

1. **`download_if_not_exist` always-callable** rather than gated — its stub is a no-op for cached files, so core modules don't need cfgs scattered through them. This is the main pragmatic shape of the PR.
2. **Python wheel keeps `download` enabled** — pip users genuinely need `update_datafiles()` on first use, so the dep-reduction win is for Rust library consumers (`cargo add satkit`), not the Python wheel.

## Test plan

- [x] `cargo build` — clean, no `ureq` in dep tree (`cargo tree -e normal | grep -E "ureq|rustls|ring|webpki"` → empty)
- [x] `cargo build --features download` — clean, ureq present
- [x] `cargo test --release` — 158 lib + 39 doc tests pass
- [x] `cargo test --release --features download` — 159 lib + 41 doc tests pass
- [x] `cargo check --manifest-path python/Cargo.toml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)