### PR TITLE
chore: deprecate satkit::Error / satkit::Result façade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### `satkit::Error` façade is deprecated
+
+- **`satkit::Error` and `satkit::Result` marked `#[deprecated(since = "0.17.0")]`.** The top-level error enum was added in 0.16.x (PR #86) as a convenience for downstream apps that wanted a single result type to unify the per-module typed errors. In practice the module-scoped errors (`tle::Error`, `orbitprop::Error`, …) plus a downstream-defined `enum AppError` or `anyhow::Result` cover the use case more cleanly and don't lock satkit into a public surface that has to grow in lockstep with every new module-level error variant. Both `Error` and `Result` are still exported and functional; the deprecation just nudges callers toward the more durable pattern. Removal is planned for a future release.
+
 ### `update_datafiles` uses conditional GETs to skip unchanged files
 
 - **`If-Modified-Since` on every refresh download.** `download_file` now formats the local file's mtime as an HTTP-date and sends it as `If-Modified-Since`. On a `304 Not Modified` response, the existing file is left untouched and the function returns `Ok(false)`. The two regularly-refreshed files (`EOP-All.csv` and `SW-All.csv`, both served by celestrak.org) had been re-downloaded on every `update_datafiles()` call regardless of whether they had changed — now they only transfer when the server reports a newer `Last-Modified`. Bandwidth-constrained users (e.g. on cellular) see ~3 MB/run drop to a pair of HEAD-sized 304s. Resolves [#97](https://github.com/ssmichael1/satkit/issues/97).

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,14 @@
 //! Top-level error type for the satkit crate.
 //!
-//! Most functions return module-scoped error types
+//! **Deprecated as of 0.17.0.** Prefer the module-scoped error types
 //! (e.g. [`tle::Error`](crate::tle::Error),
-//! [`orbitprop::Error`](crate::orbitprop::Error)). For downstream apps
-//! that consume multiple modules and don't want to define their own
-//! outer error, this façade has `From` impls for every public module
-//! error and can be used as a single result type.
+//! [`orbitprop::Error`](crate::orbitprop::Error)) directly, and either
+//! define a downstream `enum AppError` with the variants you actually
+//! use, or use `anyhow` / `color_eyre` for application-level error
+//! aggregation. This façade will be removed in a future release.
+//!
+//! The original use case was a single result type that lets `?` work
+//! across modules without an outer enum:
 //!
 //! ```rust,ignore
 //! fn do_thing() -> Result<(), satkit::Error> {
@@ -18,6 +21,10 @@
 use thiserror::Error;
 
 /// Top-level satkit error covering every public module-scoped error.
+#[deprecated(
+    since = "0.17.0",
+    note = "use the module-scoped error types (e.g. `tle::Error`) and define a downstream error enum, or use `anyhow`/`color_eyre`"
+)]
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
@@ -77,4 +84,9 @@ pub enum Error {
 }
 
 /// Convenient type alias used throughout satkit.
+#[deprecated(
+    since = "0.17.0",
+    note = "use the module-scoped error types (e.g. `tle::Error`) and define a downstream error enum, or use `anyhow`/`color_eyre`"
+)]
+#[allow(deprecated)]
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,8 +218,9 @@ pub mod omm;
 mod time;
 pub use time::{Duration, Instant, InstantError, TimeLike, TimeScale, Weekday};
 
-// Top-level façade error type
+// Top-level façade error type (deprecated 0.17.0; re-exported for source compat).
 mod error;
+#[allow(deprecated)]
 pub use error::{Error, Result};
 
 // Core types available at crate level


### PR DESCRIPTION
## Summary

- Marks `satkit::Error` and `satkit::Result` with `#[deprecated(since = "0.17.0")]`.
- Updates the module docstring to lead with the deprecation notice and point at the recommended downstream pattern (module-scoped errors + a local `AppError`, or `anyhow`/`color_eyre`).
- Adds `#[allow(deprecated)]` on the `pub use error::{Error, Result}` re-export so the crate's own build stays warning-free; downstream callers naming `satkit::Error` or `satkit::Result` will see the deprecation at their use site, which is the intent.

## Rationale

The façade was added in #86 as a convenience for downstream apps that wanted a single result type. In practice the module-scoped errors plus a local `AppError` or `anyhow::Result` cover that use case more cleanly, and committing to the façade as a public API surface would mean adding a new variant in lockstep with every future module-level error.

This is the "sleep-on" item flagged in the simplifier-thread notes after #86 landed: deprecate before tagging v0.17 is much cheaper than going through a deprecation cycle later. Both `Error` and `Result` remain exported and functional — this is a deprecate-then-remove path, not a remove.

## Test plan

- [x] `cargo build` clean with no deprecation warnings inside satkit (the `#[allow(deprecated)]` on the re-export takes care of that).
- [x] A downstream caller that names `satkit::Error` or `satkit::Result` will see the deprecation warning at their use site — verified by removing the `#[allow(deprecated)]` locally and confirming the warning fires on the re-export only.
- [x] All existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)