### PR TITLE
feat: skip redundant space-weather downloads via If-Modified-Since (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## Unreleased
 
+### `update_datafiles` uses conditional GETs to skip unchanged files
+
+- **`If-Modified-Since` on every refresh download.** `download_file` now formats the local file's mtime as an HTTP-date and sends it as `If-Modified-Since`. On a `304 Not Modified` response, the existing file is left untouched and the function returns `Ok(false)`. The two regularly-refreshed files (`EOP-All.csv` and `SW-All.csv`, both served by celestrak.org) had been re-downloaded on every `update_datafiles()` call regardless of whether they had changed — now they only transfer when the server reports a newer `Last-Modified`. Bandwidth-constrained users (e.g. on cellular) see ~3 MB/run drop to a pair of HEAD-sized 304s. Resolves [#97](https://github.com/ssmichael1/satkit/issues/97).
+- **New `%a` format code in `Instant::strftime`** (`src/time/instantparse.rs`). Abbreviated weekday name — `Sun`, `Mon`, ..., `Sat` — parallel to the existing full-name `%A`. Added to support the RFC 7231 IMF-fixdate format (`%a, %d %b %Y %H:%M:%S GMT`) used by `If-Modified-Since`. No new dependencies.
+- **Behavior of `overwrite_if_exists=false` is unchanged**: the local-existence fast path still short-circuits before any network call. The flag now effectively means "ask the server whether to re-fetch" when true, rather than "always re-fetch".
+
 ### `ITRFCoord::to_enu` / `to_ned`: parameter renamed `ref_coord` → `origin`, docstrings overhauled
 
 - **Parameter rename.** `ITRFCoord::to_enu(&self, ref_coord)` and `to_ned(&self, ref_coord)` now take `origin` instead. The ENU/NED triad is *anchored* at this argument — calling it "origin" matches the standard local-tangent-frame terminology and makes call sites read like prose: `satellite.to_enu(&station)` ("ENU of the satellite, with the station as the origin"). Rust callers are unaffected (positional args); Python callers using `origin=` as a kwarg will need to update from `refcoord=` / `other=`. Resolves [#91](https://github.com/ssmichael1/satkit/issues/91).

--- a/src/time/instantparse.rs
+++ b/src/time/instantparse.rs
@@ -47,6 +47,9 @@ const MONTH_ABBRS: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
+/// Abbreviated weekday names, indexed by `Weekday as i32` (0 = Sunday).
+const WEEKDAY_ABBRS: [&str; 7] = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 #[derive(PartialEq, Debug)]
 enum ParseVal {
     Str(String),
@@ -538,6 +541,7 @@ impl Instant {
     /// * %S - Second as a zero-padded decimal number
     /// * %f - Microsecond as a decimal number
     /// * %A - Full weekday name (Sunday, Monday, etc.)
+    /// * %a - Abbreviated weekday name (Sun, Mon, etc.)
     /// * %w - Weekday as a decimal number [0(Sunday), 6(Saturday)]
     ///
     /// # Returns:
@@ -584,6 +588,14 @@ impl Instant {
                     Some('A') => {
                         let weekday = self.day_of_week();
                         result.push_str(&weekday.to_string());
+                    }
+                    Some('a') => {
+                        let idx = self.day_of_week() as i32;
+                        if (0..7).contains(&idx) {
+                            result.push_str(WEEKDAY_ABBRS[idx as usize]);
+                        } else {
+                            result.push_str("Invalid");
+                        }
                     }
                     Some('w') => {
                         let weekday = self.day_of_week();

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -64,19 +64,45 @@ pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -
     let fullpath = downloaddir.join(fname);
     if fullpath.exists() && !overwrite_if_exists {
         println!("File {} exists; skipping download", fname.to_str().unwrap());
-        Ok(false)
-    } else {
-        println!("Downloading {}", fname.to_str().unwrap());
-
-        // Try to set proxy, if any, from environment variables
-        let agent = ureq::Agent::new_with_defaults();
-
-        let mut resp = agent.get(url).call()?;
-
-        let mut dest = std::fs::File::create(fullpath)?;
-        std::io::copy(&mut resp.body_mut().as_reader(), &mut dest)?;
-        Ok(true)
+        return Ok(false);
     }
+
+    let agent = ureq::Agent::new_with_defaults();
+    let mut req = agent.get(url);
+
+    // If we already have a local copy, ask the server to only send
+    // the body if it has changed since we wrote it.
+    let if_modified_since = fullpath
+        .metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|mtime| {
+            let unix = mtime
+                .duration_since(std::time::UNIX_EPOCH)
+                .ok()?
+                .as_secs_f64();
+            crate::time::Instant::from_unixtime(unix)
+                .strftime("%a, %d %b %Y %H:%M:%S GMT")
+                .ok()
+        });
+    if let Some(ref date) = if_modified_since {
+        req = req.header("If-Modified-Since", date.as_str());
+    }
+
+    let mut resp = req.call()?;
+
+    if resp.status().as_u16() == 304 {
+        println!(
+            "File {} unchanged on server; skipping download",
+            fname.to_str().unwrap()
+        );
+        return Ok(false);
+    }
+
+    println!("Downloading {}", fname.to_str().unwrap());
+    let mut dest = std::fs::File::create(fullpath)?;
+    std::io::copy(&mut resp.body_mut().as_reader(), &mut dest)?;
+    Ok(true)
 }
 
 #[cfg(not(feature = "download"))]


### PR DESCRIPTION
## Summary

- `download_file` now sends `If-Modified-Since` based on the local file's mtime; on a 304 the existing file is left untouched and the function returns `Ok(false)`.
- Adds the `%a` (abbreviated weekday) format code to `Instant::strftime`, parallel to the existing `%A`. Needed for the RFC 7231 IMF-fixdate format used by `If-Modified-Since`. No new dependencies — the HTTP-date is formatted via the existing strftime machinery.
- `update_datafiles` now only transfers EOP-All.csv / SW-All.csv when celestrak reports a newer `Last-Modified` (resolves the cellular / bandwidth-constrained case in the issue — ~3 MB/run drops to a pair of HEAD-sized 304s).
- Behaviour of `overwrite_if_exists=false` is unchanged: the existence fast-path still short-circuits before any network call. The flag now effectively means "ask the server whether to re-fetch" when true, rather than "always re-fetch".

Resolves #97.

## Test plan

- [x] `cargo test --lib --features download` — 159 passing locally (no new tests; the change is on the network path and exercised by the existing `solar_cycle_forecast::test_download_and_parse` integration test plus manual verification of the HTTP-date string against the RFC 7231 reference example).
- [x] `cargo build` with and without `--features download` — both clean.
- [x] Sanity check: `Instant::from_datetime(1994, 11, 6, 8, 49, 37.0).strftime("%a, %d %b %Y %H:%M:%S GMT")` produces `"Sun, 06 Nov 1994 08:49:37 GMT"` (RFC 7231 example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)