### PR TITLE
thiserror migration Phase 3: internal astronomy modules

### DIFF
--- a/python/src/mod_utils.rs
+++ b/python/src/mod_utils.rs
@@ -92,7 +92,7 @@ fn datadir() -> PyResult<Py<PyAny>> {
 #[pyfunction]
 fn set_datadir(datadir: String) -> Result<()> {
     let d = PathBuf::from(datadir);
-    satkit::utils::set_datadir(&d)
+    Ok(satkit::utils::set_datadir(&d)?)
 }
 
 /// Check if data files are found

--- a/python/src/pyinstant.rs
+++ b/python/src/pyinstant.rs
@@ -241,7 +241,7 @@ impl PyInstant {
     ///
     #[staticmethod]
     fn from_string(s: &str) -> Result<Self> {
-        Instant::from_string(s).map(Self)
+        Ok(Instant::from_string(s).map(Self)?)
     }
 
     /// Create satkit.time object from string with given format
@@ -269,7 +269,7 @@ impl PyInstant {
     /// %B: Month as locale’s full name
     #[staticmethod]
     fn strptime(s: &str, fmt: &str) -> Result<Self> {
-        Instant::strptime(s, fmt).map(Self)
+        Ok(Instant::strptime(s, fmt).map(Self)?)
     }
 
     /// Format time object as string
@@ -470,7 +470,7 @@ impl PyInstant {
         min: i32,
         sec: f64,
     ) -> Result<Self> {
-        Instant::from_datetime(year, month, day, hour, min, sec).map(Self)
+        Ok(Instant::from_datetime(year, month, day, hour, min, sec).map(Self)?)
     }
 
     /// Convert from Python datetime object

--- a/python/src/pyjplephem.rs
+++ b/python/src/pyjplephem.rs
@@ -24,7 +24,7 @@ pub fn geocentric_state(
 ) -> PyResult<Py<PyAny>> {
     let rbody: SolarSystem = body.into();
     let f = |tm: &Instant| -> Result<(Vector3, Vector3)> {
-        jplephem::geocentric_state(rbody, tm)
+        Ok(jplephem::geocentric_state(rbody, tm)?)
     };
     tuple_func_of_time_arr(f, tm)
 }
@@ -53,7 +53,7 @@ pub fn barycentric_state(
 ) -> PyResult<Py<PyAny>> {
     let rbody: SolarSystem = body.into();
     let f = |tm: &Instant| -> Result<(Vector3, Vector3)> {
-        jplephem::barycentric_state(rbody, tm)
+        Ok(jplephem::barycentric_state(rbody, tm)?)
     };
     tuple_func_of_time_arr(f, tm)
 }
@@ -72,7 +72,7 @@ pub fn geocentric_pos(
     tm: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
     let rbody: SolarSystem = body.into();
-    let f = |tm: &Instant| -> Result<Vector3> { jplephem::geocentric_pos(rbody, tm) };
+    let f = |tm: &Instant| -> Result<Vector3> { Ok(jplephem::geocentric_pos(rbody, tm)?) };
     py_vec3_of_time_result_arr(&f, tm)
 }
 
@@ -97,6 +97,6 @@ pub fn barycentric_pos(
     tm: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
     let rbody: SolarSystem = body.into();
-    let f = |tm: &Instant| -> Result<Vector3> { jplephem::barycentric_pos(rbody, tm) };
+    let f = |tm: &Instant| -> Result<Vector3> { Ok(jplephem::barycentric_pos(rbody, tm)?) };
     py_vec3_of_time_result_arr(&f, tm)
 }

--- a/src/earth_orientation_params.rs
+++ b/src/earth_orientation_params.rs
@@ -18,6 +18,7 @@
 
 use std::fs::File;
 use std::io::{self, BufRead};
+use std::num::ParseFloatError;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::Once;
@@ -25,7 +26,68 @@ use std::sync::Once;
 use crate::utils::datadir;
 use crate::utils::{download_file, download_if_not_exist};
 
-use anyhow::{bail, Context, Result};
+use thiserror::Error;
+
+/// Errors produced by the
+/// [`earth_orientation_params`](crate::earth_orientation_params) module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// A line in the EOP CSV file has fewer than the expected 12 fields.
+    #[error("Invalid entry in EOP file")]
+    InvalidEntry,
+
+    /// The legacy `finals2000A.all` file could not be located.
+    #[error("Cannot open earth orientation parameters file: {0}")]
+    LegacyFileMissing(String),
+
+    /// Failed to open the legacy `finals2000A.all` file.
+    #[error("Couldn't open {path}: {source}")]
+    LegacyOpenFailed {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// Failed to parse a numeric field from the legacy bulletin file.
+    #[error("Could not extract {field} from file")]
+    LegacyFieldParse {
+        field: &'static str,
+        #[source]
+        source: ParseFloatError,
+    },
+
+    /// The configured data directory is read-only and cannot receive an
+    /// updated EOP file.
+    #[error(
+        "Data directory is read-only. Try setting the environment variable SATKIT_DATA \
+         to a writeable directory and re-starting or explicitly set data directory"
+    )]
+    DataDirReadOnly,
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    ParseFloat(#[from] ParseFloatError),
+
+    #[error(transparent)]
+    Datadir(#[from] crate::utils::datadir::Error),
+
+    /// Wraps an [`anyhow::Error`] surfaced by the (still-anyhow) download
+    /// helpers in [`crate::utils::download`].
+    #[error("Download failed: {0}")]
+    Download(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Download(e)
+    }
+}
+
+/// Convenient type alias used throughout the
+/// `earth_orientation_params` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug)]
 #[allow(non_snake_case)]
@@ -57,7 +119,7 @@ fn load_eop_file_csv(filename: Option<PathBuf>) -> Result<Vec<EOPEntry>> {
             let line = rline.unwrap();
             let lvals: Vec<&str> = line.split(",").collect();
             if lvals.len() < 12 {
-                bail!("Invalid entry in EOP file");
+                return Err(Error::InvalidEntry);
             }
             Ok(EOPEntry {
                 mjd_utc: lvals[1].parse()?,
@@ -81,14 +143,18 @@ fn load_eop_file_legacy(filename: Option<PathBuf>) -> Result<Vec<EOPEntry>> {
         });
 
     if !path.is_file() {
-        bail!(
-            "Cannot open earth orientation parameters file: {}",
-            path.to_str().unwrap()
-        );
+        return Err(Error::LegacyFileMissing(
+            path.to_str().unwrap_or_default().to_string(),
+        ));
     }
 
     let file = match File::open(&path) {
-        Err(why) => bail!("Couldn't open {}: {}", path.display(), why),
+        Err(why) => {
+            return Err(Error::LegacyOpenFailed {
+                path: path.display().to_string(),
+                source: why,
+            });
+        }
         Ok(file) => file,
     };
 
@@ -112,22 +178,30 @@ fn load_eop_file_legacy(filename: Option<PathBuf>) -> Result<Vec<EOPEntry>> {
                 let dy_str: String = v.chars().skip(116).take(9).collect();
 
                 eopvec.push(EOPEntry {
-                    mjd_utc: mjd_str
-                        .trim()
-                        .parse()
-                        .context("Could not extract MJD from file")?,
-                    xp: xp_str
-                        .trim()
-                        .parse()
-                        .context("Could not extract X polar motion from file")?,
-                    yp: yp_str
-                        .trim()
-                        .parse()
-                        .context("Could not extract Y polar motion from file")?,
-                    dut1: dut1_str
-                        .trim()
-                        .parse()
-                        .context("Could not extract delta UT1 from file")?,
+                    mjd_utc: mjd_str.trim().parse().map_err(|source| {
+                        Error::LegacyFieldParse {
+                            field: "MJD",
+                            source,
+                        }
+                    })?,
+                    xp: xp_str.trim().parse().map_err(|source| {
+                        Error::LegacyFieldParse {
+                            field: "X polar motion",
+                            source,
+                        }
+                    })?,
+                    yp: yp_str.trim().parse().map_err(|source| {
+                        Error::LegacyFieldParse {
+                            field: "Y polar motion",
+                            source,
+                        }
+                    })?,
+                    dut1: dut1_str.trim().parse().map_err(|source| {
+                        Error::LegacyFieldParse {
+                            field: "delta UT1",
+                            source,
+                        }
+                    })?,
                     lod: lod_str.trim().parse().unwrap_or(0.0),
                     dX: dx_str.trim().parse().unwrap_or(0.0),
                     dY: dy_str.trim().parse().unwrap_or(0.0),
@@ -180,12 +254,7 @@ pub fn disable_eop_time_warning() {
 pub fn update() -> Result<()> {
     let d = datadir()?;
     if d.metadata()?.permissions().readonly() {
-        bail!(
-            r#"Data directory is read-only.
-             Try setting the environment variable SATKIT_DATA
-             to a writeable directory and re-starting or explicitly set
-             data directory"#
-        );
+        return Err(Error::DataDirReadOnly);
     }
 
     let url = "http://celestrak.org/SpaceData/EOP-All.csv";

--- a/src/earthgravity.rs
+++ b/src/earthgravity.rs
@@ -1,8 +1,52 @@
 use crate::utils::{datadir, download_if_not_exist};
-use anyhow::{bail, Context, Result};
 use std::collections::HashMap;
 use std::io::{self, BufRead};
+use std::num::{ParseFloatError, ParseIntError};
 use std::path::PathBuf;
+use thiserror::Error;
+
+/// Errors produced by the [`earthgravity`](crate::earthgravity) module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The header of the gravity model file did not declare a non-zero
+    /// `max_degree`.
+    #[error("Invalid file; did not find max degree")]
+    MissingMaxDegree,
+
+    /// A coefficient line had fewer than the required `n m C [S]` fields.
+    #[error("Invalid line: {0}")]
+    InvalidLine(String),
+
+    /// Failed to open the gravity model file.
+    #[error("Failed to open gravity model file: {0}")]
+    OpenFailed(#[source] std::io::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    ParseFloat(#[from] ParseFloatError),
+
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+
+    #[error(transparent)]
+    Datadir(#[from] crate::utils::datadir::Error),
+
+    /// Wraps an [`anyhow::Error`] surfaced by the (still-anyhow) download
+    /// helpers in [`crate::utils::download`].
+    #[error("Download failed: {0}")]
+    Download(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Download(e)
+    }
+}
+
+/// Convenient type alias used throughout the `earthgravity` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 use crate::mathtypes::*;
 type CoeffTable = DMatrix<f64>;
@@ -465,7 +509,7 @@ impl Gravity {
         }
         */
 
-        let file = std::fs::File::open(&path).context("Failed to open gravity model file")?;
+        let file = std::fs::File::open(&path).map_err(Error::OpenFailed)?;
 
         let mut name = String::new();
         let mut gravity_constant: f64 = 0.0;
@@ -503,7 +547,7 @@ impl Gravity {
             }
         }
         if max_degree == 0 {
-            bail!("Invalid file; did not find max degree");
+            return Err(Error::MissingMaxDegree);
         }
 
         // Create matrix with lookup values
@@ -512,7 +556,7 @@ impl Gravity {
         for line in &lines[header_cnt..] {
             let s: Vec<&str> = line.split_whitespace().collect();
             if s.len() < 3 {
-                bail!("Invalid line: {}", line);
+                return Err(Error::InvalidLine(line.clone()));
             }
 
             let n: usize = s[1].parse()?;

--- a/src/jplephem.rs
+++ b/src/jplephem.rs
@@ -23,16 +23,75 @@ use crate::solarsystem::SolarSystem;
 
 use crate::utils::{datadir, download_if_not_exist};
 
+use std::array::TryFromSliceError;
+use std::num::{ParseFloatError, ParseIntError};
+use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 use std::sync::OnceLock;
 
 use crate::mathtypes::*;
 use crate::{Instant, TimeLike, TimeScale};
 
-use anyhow::{bail, Result};
+use thiserror::Error;
+
+/// Errors produced by the [`jplephem`](crate::jplephem) module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Returned when [`Instant`]'s Julian date falls outside the
+    /// `[jd_start, jd_stop]` window of the loaded ephemerides file.
+    #[error("Invalid Julian date: {0}")]
+    InvalidJulianDate(f64),
+
+    /// The Chebyshev dispatcher hit a coefficient count outside the table
+    /// of supported sizes — typically because the requested body is not
+    /// represented in the loaded ephemeris file.
+    #[error("Invalid body")]
+    InvalidBody,
+
+    /// The opened ephemerides file is shorter than required to hold the
+    /// declared Chebyshev coefficient block.
+    #[error("Invalid record size for cheby data")]
+    InvalidRecordSize,
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Utf8(#[from] Utf8Error),
+
+    #[error(transparent)]
+    FromUtf8(#[from] FromUtf8Error),
+
+    #[error(transparent)]
+    TryFromSlice(#[from] TryFromSliceError),
+
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+
+    #[error(transparent)]
+    ParseFloat(#[from] ParseFloatError),
+
+    #[error(transparent)]
+    Datadir(#[from] crate::utils::datadir::Error),
+
+    /// Wraps an [`anyhow::Error`] surfaced by the (still-anyhow) download
+    /// helpers in [`crate::utils::download`].
+    #[error("Download failed: {0}")]
+    Download(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Download(e)
+    }
+}
+
+/// Convenient type alias used throughout the `jplephem` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 impl TryFrom<i32> for SolarSystem {
     type Error = ();
-    fn try_from(v: i32) -> Result<Self, Self::Error> {
+    fn try_from(v: i32) -> std::result::Result<Self, Self::Error> {
         match v {
             x if x == Self::Mercury as i32 => Ok(Self::Mercury),
             x if x == Self::Venus as i32 => Ok(Self::Venus),
@@ -99,7 +158,7 @@ macro_rules! dispatch_ncoeff {
             12 => $self.$method::<12>($setup),
             13 => $self.$method::<13>($setup),
             14 => $self.$method::<14>($setup),
-            _ => bail!("Invalid body"),
+            _ => return Err(Error::InvalidBody),
         }
     };
 }
@@ -118,7 +177,7 @@ impl JPLEphem {
     fn cheby_setup(&self, body: SolarSystem, tm: &Instant) -> Result<ChebySetup> {
         let tt = tm.as_jd_with_scale(TimeScale::TT);
         if self.jd_start > tt || self.jd_stop < tt {
-            bail!("Invalid Julian date: {}", tt);
+            return Err(Error::InvalidJulianDate(tt));
         }
 
         let t_int = (tt - self.jd_start) / self.jd_step;
@@ -289,7 +348,7 @@ impl JPLEphem {
                 let mut v: DMatrix<f64> = DMatrix::zeros(ncoeff, nrecords);
 
                 if raw.len() < record_size * 2 + ncoeff * nrecords * 8 {
-                    bail!("Invalid record size for cheby data");
+                    return Err(Error::InvalidRecordSize);
                 }
 
                 unsafe {

--- a/src/kepler.rs
+++ b/src/kepler.rs
@@ -1,20 +1,23 @@
 //! Keplerian orbital elements module
 //!
 
-use anyhow::Result;
 use thiserror::Error;
 
+/// Errors that can occur while constructing or converting [`Kepler`] elements.
 #[derive(Debug, Error)]
-pub enum KeplerError {
+pub enum Error {
+    /// Returned by [`Kepler::from_pv`] when the computed eccentricity is
+    /// outside the valid range for an elliptical orbit.
     #[error("Eccentricity Out of Bounds {0}")]
     EccenOutOfBound(f64),
 }
 
-impl<T> From<KeplerError> for Result<T> {
-    fn from(e: KeplerError) -> Self {
-        Err(e.into())
-    }
-}
+/// Convenient type alias used throughout the `kepler` module.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Backwards-compatible alias for [`Error`].
+#[deprecated(note = "use kepler::Error instead")]
+pub type KeplerError = Error;
 
 /// Keplerian element can be defined by multiple
 /// types of "anomalies", which describe the position
@@ -271,7 +274,7 @@ impl Kepler {
             / crate::consts::MU_EARTH;
         let eccen = e.norm();
         if eccen >= 1.0 {
-            return KeplerError::EccenOutOfBound(eccen).into();
+            return Err(Error::EccenOutOfBound(eccen));
         }
         let xi = v.norm().powi(2) / 2.0 - crate::consts::MU_EARTH / r.norm();
         let a = -crate::consts::MU_EARTH / (2.0 * xi);

--- a/src/lpephem/mod.rs
+++ b/src/lpephem/mod.rs
@@ -1,3 +1,5 @@
+//! Low-precision ephemerides for the sun, moon, and planets.
+
 /// Lunar calculations
 pub mod moon;
 /// Solar calculations
@@ -7,3 +9,39 @@ pub mod sun;
 mod planets;
 pub use planets::heliocentric_pos;
 
+use thiserror::Error;
+
+/// Errors produced by the [`lpephem`](crate::lpephem) module.
+///
+/// Shared across the [`sun`] and [`planets`] submodules; [`moon`] does
+/// not currently surface fallible operations.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Returned by [`sun::riseset`] when the sun does not rise or set on
+    /// the given date at the supplied location (e.g. polar regions in
+    /// summer or winter).
+    #[error(
+        "Invalid position.  Sun doesn't rise/set on this day at this location \
+         (e.g., Alaska in summer)"
+    )]
+    NoSunriseOrSunset,
+
+    /// Returned by [`heliocentric_pos`] when the requested body is not
+    /// represented in the low-precision Keplerian-element table.
+    #[error("Invalid body")]
+    InvalidBody,
+
+    /// Returned by [`heliocentric_pos`] when the requested time falls
+    /// outside the validity window of the low-precision tables
+    /// (3000 BC – 3000 AD).
+    #[error("Time out of range")]
+    TimeOutOfRange,
+
+    /// Wraps an error from constructing an [`Instant`](crate::Instant)
+    /// for the validity-window endpoints.
+    #[error(transparent)]
+    InvalidEpoch(#[from] crate::time::InstantError),
+}
+
+/// Convenient type alias used throughout the `lpephem` module.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lpephem/planets.rs
+++ b/src/lpephem/planets.rs
@@ -42,7 +42,7 @@ use crate::SolarSystem;
 use crate::TimeScale;
 
 use crate::mathtypes::*;
-use anyhow::{bail, Result};
+use super::{Error, Result};
 
 /// Returns the heliocentric position of a planet
 ///
@@ -153,7 +153,7 @@ pub fn heliocentric_pos<T: TimeLike>(body: SolarSystem, time: &T) -> Result<Vect
                     224.06891629,
                     110.30393684,
                 ],
-                _ => bail!("Invalid Body"),
+                _ => return Err(Error::InvalidBody),
             };
 
             let adot: [f64; 6] = match body {
@@ -229,7 +229,7 @@ pub fn heliocentric_pos<T: TimeLike>(body: SolarSystem, time: &T) -> Result<Vect
                     -0.04062942,
                     -0.01183482,
                 ],
-                _ => bail!("Invalid Body"),
+                _ => return Err(Error::InvalidBody),
             };
             // Julian century
             (
@@ -315,7 +315,7 @@ pub fn heliocentric_pos<T: TimeLike>(body: SolarSystem, time: &T) -> Result<Vect
                     224.09702598,
                     110.30167986,
                 ],
-                _ => bail!("Invalid Body"),
+                _ => return Err(Error::InvalidBody),
             };
             let adot: [f64; 6] = match body {
                 SolarSystem::Mercury => [
@@ -390,7 +390,7 @@ pub fn heliocentric_pos<T: TimeLike>(body: SolarSystem, time: &T) -> Result<Vect
                     -0.00968827,
                     -0.00809981,
                 ],
-                _ => bail!("Invalid Body"),
+                _ => return Err(Error::InvalidBody),
             };
             let error_terms: Option<[f64; 4]> = match body {
                 SolarSystem::Jupiter => Some([-0.00012452, 0.06064060, -0.35635438, 38.35125000]),
@@ -410,7 +410,7 @@ pub fn heliocentric_pos<T: TimeLike>(body: SolarSystem, time: &T) -> Result<Vect
                 error_terms,
             )
         } else {
-            bail!("Time out of range");
+            return Err(Error::TimeOutOfRange);
         }
     };
 

--- a/src/lpephem/sun.rs
+++ b/src/lpephem/sun.rs
@@ -5,7 +5,7 @@ use crate::TimeLike;
 use crate::TimeScale;
 
 use crate::mathtypes::*;
-use anyhow::Result;
+use super::{Error, Result};
 
 ///
 /// Sun position in the Geocentric Celestial Reference Frame (GCRF)
@@ -249,10 +249,7 @@ pub fn riseset<T: TimeLike>(
         let coslha = sind(deltasun).mul_add(-sind(latitude), cosd(sigma))
             / (cosd(deltasun) * cosd(latitude));
         if coslha.abs() > 1.0 {
-            anyhow::bail!(
-                "Invalid position.  Sun doesn't rise/set on this day at \
-                 this location (e.g., Alaska in summer)"
-            );
+            return Err(Error::NoSunriseOrSunset);
         }
         let mut lha = f64::acos(coslha) * RAD2DEG;
 

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -1017,7 +1017,7 @@ mod tests {
                 let hour: i32 = lvals[4].parse()?;
                 let min: i32 = lvals[5].parse()?;
                 let sec: f64 = lvals[6].parse()?;
-                Instant::from_datetime(year, mon, day, hour, min, sec)
+                Ok(Instant::from_datetime(year, mon, day, hour, min, sec)?)
             })
             .collect::<Result<Vec<crate::Instant>, _>>()?;
 

--- a/src/solar_cycle_forecast.rs
+++ b/src/solar_cycle_forecast.rs
@@ -9,12 +9,67 @@
 
 use crate::utils::{datadir, download_to_string};
 use crate::{Instant, TimeLike};
-use anyhow::{bail, Result};
+use std::num::ParseIntError;
+use thiserror::Error;
 
 use std::path::PathBuf;
 use std::sync::RwLock;
 
 use std::sync::OnceLock;
+
+/// Errors produced by the [`solar_cycle_forecast`](crate::solar_cycle_forecast)
+/// module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The cached forecast file is missing on disk.
+    #[error("Solar cycle forecast file not found")]
+    FileNotFound,
+
+    /// The downloaded JSON document is not the expected array of records.
+    #[error("Expected JSON array in solar cycle forecast")]
+    NotJsonArray,
+
+    /// A forecast entry is missing its `time-tag` field.
+    #[error("Missing time-tag")]
+    MissingTimeTag,
+
+    /// A forecast entry is missing its `predicted_f10.7` field.
+    #[error("Missing predicted_f10.7")]
+    MissingPredictedF107,
+
+    /// The downloaded forecast contains zero records.
+    #[error("Downloaded forecast contains no records")]
+    EmptyForecast,
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    InvalidEpoch(#[from] crate::time::InstantError),
+
+    #[error(transparent)]
+    Datadir(#[from] crate::utils::datadir::Error),
+
+    #[error(transparent)]
+    ParseInt(#[from] ParseIntError),
+
+    /// Wraps an [`anyhow::Error`] surfaced by the (still-anyhow) download
+    /// helpers in [`crate::utils::download`].
+    #[error("Download failed: {0}")]
+    Download(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Download(e)
+    }
+}
+
+/// Convenient type alias used throughout the `solar_cycle_forecast` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone)]
 pub struct ForecastRecord {
@@ -29,7 +84,7 @@ fn forecast_path() -> Result<PathBuf> {
 fn load_forecast() -> Result<Vec<ForecastRecord>> {
     let path = forecast_path()?;
     if !path.is_file() {
-        bail!("Solar cycle forecast file not found");
+        return Err(Error::FileNotFound);
     }
     let contents = std::fs::read_to_string(&path)?;
     parse_forecast_json(&contents)
@@ -37,15 +92,11 @@ fn load_forecast() -> Result<Vec<ForecastRecord>> {
 
 fn parse_forecast_json(contents: &str) -> Result<Vec<ForecastRecord>> {
     let parsed: serde_json::Value = serde_json::from_str(contents)?;
-    let entries = parsed
-        .as_array()
-        .ok_or_else(|| anyhow::anyhow!("Expected JSON array in solar cycle forecast"))?;
+    let entries = parsed.as_array().ok_or(Error::NotJsonArray)?;
 
     let mut records = Vec::new();
     for entry in entries {
-        let time_tag = entry["time-tag"]
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("Missing time-tag"))?;
+        let time_tag = entry["time-tag"].as_str().ok_or(Error::MissingTimeTag)?;
 
         // Parse "YYYY-MM" format
         let parts: Vec<&str> = time_tag.split('-').collect();
@@ -59,7 +110,7 @@ fn parse_forecast_json(contents: &str) -> Result<Vec<ForecastRecord>> {
 
         let f107 = entry["predicted_f10.7"]
             .as_f64()
-            .ok_or_else(|| anyhow::anyhow!("Missing predicted_f10.7"))?;
+            .ok_or(Error::MissingPredictedF107)?;
 
         records.push(ForecastRecord {
             date,
@@ -121,7 +172,7 @@ pub fn update() -> Result<()> {
     // Validate before saving
     let records = parse_forecast_json(&contents)?;
     if records.is_empty() {
-        bail!("Downloaded forecast contains no records");
+        return Err(Error::EmptyForecast);
     }
 
     let path = forecast_path()?;

--- a/src/solar_cycle_forecast.rs
+++ b/src/solar_cycle_forecast.rs
@@ -62,6 +62,10 @@ pub enum Error {
     /// helpers in [`crate::utils::download`].
     #[error("Download failed: {0}")]
     Download(anyhow::Error),
+
+    /// The crate was built without the `download` feature enabled.
+    #[error("satkit was built without the `download` feature")]
+    DownloadFeatureDisabled,
 }
 
 impl From<anyhow::Error> for Error {
@@ -191,7 +195,7 @@ pub fn update() -> Result<()> {
 
 #[cfg(not(feature = "download"))]
 pub fn update() -> Result<()> {
-    bail!("satkit was built without the `download` feature")
+    Err(Error::DownloadFeatureDisabled)
 }
 
 #[cfg(test)]

--- a/src/spaceweather.rs
+++ b/src/spaceweather.rs
@@ -6,11 +6,56 @@ use std::path::PathBuf;
 use crate::utils::{datadir, download_file, download_if_not_exist};
 use crate::Instant;
 use crate::TimeLike;
-use anyhow::{bail, Context, Result};
+use thiserror::Error;
 
 use std::sync::RwLock;
 
 use std::sync::OnceLock;
+
+/// Errors produced by the [`spaceweather`](crate::spaceweather) module.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// A field in the CSV space-weather record could not be parsed as the
+    /// expected numeric type.
+    #[error("Invalid number in file: {0}")]
+    InvalidNumber(&'static str),
+
+    /// No space-weather record exists for the requested time.
+    #[error("No space weather record found for date")]
+    NoRecordForDate,
+
+    /// The configured data directory is read-only and cannot receive an
+    /// updated space-weather file.
+    #[error(
+        "Data directory is read-only. Try setting the environment variable SATKIT_DATA \
+         to a writeable directory and re-starting or explicitly set data directory to \
+         a writeable directory"
+    )]
+    DataDirReadOnly,
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    InvalidEpoch(#[from] crate::time::InstantError),
+
+    #[error(transparent)]
+    Datadir(#[from] crate::utils::datadir::Error),
+
+    /// Wraps an [`anyhow::Error`] surfaced by the (still-anyhow) download
+    /// helpers in [`crate::utils::download`].
+    #[error("Download failed: {0}")]
+    Download(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Download(e)
+    }
+}
+
+/// Convenient type alias used throughout the `spaceweather` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone)]
 pub struct SpaceWeatherRecord {
@@ -40,14 +85,14 @@ pub struct SpaceWeatherRecord {
     pub f10p7_adj_l81: f64,
 }
 
-fn str2num<T: core::str::FromStr>(s: &str, sidx: usize, eidx: usize) -> Result<T> {
+fn str2num<T: core::str::FromStr>(s: &str, sidx: usize, eidx: usize, field: &'static str) -> Result<T> {
     s.chars()
         .skip(sidx)
         .take(eidx - sidx)
         .collect::<String>()
         .trim()
         .parse()
-        .map_err(|_| anyhow::anyhow!("Invalid number in file"))
+        .map_err(|_| Error::InvalidNumber(field))
 }
 
 impl PartialEq for SpaceWeatherRecord {
@@ -88,9 +133,9 @@ fn load_space_weather_csv() -> Result<Vec<SpaceWeatherRecord>> {
             let line = rline.unwrap();
             let lvals: Vec<&str> = line.split(",").collect();
 
-            let year: u32 = str2num(lvals[0], 0, 4).context("Cannot read year")?;
-            let mon: u32 = str2num(lvals[0], 5, 7).context("Cannot read month")?;
-            let day: u32 = str2num(lvals[0], 8, 10).context("Cannot read day of month")?;
+            let year: u32 = str2num(lvals[0], 0, 4, "year")?;
+            let mon: u32 = str2num(lvals[0], 5, 7, "month")?;
+            let day: u32 = str2num(lvals[0], 8, 10, "day of month")?;
 
             Ok(SpaceWeatherRecord {
                 date: (Instant::from_date(year as i32, mon as i32, day as i32)?),
@@ -162,7 +207,7 @@ pub fn get<T: TimeLike>(tm: &T) -> Result<SpaceWeatherRecord> {
         .rev()
         .find(|x| x.date <= tm)
         .cloned()
-        .ok_or_else(|| anyhow::anyhow!("No space weather record found for date"))
+        .ok_or(Error::NoRecordForDate)
 }
 
 /// Download new Space Weather file, and load it.
@@ -170,12 +215,7 @@ pub fn update() -> Result<()> {
     // Get data directory
     let d = datadir()?;
     if d.metadata()?.permissions().readonly() {
-        bail!(
-            r#"Data directory is read-only.
-             Try setting the environment variable SATKIT_DATA
-             to a writeable directory and re-starting or explicitly set
-             data directory to writeable directory"#
-        );
+        return Err(Error::DataDirReadOnly);
     }
 
     // Download most-recent EOP

--- a/src/time/instant.rs
+++ b/src/time/instant.rs
@@ -1,7 +1,8 @@
-use super::TimeScale;
+use super::{InstantError, TimeScale};
 use serde::{Deserialize, Serialize};
 
-use anyhow::{bail, Result};
+/// Local result alias used by [`Instant`] constructors.
+type Result<T> = std::result::Result<T, InstantError>;
 
 // Days in the month, neglecting leap years
 const MDAYS: [u32; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
@@ -580,7 +581,7 @@ impl Instant {
 
         // Bounds checking on input
         if !(1..=12).contains(&month) {
-            bail!("Invalid month: {}", month);
+            return Err(InstantError::InvalidMonth(month));
         }
         let max_day = if month == 2 {
             if (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0) {
@@ -592,13 +593,13 @@ impl Instant {
             MDAYS[(month - 1) as usize]
         };
         if day < 1 || day > max_day as i32 {
-            bail!("Invalid day: {}", day);
+            return Err(InstantError::InvalidDay(day));
         }
         if !(0..=23).contains(&hour) {
-            bail!("Invalid hour: {}", hour);
+            return Err(InstantError::InvalidHour(hour));
         }
         if !(0..=59).contains(&minute) {
-            bail!("Invalid minute: {}", minute);
+            return Err(InstantError::InvalidMinute(minute));
         }
         if !(0.0..60.0).contains(&second) {
             // Check for rare case of leap second
@@ -606,7 +607,7 @@ impl Instant {
                 // Are we in a leap second?
                 check_leapsecond = true;
             } else {
-                bail!("Invalid second: {}", second);
+                return Err(InstantError::InvalidSecondF(second));
             }
         }
 
@@ -651,7 +652,7 @@ impl Instant {
                 }
             }
             if !valid_leap_second {
-                bail!("Invalid second");
+                return Err(InstantError::InvalidLeapSecond);
             }
         }
 

--- a/src/time/instant_err.rs
+++ b/src/time/instant_err.rs
@@ -1,5 +1,8 @@
+use std::num::ParseIntError;
+
 use thiserror::Error;
 
+/// Errors produced when constructing or parsing an [`Instant`](crate::Instant).
 #[derive(Error, Debug)]
 pub enum InstantError {
     #[error("Invalid Month String: {0}")]
@@ -14,6 +17,15 @@ pub enum InstantError {
     InvalidMinute(i32),
     #[error("Invalid Second: {0}")]
     InvalidSecond(i32),
+    /// Raised when a fractional second falls outside `[0.0, 60.0)` and is
+    /// not a valid leap second on the requested date.
+    #[error("Invalid Second: {0}")]
+    InvalidSecondF(f64),
+    /// Raised when the seconds field is in the leap-second range
+    /// `[60.0, 61.0)` but the supplied date does not correspond to an
+    /// actual UTC leap second.
+    #[error("Invalid leap second")]
+    InvalidLeapSecond,
     #[error("Invalid Microsecond: {0}")]
     InvalidMicrosecond(i32),
     #[error("Invalid String: {0}")]
@@ -22,4 +34,8 @@ pub enum InstantError {
     InvalidFormat(char),
     #[error("Missing Format Character")]
     MissingFormat,
+    /// Wraps a [`ParseIntError`] surfaced while parsing a numeric field
+    /// (year, month, day, hour, minute, ...).
+    #[error("Failed to parse integer field: {0}")]
+    ParseInt(#[from] ParseIntError),
 }

--- a/src/time/instantparse.rs
+++ b/src/time/instantparse.rs
@@ -5,7 +5,8 @@
 use crate::time::InstantError;
 use crate::Instant;
 
-use anyhow::Result;
+/// Local result alias used by [`Instant`] string parsers.
+type Result<T> = std::result::Result<T, InstantError>;
 
 /// Collect characters from a `Peekable<Chars>` while `pred` holds, leaving the
 /// first non-matching character available for the next read (unlike std's
@@ -99,9 +100,7 @@ impl Instant {
                         5 => cstr.parse::<i32>()? * 10,
                         6 => cstr.parse::<i32>()?,
                         _ => {
-                            return Err(
-                                InstantError::InvalidMicrosecond(cstr.parse::<i32>()?).into()
-                            );
+                            return Err(InstantError::InvalidMicrosecond(cstr.parse::<i32>()?));
                         }
                     },
                     false => cstr.parse::<i32>()?,
@@ -273,7 +272,7 @@ impl Instant {
         });
 
         if year == -1 || month == -1 || day == -1 {
-            return Err(InstantError::InvalidString(s.to_string()).into());
+            return Err(InstantError::InvalidString(s.to_string()));
         }
         if hour == -1 || minute == -1 || second < 0 {
             hour = 0;
@@ -370,8 +369,7 @@ impl Instant {
                             _ => {
                                 return Err(InstantError::InvalidMicrosecond(
                                     smicro.parse::<i32>().unwrap(),
-                                )
-                                .into());
+                                ));
                             }
                         }
                     }
@@ -399,10 +397,10 @@ impl Instant {
                         }
                     }
                     Some(t) => {
-                        return Err(InstantError::InvalidFormat(t).into());
+                        return Err(InstantError::InvalidFormat(t));
                     }
                     None => {
-                        return Err(InstantError::InvalidFormat('%').into());
+                        return Err(InstantError::InvalidFormat('%'));
                     }
                 },
                 _ => {
@@ -411,8 +409,7 @@ impl Instant {
                         return Err(InstantError::InvalidString(format!(
                             "{} doesn't match {}",
                             c, n
-                        ))
-                        .into());
+                        )));
                     }
                 }
             }

--- a/src/utils/datadir.rs
+++ b/src/utils/datadir.rs
@@ -5,7 +5,28 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-use anyhow::{bail, Result};
+use thiserror::Error;
+
+/// Errors that can occur while resolving or setting the satkit data directory.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The path passed to [`set_datadir`] is not an existing directory.
+    #[error("Data directory does not exist")]
+    DirectoryDoesNotExist,
+
+    /// The data-directory singleton has already been initialized and cannot
+    /// be overwritten.
+    #[error("Could not set data directory")]
+    SetFailed,
+
+    /// None of the candidate locations contained valid data and no writable
+    /// candidate could be created.
+    #[error("Could not find valid writeable data directory")]
+    NoWriteableDirectory,
+}
+
+/// Convenient type alias used throughout the `datadir` module.
+pub type Result<T> = std::result::Result<T, Error>;
 
 // Pointer to the one and only data directory
 static DATADIR_SINGLETON: Mutex<OnceCell<Option<PathBuf>>> = Mutex::new(OnceCell::new());
@@ -58,14 +79,14 @@ pub fn testdirs() -> Vec<PathBuf> {
 /// Generally this should not be needed
 pub fn set_datadir(d: &Path) -> Result<()> {
     if !d.is_dir() {
-        bail!("Data directory does not exist");
+        return Err(Error::DirectoryDoesNotExist);
     }
 
     let mut dd = DATADIR_SINGLETON.lock().unwrap();
     dd.take();
     match dd.set(Some(d.to_path_buf())) {
         Ok(_) => Ok(()),
-        Err(_) => bail!("Could not set data directory"),
+        Err(_) => Err(Error::SetFailed),
     }
 }
 
@@ -84,7 +105,7 @@ pub fn set_datadir(d: &Path) -> Result<()> {
 ///
 /// Returns:
 ///
-///  * anyhow::Result<<std::path::PathBuf>> representing directory
+///  * Result<<std::path::PathBuf>> representing directory
 ///    where files are stored
 pub fn datadir() -> Result<PathBuf> {
     let dd = DATADIR_SINGLETON.lock().unwrap();
@@ -118,7 +139,7 @@ pub fn datadir() -> Result<PathBuf> {
 
     match res.as_ref() {
         Some(v) => Ok(v.clone()),
-        None => bail!("Could not find valid writeable data directory"),
+        None => Err(Error::NoWriteableDirectory),
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,4 @@
-mod datadir;
+pub mod datadir;
 pub use datadir::data_found;
 pub use datadir::datadir;
 pub use datadir::set_datadir;


### PR DESCRIPTION
## Summary

Phase 3 of the `anyhow` → `thiserror` migration tracked in #81. Covers the 9 internal astronomy modules. Branched from `main`, independently mergeable from #83 and #84.

Refs #81. After this lands, the only remaining anyhow surface is `utils/download.rs` and `utils/update_data.rs` — those will be a small Phase 4 follow-up after #82 (download feature) merges, since both files conflict with that PR.

## What changed

**`time::InstantError`** (extended in place at `src/time/instant_err.rs`) — pre-existing variants kept; added:
- `InvalidSecondF(f64)`, `InvalidLeapSecond`, `ParseInt(#[from] ParseIntError)`

**`utils::datadir::Error`** (`src/utils/datadir.rs`):
- `DirectoryDoesNotExist`, `SetFailed`, `NoWriteableDirectory`
- `utils::datadir` is now `pub mod` so siblings can `#[from]` it

**`kepler::Error`** (`src/kepler.rs`):
- `EccenOutOfBound(f64)`
- Kept `#[deprecated] type KeplerError = Error;` for source-level compat

**`spaceweather::Error`**:
- `InvalidNumber(&'static str)`, `NoRecordForDate`, `DataDirReadOnly`, `Io(#[from])`, `InvalidEpoch(#[from] InstantError)`, `Datadir(#[from] datadir::Error)`, `Download(anyhow::Error)`

**`solar_cycle_forecast::Error`**:
- `FileNotFound`, `NotJsonArray`, `MissingTimeTag`, `MissingPredictedF107`, `EmptyForecast`, `Io(#[from])`, `Json(#[from])`, `InvalidEpoch(#[from] InstantError)`, `Datadir(#[from] datadir::Error)`, `ParseInt(#[from])`, `Download(anyhow::Error)`

**`earth_orientation_params::Error`**:
- `InvalidEntry`, `LegacyFileMissing(String)`, `LegacyOpenFailed { path, source }`, `LegacyFieldParse { field, source }`, `DataDirReadOnly`, `Io(#[from])`, `ParseFloat(#[from])`, `Datadir(#[from])`, `Download(anyhow::Error)`

**`jplephem::Error`**:
- `InvalidJulianDate(f64)`, `InvalidBody`, `InvalidRecordSize`, `Io(#[from])`, `Utf8(#[from])`, `FromUtf8(#[from])`, `TryFromSlice(#[from])`, `ParseInt(#[from])`, `ParseFloat(#[from])`, `Datadir(#[from])`, `Download(anyhow::Error)`

**`earthgravity::Error`**:
- `MissingMaxDegree`, `InvalidLine(String)`, `OpenFailed(#[source])`, `Io(#[from])`, `ParseFloat(#[from])`, `ParseInt(#[from])`, `Datadir(#[from])`, `Download(anyhow::Error)`

**`lpephem::Error`** (shared by `sun.rs` + `planets.rs`, in `src/lpephem/mod.rs`):
- `NoSunriseOrSunset`, `InvalidBody`, `TimeOutOfRange`, `InvalidEpoch(#[from] InstantError)`

## Judgment calls worth a look

1. **`kepler` ↔ `time` not actually circular.** Inspected `Kepler::from_pv` — it doesn't call any `Instant::*` constructor, so `kepler::Error` has no `InstantError` variant. Clean isolation.
2. **`time::InstantError` extended in place** — three new variants (`InvalidSecondF`, `InvalidLeapSecond`, `ParseInt(#[from])`) rather than introducing a competing `time::Error`. Existing public surface (consumed by `omm::Error::InvalidEpoch` from #83) is preserved.
3. **`utils::datadir::Error`, not `utils::Error`** — chose the narrower home because `utils/download.rs` and `utils/update_data.rs` still own anyhow until Phase 4. A unified `utils::Error` would be misleading.
4. **`Download(anyhow::Error)` variant** — most modules have a `Download` variant wrapping anyhow because the actual download paths still go through `utils/download.rs` which is anyhow-backed (Phase 4). Once Phase 4 lands, these become typed.
5. **Cross-module retyping deferred.** Did NOT retype the stringified variants on parallel branches:
   - `tle::Error::InvalidEpoch(String)` → `#[from] InstantError` (deferred)
   - `tle::Error::KeplerConversion(String)` → `#[from] kepler::Error` (deferred)
   - `orbitprop::Error::Precompute(String)` → `#[from] jplephem::Error` (deferred)
   These touch #83/#84 and will conflict — handle in a follow-up after both merge.
6. **One incidental touch in `orbitprop/propagator.rs:1020`** — a doc-test helper closure returns `anyhow::Result<Instant>`; with `Instant::from_datetime` now typed, needed `Ok(... ?)` wrapping. **Heads-up: this line will likely conflict with #84's orbitprop migration at merge time. Single-line conflict, trivial to resolve.**
7. **Python bindings**: 4 sites needed `Ok(... ?)` wrapping where Rust couldn't infer `?`-coercion (`pyjplephem.rs` ×4, `pyinstant.rs` ×3, `mod_utils::set_datadir`). Same pattern as Phases 1 and 2 — anyhow's blanket `From<E: Error + Send + Sync + 'static>` handles conversion to `PyErr`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo build --no-default-features` — clean
- [x] `cargo test --release` — 159 lib + 41 doc tests pass
- [x] `cargo check --manifest-path python/Cargo.toml` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)