### PR TITLE
thiserror migration Phase 2: frames + itrfcoord + orbitprop

### DIFF
--- a/python/src/pysatstate.rs
+++ b/python/src/pysatstate.rs
@@ -372,9 +372,11 @@ impl PySatState {
             .as_ref()
             .map(|s| &s.0 as &dyn satkit::orbitprop::SatProperties);
 
-        self.0
-            .propagate(&time, propsettings.as_ref(), satprops_ref)
-            .map(Self)
+        Ok(Self(self.0.propagate(
+            &time,
+            propsettings.as_ref(),
+            satprops_ref,
+        )?))
     }
 
     fn __getnewargs_ex__<'a>(&self, py: Python<'a>) -> (Bound<'a, PyTuple>, Bound<'a, PyDict>) {

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -1,4 +1,16 @@
-use anyhow::bail;
+use thiserror::Error;
+
+/// Errors produced by the `frames` module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Returned by [`Frame::from_str`](std::str::FromStr::from_str) when the
+    /// input string does not match any known frame name.
+    #[error("Invalid Frame")]
+    InvalidFrame,
+}
+
+/// Convenient type alias used throughout the `frames` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Reference frame identifier.
 ///
@@ -116,9 +128,9 @@ impl std::fmt::Display for Frame {
 }
 
 impl std::str::FromStr for Frame {
-    type Err = anyhow::Error;
+    type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
             "ITRF" => Ok(Self::ITRF),
             "TIRS" => Ok(Self::TIRS),
@@ -132,7 +144,7 @@ impl std::str::FromStr for Frame {
             // canonical is RTN.
             "RTN" | "RSW" | "RIC" => Ok(Self::RTN),
             "NTW" => Ok(Self::NTW),
-            _ => bail!("Invalid Frame"),
+            _ => Err(Error::InvalidFrame),
         }
     }
 }

--- a/src/itrfcoord.rs
+++ b/src/itrfcoord.rs
@@ -5,7 +5,19 @@ use crate::consts::WGS84_F;
 
 use crate::mathtypes::*;
 
-use anyhow::Result;
+use thiserror::Error;
+
+/// Errors produced by the `itrfcoord` module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Returned by [`ITRFCoord::from_slice`] and the [`TryFrom`] impls
+    /// when the input slice does not contain exactly three elements.
+    #[error("Input slice must have 3 elements, got {got}")]
+    InvalidSliceLength { got: usize },
+}
+
+/// Convenient type alias used throughout the `itrfcoord` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Geodetic coordinates with named fields
 ///
