### PR TITLE
thiserror migration Phase 1: tle + omm

### DIFF
--- a/python/src/pytle.rs
+++ b/python/src/pytle.rs
@@ -67,19 +67,18 @@ impl PyTLE {
     ///           only 1 are passed in
     #[staticmethod]
     fn from_lines(lines: Vec<String>) -> Result<Py<PyAny>> {
-        TLE::from_lines(&lines).and_then(|v| {
-            pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
-                if v.len() > 1 {
-                    v.into_iter()
-                        .map(|t| tle_into_py(t, py))
-                        .collect::<Vec<_>>()
-                        .into_py_any(py)
-                } else {
-                    Ok(tle_into_py(v.into_iter().next().unwrap(), py))
-                }
-            })
-            .map_err(|e| e.into())
+        let v = TLE::from_lines(&lines)?;
+        pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
+            if v.len() > 1 {
+                v.into_iter()
+                    .map(|t| tle_into_py(t, py))
+                    .collect::<Vec<_>>()
+                    .into_py_any(py)
+            } else {
+                Ok(tle_into_py(v.into_iter().next().unwrap(), py))
+            }
         })
+        .map_err(|e| e.into())
     }
 
     /// Load TLE(s) from a URL
@@ -246,12 +245,12 @@ impl PyTLE {
 
     /// Output as 2 canonical TLE Lines
     fn to_2line(&self) -> Result<[String; 2]> {
-        self.0.to_2line()
+        Ok(self.0.to_2line()?)
     }
 
     // Output as 2 canonical TLE lines preceded by a name line (3-line element set)
     fn to_3line(&self) -> Result<[String; 3]> {
-        self.0.to_3line()
+        Ok(self.0.to_3line()?)
     }
 
     // Fit a TLE from GCRF states and times

--- a/src/omm/error.rs
+++ b/src/omm/error.rs
@@ -1,0 +1,57 @@
+//! Errors produced by the `omm` module.
+
+use std::num::{ParseFloatError, ParseIntError};
+
+use thiserror::Error;
+
+/// Errors that can occur while parsing or using OMM messages.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Missing required field {0}")]
+    MissingField(&'static str),
+
+    #[error("Invalid float for {field}: {source}")]
+    InvalidFloatField {
+        field: &'static str,
+        #[source]
+        source: ParseFloatError,
+    },
+
+    #[error("Invalid float value: {0}")]
+    InvalidFloat(#[from] ParseFloatError),
+
+    #[error("Invalid integer value: {0}")]
+    InvalidInt(#[from] ParseIntError),
+
+    /// Raised when [`OMM::epoch_instant`](crate::omm::OMM::epoch_instant)
+    /// fails to parse `epoch` as RFC 3339.
+    #[error(transparent)]
+    InvalidEpoch(#[from] crate::time::InstantError),
+
+    #[error("Unsupported MEAN_ELEMENT_THEORY: {0}")]
+    UnsupportedMeanElementTheory(String),
+
+    #[error("Unsupported TIME_SYSTEM for SGP4: {0}")]
+    UnsupportedTimeSystem(String),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Http(#[from] ureq::Error),
+
+    /// Returned by [`OMM::from_url`](crate::omm::OMM::from_url) when the
+    /// response looks like XML but the `omm-xml` cargo feature is disabled.
+    #[error("Response appears to be XML but the `omm-xml` feature is not enabled")]
+    XmlFeatureDisabled,
+
+    #[cfg(feature = "omm-xml")]
+    #[error(transparent)]
+    Xml(#[from] quick_xml::DeError),
+}
+
+/// Convenient type alias used throughout the `omm` module.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/omm/error.rs
+++ b/src/omm/error.rs
@@ -40,6 +40,7 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
+    #[cfg(feature = "download")]
     #[error(transparent)]
     Http(#[from] ureq::Error),
 

--- a/src/omm/mod.rs
+++ b/src/omm/mod.rs
@@ -12,7 +12,9 @@
 
 use serde::{Deserialize, Deserializer};
 
-use anyhow::Result;
+mod error;
+
+pub use error::{Error, Result};
 
 #[cfg(feature = "omm-xml")]
 mod xml;
@@ -20,7 +22,7 @@ mod xml;
 use crate::sgp4::{SGP4InitArgs, SGP4Source, SatRec};
 use crate::{Instant, TimeScale};
 
-fn de_f64_from_number_or_string<'de, D>(deserializer: D) -> Result<f64, D::Error>
+fn de_f64_from_number_or_string<'de, D>(deserializer: D) -> std::result::Result<f64, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -37,7 +39,9 @@ where
     }
 }
 
-fn de_opt_f64_from_number_or_string<'de, D>(deserializer: D) -> Result<Option<f64>, D::Error>
+fn de_opt_f64_from_number_or_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<f64>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -65,7 +69,9 @@ where
     }
 }
 
-fn de_opt_u32_from_number_or_string<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+fn de_opt_u32_from_number_or_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u32>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -100,7 +106,9 @@ where
     }
 }
 
-fn de_opt_u8_from_number_or_string<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+fn de_opt_u8_from_number_or_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<u8>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -293,8 +301,8 @@ impl OMM {
     /// # Errors
     ///
     /// Returns an error if `epoch` is not a valid RFC 3339 timestamp.
-    pub fn epoch_instant(&self) -> anyhow::Result<Instant> {
-        Instant::from_rfc3339(&self.epoch).map_err(|e| anyhow::anyhow!(e))
+    pub fn epoch_instant(&self) -> Result<Instant> {
+        Instant::from_rfc3339(&self.epoch).map_err(Error::from)
     }
 
     /// Deserializes one or more OMM records from a JSON string.
@@ -334,7 +342,7 @@ impl OMM {
     ///
     /// Returns an error if the JSON is malformed or required OMM fields are missing/invalid.
     pub fn from_json_string(s: &str) -> Result<Vec<Self>> {
-        serde_json::from_str(s).map_err(|e| anyhow::anyhow!(e))
+        serde_json::from_str(s).map_err(Error::from)
     }
 
     /// Deserializes one or more OMM records from a JSON file.
@@ -356,9 +364,9 @@ impl OMM {
     ///
     /// Returns an error if the file cannot be read or the JSON payload is invalid.
     pub fn from_json_file<P: AsRef<std::path::Path>>(path: P) -> Result<Vec<Self>> {
-        let file = std::fs::File::open(path).map_err(|e| anyhow::anyhow!(e))?;
+        let file = std::fs::File::open(path)?;
         let reader = std::io::BufReader::new(file);
-        serde_json::from_reader(reader).map_err(|e| anyhow::anyhow!(e))
+        serde_json::from_reader(reader).map_err(Error::from)
     }
 
     /// Load OMM(s) from a URL
@@ -395,7 +403,7 @@ impl OMM {
             }
             #[cfg(not(feature = "omm-xml"))]
             {
-                anyhow::bail!("Response appears to be XML but the `omm-xml` feature is not enabled")
+                Err(Error::XmlFeatureDisabled)
             }
         }
     }
@@ -418,13 +426,13 @@ impl SGP4Source for OMM {
 
         if let Some(theory) = &self.mean_element_theory {
             if !theory.trim().eq_ignore_ascii_case("SGP4") {
-                anyhow::bail!("Unsupported MEAN_ELEMENT_THEORY: {theory}");
+                return Err(Error::UnsupportedMeanElementTheory(theory.clone()).into());
             }
         }
 
         if let Some(ts) = &self.time_system {
             if !ts.trim().eq_ignore_ascii_case("UTC") {
-                anyhow::bail!("Unsupported TIME_SYSTEM for SGP4: {ts}");
+                return Err(Error::UnsupportedTimeSystem(ts.clone()).into());
             }
         }
 

--- a/src/omm/xml.rs
+++ b/src/omm/xml.rs
@@ -1,17 +1,16 @@
-use anyhow::Result;
 use serde::Deserialize;
 
-use super::OMM;
+use super::{Error, Result, OMM};
 
-fn parse_required_f64(field: &str, value: Option<String>) -> anyhow::Result<f64> {
-    let value = value.ok_or_else(|| anyhow::anyhow!("Missing required field {field}"))?;
+fn parse_required_f64(field: &'static str, value: Option<String>) -> Result<f64> {
+    let value = value.ok_or(Error::MissingField(field))?;
     value
         .trim()
         .parse::<f64>()
-        .map_err(|e| anyhow::anyhow!("Invalid float for {field}: {e}"))
+        .map_err(|source| Error::InvalidFloatField { field, source })
 }
 
-fn parse_optional_f64(value: Option<String>) -> anyhow::Result<Option<f64>> {
+fn parse_optional_f64(value: Option<String>) -> Result<Option<f64>> {
     match value {
         None => Ok(None),
         Some(s) => {
@@ -19,15 +18,13 @@ fn parse_optional_f64(value: Option<String>) -> anyhow::Result<Option<f64>> {
             if s.is_empty() {
                 Ok(None)
             } else {
-                s.parse::<f64>()
-                    .map(Some)
-                    .map_err(|e| anyhow::anyhow!("Invalid float value: {e}"))
+                s.parse::<f64>().map(Some).map_err(Error::from)
             }
         }
     }
 }
 
-fn parse_optional_u8(value: Option<String>) -> anyhow::Result<Option<u8>> {
+fn parse_optional_u8(value: Option<String>) -> Result<Option<u8>> {
     match value {
         None => Ok(None),
         Some(s) => {
@@ -35,15 +32,13 @@ fn parse_optional_u8(value: Option<String>) -> anyhow::Result<Option<u8>> {
             if s.is_empty() {
                 Ok(None)
             } else {
-                s.parse::<u8>()
-                    .map(Some)
-                    .map_err(|e| anyhow::anyhow!("Invalid u8 value: {e}"))
+                s.parse::<u8>().map(Some).map_err(Error::from)
             }
         }
     }
 }
 
-fn parse_optional_u32(value: Option<String>) -> anyhow::Result<Option<u32>> {
+fn parse_optional_u32(value: Option<String>) -> Result<Option<u32>> {
     match value {
         None => Ok(None),
         Some(s) => {
@@ -51,9 +46,7 @@ fn parse_optional_u32(value: Option<String>) -> anyhow::Result<Option<u32>> {
             if s.is_empty() {
                 Ok(None)
             } else {
-                s.parse::<u32>()
-                    .map(Some)
-                    .map_err(|e| anyhow::anyhow!("Invalid u32 value: {e}"))
+                s.parse::<u32>().map(Some).map_err(Error::from)
             }
         }
     }
@@ -180,9 +173,9 @@ struct OmmXmlTleParameters {
 }
 
 impl TryFrom<OmmXmlMessage> for OMM {
-    type Error = anyhow::Error;
+    type Error = Error;
 
-    fn try_from(xml: OmmXmlMessage) -> std::result::Result<Self, Self::Error> {
+    fn try_from(xml: OmmXmlMessage) -> Result<Self> {
         let metadata = xml.body.segment.metadata;
         let mean = xml.body.segment.data.mean_elements;
         let tle = xml.body.segment.data.tle_parameters;
@@ -308,13 +301,13 @@ impl OMM {
     /// Returns an error if XML parsing fails or if required OMM fields are missing/invalid.
     pub fn from_xml_string(s: &str) -> Result<Vec<Self>> {
         if s.contains("<ndm") {
-            let root: OmmXmlRoot = quick_xml::de::from_str(s).map_err(|e| anyhow::anyhow!(e))?;
+            let root: OmmXmlRoot = quick_xml::de::from_str(s)?;
             root.omms
                 .into_iter()
                 .map(Self::try_from)
                 .collect::<Result<Vec<_>>>()
         } else {
-            let msg: OmmXmlMessage = quick_xml::de::from_str(s).map_err(|e| anyhow::anyhow!(e))?;
+            let msg: OmmXmlMessage = quick_xml::de::from_str(s)?;
             Ok(vec![Self::try_from(msg)?])
         }
     }
@@ -328,7 +321,7 @@ impl OMM {
     /// Returns an error if the file cannot be read, XML parsing fails, or required
     /// OMM fields are missing/invalid.
     pub fn from_xml_file<P: AsRef<std::path::Path>>(path: P) -> Result<Vec<Self>> {
-        let s = std::fs::read_to_string(path).map_err(|e| anyhow::anyhow!(e))?;
+        let s = std::fs::read_to_string(path)?;
         Self::from_xml_string(&s)
     }
 }

--- a/src/tle/error.rs
+++ b/src/tle/error.rs
@@ -62,6 +62,7 @@ pub enum Error {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
+    #[cfg(feature = "download")]
     #[error(transparent)]
     Http(#[from] ureq::Error),
 }

--- a/src/tle/error.rs
+++ b/src/tle/error.rs
@@ -1,0 +1,70 @@
+//! Errors produced by the `tle` module.
+
+use thiserror::Error;
+
+/// Errors that can occur while parsing, formatting, or fitting TLEs.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid TLE line lengths: line1 = {line1}, line2 = {line2}")]
+    InvalidLineLengths { line1: usize, line2: usize },
+
+    #[error("Line {line} too short: expected 69 characters, got {got}")]
+    LineTooShort { line: u8, got: usize },
+
+    /// Failed to parse a numeric/string field from a TLE line.
+    #[error("Could not parse {field}: {message}")]
+    ParseField {
+        field: &'static str,
+        message: String,
+    },
+
+    #[error("Year out of range for TLE: {0}")]
+    YearOutOfRange(i32),
+
+    #[error("Invalid sat num: {0}")]
+    InvalidSatNum(String),
+
+    #[error("Invalid first digit in sat num: {0}")]
+    InvalidFirstDigit(char),
+
+    #[error("Parse error")]
+    EmptySatNum,
+
+    #[error("Sat num >= 340000 cannot be represented in alpha5 format")]
+    SatNumTooLargeForAlpha5,
+
+    #[error("Invalid sat num value")]
+    InvalidSatNumValue,
+
+    /// Wraps an error from constructing an [`Instant`](crate::time::Instant)
+    /// while assembling a TLE epoch.
+    #[error("Invalid TLE epoch: {0}")]
+    InvalidEpoch(String),
+
+    #[error("States and times must have the same length")]
+    StatesTimesLengthMismatch,
+
+    #[error("States and times must not be empty")]
+    EmptyStates,
+
+    #[error("Epoch is out of range. Must be between {min} and {max}")]
+    EpochOutOfRange { min: String, max: String },
+
+    #[error("Could not convert state to Keplerian elements: {0}")]
+    KeplerConversion(String),
+
+    #[error("SGP4 evaluation failed: {0}")]
+    Sgp4(String),
+
+    #[error("Normal equations are singular: {0}")]
+    SingularNormalEquations(String),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Http(#[from] ureq::Error),
+}
+
+/// Convenient type alias used throughout the `tle` module.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/tle/fitting.rs
+++ b/src/tle/fitting.rs
@@ -1,7 +1,6 @@
-use super::TLE;
+use super::{Error, Result, TLE};
 
 use crate::Instant;
-use anyhow::{bail, Context, Result};
 
 use numeris::{Matrix, Vector};
 
@@ -88,7 +87,7 @@ fn residuals(
 ) -> Result<Vec<f64>> {
     let mut tle = tle_from_params(params, epoch);
     let out = crate::sgp4::sgp4(&mut tle, times)
-        .map_err(|e| anyhow::anyhow!("SGP4 evaluation failed: {:?}", e))?;
+        .map_err(|e| Error::Sgp4(format!("{e:?}")))?;
     let mut r = vec![0.0; states_teme.len() * 3];
     for (i, state) in states_teme.iter().enumerate() {
         for j in 0..3 {
@@ -202,20 +201,19 @@ impl TLE {
     ) -> Result<(Self, TleFitResult)> {
         // Make sure lengths are identical
         if states_gcrf.len() != times.len() {
-            bail!("States and times must have the same length");
+            return Err(Error::StatesTimesLengthMismatch);
         } else if states_gcrf.is_empty() {
-            bail!("States and times must not be empty");
+            return Err(Error::EmptyStates);
         }
 
         // Get the minimum time
         let min_time = times.iter().min().unwrap();
         let max_time = times.iter().max().unwrap();
         if epoch < *min_time || epoch > *max_time {
-            bail!(
-                "Epoch is out of range. Must be between {} and {}",
-                min_time,
-                max_time
-            );
+            return Err(Error::EpochOutOfRange {
+                min: min_time.to_string(),
+                max: max_time.to_string(),
+            });
         }
 
         // Find the point that is closest to the epoch
@@ -260,7 +258,7 @@ impl TLE {
             numeris::vector![closest_state[0], closest_state[1], closest_state[2]],
             numeris::vector![closest_state[3], closest_state[4], closest_state[5]],
         )
-        .context("Could not convert state to Keplerian elements")?;
+        .map_err(|e| Error::KeplerConversion(e.to_string()))?;
 
         // Move Kepler state to epoch
         if (epoch - closest_time).as_microseconds().abs() > 10 {
@@ -367,7 +365,7 @@ impl TLE {
                 }
                 let lu = damped
                     .lu()
-                    .map_err(|e| anyhow::anyhow!("Normal equations are singular: {:?}", e))?;
+                    .map_err(|e| Error::SingularNormalEquations(format!("{e:?}")))?;
                 let neg_g: Vector<f64, NPARAM> = -jtr;
                 let delta = lu.solve(&neg_g);
 
@@ -452,6 +450,7 @@ impl TLE {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
 
     #[test]
     fn test_fit_from_states() -> Result<()> {

--- a/src/tle/mod.rs
+++ b/src/tle/mod.rs
@@ -7,9 +7,10 @@ use crate::sgp4::{SGP4InitArgs, SGP4Source};
 // TLE fitting from state vectors
 mod fitting;
 
-pub use fitting::{TleFitResult, TleFitStatus};
+mod error;
 
-use anyhow::{bail, Context, Result};
+pub use error::{Error, Result};
+pub use fitting::{TleFitResult, TleFitStatus};
 
 // 'I' and 'O' are not part of the allowed chars to avoid any confusion with 0 or 1
 const ALPHA5_MATCHING: &str = "ABCDEFGHJKLMNPQRSTUVWXYZ";
@@ -308,11 +309,10 @@ impl TLE {
     ///
     pub fn load_3line(line0: &str, line1: &str, line2: &str) -> Result<Self> {
         if line1.len() < 69 || line2.len() < 69 {
-            bail!(
-                "Invalid TLE line lengths: line1 = {}, line2 = {}",
-                line1.len(),
-                line2.len()
-            );
+            return Err(Error::InvalidLineLengths {
+                line1: line1.len(),
+                line2: line2.len(),
+            });
         }
 
         match Self::load_2line(line1, line2) {
@@ -363,22 +363,33 @@ impl TLE {
     ///
     pub fn load_2line(line1: &str, line2: &str) -> Result<Self> {
         if line1.len() < 69 {
-            bail!(
-                "Line 1 too short: expected 69 characters, got {}",
-                line1.len()
-            );
+            return Err(Error::LineTooShort {
+                line: 1,
+                got: line1.len(),
+            });
         }
         if line2.len() < 69 {
-            bail!(
-                "Line 2 too short: expected 69 characters, got {}",
-                line2.len()
-            );
+            return Err(Error::LineTooShort {
+                line: 2,
+                got: line2.len(),
+            });
+        }
+
+        // Helper for converting parse errors into ParseField variants.
+        fn parse_field<F: std::str::FromStr>(s: &str, field: &'static str) -> Result<F>
+        where
+            F::Err: std::fmt::Display,
+        {
+            s.parse::<F>().map_err(|e| Error::ParseField {
+                field,
+                message: e.to_string(),
+            })
         }
 
         let mut year: u32 = {
             let mut mstr: String = "1".to_owned();
             mstr.push_str(&line1[18..20]);
-            let mut s = mstr.parse().context("Could not parse year")?;
+            let mut s: u32 = parse_field(&mstr, "year")?;
             s -= 100;
             s
         };
@@ -387,35 +398,32 @@ impl TLE {
         // Years < 1957 = 2000s
         let century = if year >= 57 { 1900 } else { 2000 };
         year += century;
-        let day_of_year: f64 = line1[20..32]
-            .parse()
-            .context("Could not parse day of year")?;
+        let day_of_year: f64 = parse_field(&line1[20..32], "day of year")?;
 
         // Note: day_of_year starts from 1, not zero,
         // also, go from Jan 2 to avoid leap-second
         // issues, hence the "-2" at end
         let epoch = Instant::from_date(year as i32, 1, 2)
-            .context("Invalid year, month, or day")?
+            .map_err(|e| Error::InvalidEpoch(format!("Invalid year, month, or day: {e}")))?
             .add_utc_days(day_of_year - 2.0);
 
         Ok(Self {
             name: "none".to_string(),
-            sat_num: Self::alpha5_to_int(&line1[2..7])
-                .context("Could not parse satellite number")?,
+            sat_num: Self::alpha5_to_int(&line1[2..7]).map_err(|e| Error::ParseField {
+                field: "satellite number",
+                message: e.to_string(),
+            })?,
 
             intl_desig: { line1[9..16].trim().to_string() },
             desig_year: { line1[9..11].trim().parse().unwrap_or(70) },
             desig_launch: { line1[11..14].trim().parse().unwrap_or_default() },
-            desig_piece: line1[14..18]
-                .trim()
-                .parse()
-                .context("Could not parse desig_piece")?,
+            desig_piece: parse_field(line1[14..18].trim(), "desig_piece")?,
 
             epoch,
             mean_motion_dot: {
                 let mut mstr: String = "0".to_owned();
                 mstr.push_str(&line1[34..43]);
-                let mut m = mstr.parse().context("Could not parse mean motion dot")?;
+                let mut m: f64 = parse_field(&mstr, "mean motion dot")?;
                 if line1.chars().nth(33).unwrap() == '-' {
                     m *= -1.0;
                 }
@@ -426,10 +434,7 @@ impl TLE {
                 mstr.push_str(&line1[45..50]);
                 mstr.push('E');
                 mstr.push_str(&line1[50..53]);
-                let mut m = mstr
-                    .trim()
-                    .parse()
-                    .context("Coudl not parse mean motion dot dot")?;
+                let mut m: f64 = parse_field(mstr.trim(), "mean motion dot dot")?;
                 if line1.chars().nth(44).unwrap() == '-' {
                     m *= -1.0;
                 }
@@ -440,57 +445,31 @@ impl TLE {
                 mstr.push_str(&line1[54..59]);
                 mstr.push('E');
                 mstr.push_str(&line1[59..62]);
-                let mut m = mstr
-                    .trim()
-                    .parse()
-                    .context("Could not parse bstar (drag)")?;
+                let mut m: f64 = parse_field(mstr.trim(), "bstar (drag)")?;
                 if line1.chars().nth(53).unwrap() == '-' {
                     m *= -1.0;
                 }
                 m
             },
             ephem_type: { line1[62..63].trim().parse().unwrap_or_default() },
-            element_num: line1[64..68]
-                .trim()
-                .parse()
-                .context("Could not parse element number")?,
+            element_num: parse_field(line1[64..68].trim(), "element number")?,
 
-            inclination: line2[8..16]
-                .trim()
-                .parse()
-                .context("Could not parse inclination")?,
+            inclination: parse_field(line2[8..16].trim(), "inclination")?,
 
-            raan: line2[17..25]
-                .trim()
-                .parse()
-                .context("Could not parse raan")?,
+            raan: parse_field(line2[17..25].trim(), "raan")?,
 
             eccen: {
                 let mut mstr: String = "0.".to_owned();
                 mstr.push_str(&line2[26..33]);
-                mstr.trim()
-                    .parse()
-                    .context("Could not parse eccentricity")?
+                parse_field(mstr.trim(), "eccentricity")?
             },
-            arg_of_perigee: line2[34..42]
-                .trim()
-                .parse()
-                .context("Could not parse arg of perigee")?,
+            arg_of_perigee: parse_field(line2[34..42].trim(), "arg of perigee")?,
 
-            mean_anomaly: line2[42..51]
-                .trim()
-                .parse()
-                .context("Could not parse mean anomaly")?,
+            mean_anomaly: parse_field(line2[42..51].trim(), "mean anomaly")?,
 
-            mean_motion: line2[52..63]
-                .trim()
-                .parse()
-                .context("Could not parse mean motion")?,
+            mean_motion: parse_field(line2[52..63].trim(), "mean motion")?,
 
-            rev_num: line2[63..68]
-                .trim()
-                .parse()
-                .context("Could not parse rev num")?,
+            rev_num: parse_field(line2[63..68].trim(), "rev num")?,
             satrec: None,
         })
     }
@@ -617,7 +596,7 @@ impl TLE {
         let (year, _, _, _, _, _) = self.epoch.as_datetime();
 
         if !(1957..=2056).contains(&year) {
-            bail!("Year out of range for TLE: {}", year);
+            return Err(Error::YearOutOfRange(year));
         }
 
         // Day-of-year.
@@ -666,7 +645,7 @@ impl TLE {
             // digit or a whitespace the standard `.parse()` can be used.
             Some(c) if c.is_ascii_digit() || c.is_whitespace() => match alpha5.trim().parse() {
                 Ok(i) => Ok(i),
-                Err(e) => bail!("Invalid sat num: {}", e),
+                Err(e) => Err(Error::InvalidSatNum(format!("{e}"))),
             },
             Some(c) if c.is_alphabetic() => {
                 match ALPHA5_MATCHING
@@ -675,13 +654,13 @@ impl TLE {
                 {
                     Some(p) => match alpha5[1..].parse::<i32>() {
                         Ok(i) => Ok((p as i32 + 10) * 10000 + i),
-                        Err(e) => bail!("Invalid sat num: {}", e),
+                        Err(e) => Err(Error::InvalidSatNum(format!("{e}"))),
                     },
-                    None => bail!("Invalid first digit in sat num: {}", c),
+                    None => Err(Error::InvalidFirstDigit(c)),
                 }
             }
-            Some(c) => bail!("Invalid first digit in sat num: {}", c),
-            None => bail!("Parse error"),
+            Some(c) => Err(Error::InvalidFirstDigit(c)),
+            None => Err(Error::EmptySatNum),
         }
     }
 
@@ -719,8 +698,8 @@ impl TLE {
                     .unwrap();
                 Ok(format!("{c}{:0>4}", i % 10000))
             }
-            _i @ 340000.. => bail!("Sat num >= 340000 cannot be represented in alpha5 format"),
-            _ => bail!("Invalid sat num value"),
+            _i @ 340000.. => Err(Error::SatNumTooLargeForAlpha5),
+            _ => Err(Error::InvalidSatNumValue),
         }
     }
 
@@ -862,6 +841,7 @@ mod tle_formatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::{bail, Result};
 
     #[test]
     fn testload() -> Result<()> {


### PR DESCRIPTION
## Summary

Phase 1 of the multi-PR `anyhow` → `thiserror` migration tracked in #81. Replaces `anyhow::Result` with module-local `Error` enums in `tle` and `omm` — the two most public-API-facing modules.

Refs #81. (Not closing — #81 covers Phases 2 and 3 in follow-up PRs.)

## What changed

**`tle::Error`** (in `src/tle/error.rs`):
- `InvalidLineLengths { line1, line2 }`, `LineTooShort { line, got }`
- `ParseField { field, message }` — consolidates all `.context("Could not parse <field>")` sites
- `YearOutOfRange`, `InvalidSatNum`, `InvalidFirstDigit`, `EmptySatNum`, `SatNumTooLargeForAlpha5`, `InvalidSatNumValue`
- `InvalidEpoch(String)`, `KeplerConversion(String)` — stringified pending Phases 2/3 of #81 (those types still return `anyhow`)
- `StatesTimesLengthMismatch`, `EmptyStates`, `EpochOutOfRange { min, max }` — fitting input validation
- `Sgp4(String)`, `SingularNormalEquations(String)`
- `Io(#[from] std::io::Error)`, `Http(#[from] ureq::Error)`

**`omm::Error`** (in `src/omm/error.rs`):
- `MissingField(&'static str)`
- `InvalidFloatField { field, source: ParseFloatError }`, `InvalidFloat(#[from] ParseFloatError)`, `InvalidInt(#[from] ParseIntError)`
- `InvalidEpoch(#[from] crate::time::InstantError)`
- `UnsupportedMeanElementTheory`, `UnsupportedTimeSystem`
- `Json(#[from] serde_json::Error)`, `Io(#[from] std::io::Error)`, `Http(#[from] ureq::Error)`
- `XmlFeatureDisabled`, `Xml(#[from] quick_xml::DeError)` (cfg-gated)

## Judgment calls worth a look

1. **Some `anyhow` deliberately retained.** `SGP4Source::sgp4_init_args` is a trait method (defined outside `tle`/`omm`) returning `anyhow::Result`; impls in `tle::TLE` and `omm::OMM` still satisfy that signature, with `Error` variants `.into()`'d to `anyhow::Error` at the boundary.
2. **External anyhow-returning calls stringified.** `Instant::from_date` and `Kepler::from_pv` still return `anyhow::Error`, so `tle::Error::InvalidEpoch` and `tle::Error::KeplerConversion` are `String` payloads. These become typed in Phases 2/3 (when `time` and `kepler` migrate).
3. **Python bindings keep `anyhow::Result`.** `tle::Error`/`omm::Error` implement `std::error::Error + Send + Sync + 'static`, so anyhow's blanket `From<E>` + pyo3's anyhow→PyErr conversion makes `?` work cleanly. No orphan-rule wrappers needed.
4. **Slight redundancy in `omm::Error`**: both `InvalidFloat(#[from] ParseFloatError)` and `InvalidFloatField { field, source: ParseFloatError }` exist — one for ad-hoc `?` sites, one for the field-aware `parse_required_f64` helper. Worth a glance to see if you'd prefer to collapse.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo build --no-default-features` — clean (XML-only variants correctly excluded)
- [x] `cargo test --release` — 159 lib + 41 doc tests pass
- [x] `cargo build --no-default-features` test run — 158 lib + 40 doc tests pass
- [x] `cargo check --manifest-path python/Cargo.toml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)