@@ -109,10 +121,10 @@ impl std::convert::From<[f64; 3]> for ITRFCoord {
 }
 
 impl std::convert::TryFrom<&[f64]> for ITRFCoord {
-    type Error = anyhow::Error;
+    type Error = Error;
     fn try_from(v: &[f64]) -> Result<Self> {
         if v.len() != 3 {
-            anyhow::bail!("Input slice must have 3 elements, got {}", v.len());
+            return Err(Error::InvalidSliceLength { got: v.len() });
         }
         Ok(Self {
             itrf: numeris::vector![v[0], v[1], v[2]],
@@ -190,7 +202,7 @@ impl ITRFCoord {
     ///
     pub fn from_slice(v: &[f64]) -> Result<Self> {
         if v.len() != 3 {
-            anyhow::bail!("Input slice must have 3 elements");
+            return Err(Error::InvalidSliceLength { got: v.len() });
         }
         Ok(Self {
             itrf: numeris::vector![v[0], v[1], v[2]],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub mod tle;
 pub mod utils;
 
 /// Coordinate frames (re-exported as `Frame` at crate root)
-mod frames;
+pub mod frames;
 
 // Orbital Mean-Element Messages
 pub mod omm;

--- a/src/orbitprop/error.rs
+++ b/src/orbitprop/error.rs
@@ -1,0 +1,81 @@
+//! Errors produced by the `orbitprop` module.
+
+use numeris::ode;
+use thiserror::Error;
+
+use crate::Frame;
+
+/// Errors that can occur while configuring or executing orbit propagation.
+#[derive(Debug, Error)]
+pub enum Error {
+    // -- propagator-internal errors --------------------------------------
+    /// Returned when the integrated state matrix has an unexpected
+    /// number of columns.
+    #[error("Invalid number of columns: {c}")]
+    InvalidStateColumns { c: usize },
+
+    /// Returned by the dense-output interp helpers when the underlying
+    /// ODE solution does not carry interpolation data.
+    #[error("No Dense Output in Solution")]
+    NoDenseOutputInSolution,
+
+    /// Wraps an [`ode::OdeError`] surfaced by the chosen integrator.
+    /// `OdeError` does not implement `std::error::Error` (numeris keeps
+    /// it as a plain `Display`-only enum), so this variant is built
+    /// manually rather than via `#[from]`.
+    #[error("ODE Error: {0}")]
+    OdeError(ode::OdeError),
+
+    /// RODAS4 does not support state transition matrix propagation
+    /// (`C == 7`).
+    #[error("RODAS4 does not support state transition matrix propagation")]
+    RODAS4NoSTM,
+
+    /// Gauss-Jackson 8 does not support state transition matrix
+    /// propagation (`C == 7`).
+    #[error("Gauss-Jackson 8 does not support state transition matrix propagation")]
+    GaussJackson8NoSTM,
+
+    // -- precomputed.rs --------------------------------------------------
+    /// Returned by [`Precomputed::interp`](crate::orbitprop::Precomputed::interp)
+    /// when the requested time falls outside the precomputed range.
+    #[error(
+        "Precomputed::interp: time {time} is outside of precomputed range : {begin} to {end}"
+    )]
+    PrecomputedOutOfRange {
+        time: String,
+        begin: String,
+        end: String,
+    },
+
+    /// Wraps an error surfaced while building a
+    /// [`Precomputed`](crate::orbitprop::Precomputed) interp table.
+    /// Currently captures stringified errors from the still-anyhow
+    /// `jplephem` module; will become a typed variant when that module
+    /// is migrated in Phase 3.
+    #[error("Cannot compute precomputed interpolation data: {0}")]
+    Precompute(String),
+
+    // -- satstate.rs -----------------------------------------------------
+    /// Returned by [`SatState::set_pos_uncertainty`](crate::orbitprop::SatState::set_pos_uncertainty),
+    /// [`SatState::set_vel_uncertainty`](crate::orbitprop::SatState::set_vel_uncertainty),
+    /// and the internal `cov_frame_to_gcrf` helper when the supplied
+    /// frame is not one of the supported orbital or inertial frames.
+    #[error("Unsupported frame for uncertainty: {frame}. Must be GCRF, LVLH, RIC, or NTW")]
+    UnsupportedUncertaintyFrame { frame: Frame },
+
+    // -- settings.rs -----------------------------------------------------
+    /// Returned by [`PropSettings::set_gravity`](crate::orbitprop::PropSettings::set_gravity)
+    /// when `order > degree`.
+    #[error("Gravity order ({order}) must be ≤ degree ({degree})")]
+    InvalidGravityOrder { order: u16, degree: u16 },
+}
+
+impl From<ode::OdeError> for Error {
+    fn from(e: ode::OdeError) -> Self {
+        Self::OdeError(e)
+    }
+}
+
+/// Convenient type alias used throughout the `orbitprop` module.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/orbitprop/mod.rs
+++ b/src/orbitprop/mod.rs
@@ -1,3 +1,4 @@
+mod error;
 mod precomputed;
 pub mod propagator;
 mod satproperties;
@@ -13,6 +14,7 @@ pub mod thrust;
 /// ODE integrators specific to orbit propagation
 pub mod ode;
 
+pub use error::{Error, Result};
 pub use precomputed::*;
 pub use propagator::*;
 pub use satproperties::SatProperties;

--- a/src/orbitprop/precomputed.rs
+++ b/src/orbitprop/precomputed.rs
@@ -8,7 +8,7 @@ use crate::SolarSystem;
 
 pub type InterpType = (Quaternion, Vector3, Vector3);
 
-use anyhow::Result;
+use super::error::{Error, Result};
 #[derive(Debug, Clone)]
 pub struct Precomputed {
     pub begin: Instant,
@@ -83,8 +83,10 @@ impl Precomputed {
                 for idx in 0..nsteps {
                     let t = pbegin + Duration::from_seconds((idx as f64) * step);
                     let q = qgcrf2itrf_approx(&t);
-                    let psun = jplephem::geocentric_pos(SolarSystem::Sun, &t)?;
-                    let pmoon = jplephem::geocentric_pos(SolarSystem::Moon, &t)?;
+                    let psun = jplephem::geocentric_pos(SolarSystem::Sun, &t)
+                        .map_err(|e| Error::Precompute(e.to_string()))?;
+                    let pmoon = jplephem::geocentric_pos(SolarSystem::Moon, &t)
+                        .map_err(|e| Error::Precompute(e.to_string()))?;
                     data.push((q, psun, pmoon));
                 }
                 data
@@ -95,12 +97,11 @@ impl Precomputed {
     pub fn interp<T: TimeLike>(&self, t: &T) -> Result<InterpType> {
         let t = t.as_instant();
         if t < self.begin || t > self.end {
-            anyhow::bail!(
-                "Precomputed::interp: time {} is outside of precomputed range : {} to {}",
-                t,
-                self.begin,
-                self.end
-            );
+            return Err(Error::PrecomputedOutOfRange {
+                time: t.to_string(),
+                begin: self.begin.to_string(),
+                end: self.end.to_string(),
+            });
         }
 
         let idx = (t - self.begin).as_seconds() / self.step;

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -9,7 +9,7 @@ use lpephem::sun::shadowfunc;
 
 use numeris::ode::{self, RKAdaptive, Rosenbrock};
 
-use anyhow::{Context, Result};
+use super::error::{Error, Result};
 
 use crate::mathtypes::*;
 
@@ -17,7 +17,6 @@ use crate::consts;
 use crate::orbitprop::SatProperties;
 
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct PropagationResult<const T: usize> {
@@ -71,20 +70,6 @@ pub type SimpleState = StateType<1>;
 
 // Covariance State in includes
 pub type CovState = StateType<7>;
-
-#[derive(Debug, Error)]
-pub enum PropagationError {
-    #[error("Invalid number of columns: {c}")]
-    InvalidStateColumns { c: usize },
-    #[error("No Dense Output in Solution")]
-    NoDenseOutputInSolution,
-    #[error("ODE Error: {0}")]
-    ODEError(ode::OdeError),
-    #[error("RODAS4 does not support state transition matrix propagation")]
-    RODAS4NoSTM,
-    #[error("Gauss-Jackson 8 does not support state transition matrix propagation")]
-    GaussJackson8NoSTM,
-}
 
 //
 // This actually implements the force model that is used to
@@ -251,11 +236,11 @@ pub fn propagate<const C: usize, T: TimeLike>(
 
     // RODAS4 does not support state transition matrix (C==7)
     if C == 7 && settings.integrator == crate::orbitprop::Integrator::RODAS4 {
-        return Err(PropagationError::RODAS4NoSTM.into());
+        return Err(Error::RODAS4NoSTM);
     }
     // Gauss-Jackson 8 is 2nd-order only and does not propagate STM
     if C == 7 && settings.integrator == crate::orbitprop::Integrator::GaussJackson8 {
-        return Err(PropagationError::GaussJackson8NoSTM.into());
+        return Err(Error::GaussJackson8NoSTM);
     }
 
     // Duration to end of integration, in seconds
@@ -285,8 +270,7 @@ pub fn propagate<const C: usize, T: TimeLike>(
     let required_max = tmax + padding;
     let interp: &Precomputed = match &settings.precomputed {
         Some(p) if required_min >= p.begin && required_max <= p.end => p,
-        _ => &Precomputed::new_padded(&begin, &end, 60.0, padding_secs)
-            .context("Cannot compute precomputed interpolation data")?,
+        _ => &Precomputed::new_padded(&begin, &end, 60.0, padding_secs)?,
     };
 
     let gravity = settings.gravity_model.get();
@@ -522,7 +506,7 @@ pub fn propagate<const C: usize, T: TimeLike>(
 
             let rosenbrock_res = ode::RODAS4::integrate(
                 0.0, x_end, &y0_vec, ydot_vec, jac_fn, &odesettings,
-            ).map_err(PropagationError::ODEError)?;
+            )?;
 
             // Convert RosenbrockSolution<f64, 6> to Solution<f64, 6, C>
             // Since C==1, this is essentially the same data
@@ -609,7 +593,7 @@ pub fn propagate<const C: usize, T: TimeLike>(
             let mut gj_sol = GaussJackson8::integrate(
                 0.0, x_end, &r0, &v0, accel_fn, &gj_settings,
             )
-            .map_err(PropagationError::ODEError)?;
+            ?;
 
             // Assemble final 6x1 state
             let mut final_state = Matrix::<6, C>::zeros();
@@ -633,7 +617,7 @@ pub fn propagate<const C: usize, T: TimeLike>(
             });
         }
     }
-    .map_err(PropagationError::ODEError)?;
+    ?;
 
     Ok(PropagationResult {
         time_begin: begin,
@@ -668,7 +652,7 @@ pub fn interp_propresult<const C: usize, T: TimeLike>(
         let dense = res
             .gj_dense
             .as_ref()
-            .ok_or(PropagationError::NoDenseOutputInSolution)?;
+            .ok_or(Error::NoDenseOutputInSolution)?;
         // Rehydrate a minimal GJSolution just enough for the interpolator
         let gj_sol = crate::orbitprop::ode::GJSolution::<f64, 3> {
             t: 0.0, // unused by interpolate
@@ -680,7 +664,7 @@ pub fn interp_propresult<const C: usize, T: TimeLike>(
             dense: Some(dense.clone()),
         };
         let (r, v) = crate::orbitprop::ode::GaussJackson8::interpolate(x, &gj_sol)
-            .map_err(PropagationError::ODEError)?;
+            ?;
         let mut out: StateType<C> = Matrix::<6, C>::zeros();
         let mut rv: numeris::Vector<f64, 6> = numeris::Vector::<f64, 6>::zeros();
         rv.set_block(0, 0, &r);
@@ -693,7 +677,7 @@ pub fn interp_propresult<const C: usize, T: TimeLike>(
         .odesol
         .as_ref()
         .filter(|s| s.dense.is_some())
-        .ok_or(PropagationError::NoDenseOutputInSolution)?;
+        .ok_or(Error::NoDenseOutputInSolution)?;
     let result = match res.integrator {
         Integrator::RKV98 => ode::RKV98::interpolate(x, sol),
         Integrator::RKV98NoInterp => ode::RKV98NoInterp::interpolate(x, sol),
@@ -701,11 +685,11 @@ pub fn interp_propresult<const C: usize, T: TimeLike>(
         Integrator::RKV65 => ode::RKV65::interpolate(x, sol),
         Integrator::RKTS54 => ode::RKTS54::interpolate(x, sol),
         Integrator::RODAS4 => {
-            return Err(PropagationError::NoDenseOutputInSolution.into());
+            return Err(Error::NoDenseOutputInSolution);
         }
         Integrator::GaussJackson8 => unreachable!("handled above"),
     };
-    Ok(result.map_err(PropagationError::ODEError)?)
+    Ok(result?)
 }
 
 pub fn interp_propresult_batch<const C: usize>(
@@ -723,7 +707,7 @@ pub fn interp_propresult_batch<const C: usize>(
         let dense = res
             .gj_dense
             .as_ref()
-            .ok_or(PropagationError::NoDenseOutputInSolution)?;
+            .ok_or(Error::NoDenseOutputInSolution)?;
         let gj_sol = crate::orbitprop::ode::GJSolution::<f64, 3> {
             t: 0.0,
             r: Vector3::zeros(),
@@ -734,7 +718,7 @@ pub fn interp_propresult_batch<const C: usize>(
             dense: Some(dense.clone()),
         };
         let pairs = crate::orbitprop::ode::GaussJackson8::interpolate_batch(&xs, &gj_sol)
-            .map_err(PropagationError::ODEError)?;
+            ?;
         return Ok(pairs
             .into_iter()
             .map(|(r, v)| {
@@ -752,7 +736,7 @@ pub fn interp_propresult_batch<const C: usize>(
         .odesol
         .as_ref()
         .filter(|s| s.dense.is_some())
-        .ok_or(PropagationError::NoDenseOutputInSolution)?;
+        .ok_or(Error::NoDenseOutputInSolution)?;
 
     let results = match res.integrator {
         Integrator::RKV98 => ode::RKV98::interpolate_batch(&xs, sol),
@@ -761,11 +745,11 @@ pub fn interp_propresult_batch<const C: usize>(
         Integrator::RKV65 => ode::RKV65::interpolate_batch(&xs, sol),
         Integrator::RKTS54 => ode::RKTS54::interpolate_batch(&xs, sol),
         Integrator::RODAS4 => {
-            return Err(PropagationError::NoDenseOutputInSolution.into());
+            return Err(Error::NoDenseOutputInSolution);
         }
         Integrator::GaussJackson8 => unreachable!("handled above"),
     };
-    Ok(results.map_err(PropagationError::ODEError)?)
+    Ok(results?)
 }
 
 #[cfg(test)]
@@ -778,6 +762,11 @@ mod tests {
 
     use crate::Duration;
     use std::io::{self, BufRead};
+
+    // Tests use anyhow::Result so we can `?`-convert errors from various
+    // crates (parse, Instant::from_datetime, etc.) that aren't part of
+    // orbitprop::Error.
+    use anyhow::Result;
 
     #[test]
     fn test_short_propagate() -> Result<()> {

--- a/src/orbitprop/satstate.rs
+++ b/src/orbitprop/satstate.rs
@@ -7,7 +7,7 @@ use crate::TimeLike;
 
 use crate::mathtypes::*;
 
-use anyhow::Result;
+use super::error::{Error, Result};
 
 type PVCovType = Matrix<6, 6>;
 
@@ -277,10 +277,7 @@ impl SatState {
             | Frame::CIRS
             | Frame::TEME
             | Frame::EME2000
-            | Frame::ICRF => anyhow::bail!(
-                "Unsupported frame for uncertainty: {}. Must be GCRF, LVLH, RIC, or NTW",
-                frame
-            ),
+            | Frame::ICRF => Err(Error::UnsupportedUncertaintyFrame { frame }),
         }
     }
 
@@ -559,6 +556,11 @@ mod test {
     use super::*;
     use crate::consts;
     use crate::Duration;
+
+    // Tests use anyhow::Result so we can `?`-convert errors from
+    // Instant::from_datetime and similar APIs that aren't part of
+    // orbitprop::Error.
+    use anyhow::Result;
 
     #[test]
     fn test_qgcrf2lvlh() -> Result<()> {

--- a/src/orbitprop/settings.rs
+++ b/src/orbitprop/settings.rs
@@ -4,7 +4,7 @@ use crate::earthgravity::GravityModel;
 use crate::orbitprop::Precomputed;
 use crate::TimeLike;
 
-use anyhow::Result;
+use super::error::{Error, Result};
 
 /// Choice of ODE integrator for orbit propagation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -130,11 +130,7 @@ impl PropSettings {
     /// Returns error if order > degree
     pub fn set_gravity(&mut self, degree: u16, order: u16) -> Result<()> {
         if order > degree {
-            anyhow::bail!(
-                "Gravity order ({}) must be ≤ degree ({})",
-                order,
-                degree
-            );
+            return Err(Error::InvalidGravityOrder { order, degree });
         }
         self.gravity_degree = degree;
         self.gravity_order = order;


### PR DESCRIPTION
## Summary

Phase 2 of the `anyhow` → `thiserror` migration tracked in #81. Three modules, three commits, branched from `main` so it can merge independently of #83 (Phase 1: tle + omm).

Refs #81. (Not closing — Phase 3 covers internal modules in a follow-up.)

## What changed

**`frames::Error`** (`src/frames.rs`):
- `InvalidFrame`

Side change: `mod frames` promoted to `pub mod frames` so consumers can name `satkit::frames::Error`. The `Frame` re-export at the crate root is unchanged.

**`itrfcoord::Error`** (`src/itrfcoord.rs`):
- `InvalidSliceLength { got: usize }` — used by both `from_slice` and `TryFrom<&[f64]>`

**`orbitprop::Error`** (`src/orbitprop/error.rs`):
- `InvalidStateColumns { c }`, `NoDenseOutputInSolution`
- `OdeError(ode::OdeError)` — manual `From` impl (numeris's `OdeError` doesn't impl `std::error::Error`)
- `RODAS4NoSTM`, `GaussJackson8NoSTM`
- `PrecomputedOutOfRange { time, begin, end }`
- `Precompute(String)` — stringified pending Phase 3 (`jplephem`)
- `UnsupportedUncertaintyFrame { frame: Frame }`
- `InvalidGravityOrder { order, degree }`

The pre-existing `propagator::PropagationError` enum was folded into the unified `orbitprop::Error` (no external `pub use` was found).

## Judgment calls worth a look

1. **`mod frames` → `pub mod frames`.** Small public API expansion, needed so downstream consumers can name `frames::Error`. The `Frame` re-export at the crate root keeps existing imports working.
2. **`propagator::PropagationError` folded into `orbitprop::Error`.** It was module-local with no external users; unification matches the issue's "module error" pattern.
3. **`OdeError` uses manual `From` impl** rather than `#[from]` because `numeris::ode::OdeError` only impls `Display`, not `std::error::Error`. Forward-compatible — will keep working when numeris upgrades.
4. **`Precompute(String)` stringifies jplephem errors.** Becomes typed `#[from] jplephem::Error` in Phase 3.
5. **Test modules opt back into `anyhow::Result`** locally via `use anyhow::Result;`. Same pattern as Phase 1 — tests touch many `?` boundaries (`Instant::from_datetime`, `str::parse`, `io::Error`) that aren't worth lifting into the public `Error` enum.
6. **Python binding `pysatstate.propagate`** switched `.map(Self)` to `Ok(Self(...?))` so `?` converts `orbitprop::Error` → `anyhow::Error` via the blanket impl. Only binding that needed touching.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo build --no-default-features` — clean
- [x] `cargo test --release` — 159 lib + 41 doc tests pass
- [x] `cargo check --manifest-path python/Cargo.toml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)