### PR TITLE
fix(packaging): include root build.rs in sdist; make it graceful outside a git tree

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE-MIT
 include LICENSE-APACHE
 include README.md
 include pyproject.toml
+include build.rs
 recursive-include src *.rs
 recursive-include python/src *.rs
 include python/Cargo.toml

--- a/build.rs
+++ b/build.rs
@@ -4,24 +4,29 @@ use std::time::{SystemTime, UNIX_EPOCH};
 fn main() {
     // NRLMSISE-00 is now pure Rust (src/nrlmsise.rs), no C compilation needed
 
-    // Record git hash to compile-time environment variable
-    let output = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+    // Record git hash to compile-time environment variable. Sdist /
+    // tarball builds (PyPI source distributions, conda-forge builds from
+    // a github archive, etc.) have no .git directory — fall back to
+    // "unknown" rather than blowing up the build.
+    println!("cargo:rustc-env=GIT_HASH={}", git_output(&["rev-parse", "HEAD"]));
+    println!("cargo:rustc-env=GIT_TAG={}", git_output(&["describe", "--tags"]));
     println!("cargo:rustc-env=BUILD_DATE={}", build_date_iso8601());
+}
 
-    // Record git tag
-    let output = Command::new("git")
-        .args(["describe", "--tags"])
+fn git_output(args: &[&str]) -> String {
+    Command::new("git")
+        .args(args)
         .output()
-        .unwrap();
-    println!(
-        "cargo:rustc-env=GIT_TAG={}",
-        String::from_utf8(output.stdout).unwrap()
-    );
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                String::from_utf8(o.stdout).ok().map(|s| s.trim().to_string())
+            } else {
+                None
+            }
+        })
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn build_date_iso8601() -> String {

--- a/build.rs
+++ b/build.rs
@@ -8,8 +8,14 @@ fn main() {
     // tarball builds (PyPI source distributions, conda-forge builds from
     // a github archive, etc.) have no .git directory — fall back to
     // "unknown" rather than blowing up the build.
-    println!("cargo:rustc-env=GIT_HASH={}", git_output(&["rev-parse", "HEAD"]));
-    println!("cargo:rustc-env=GIT_TAG={}", git_output(&["describe", "--tags"]));
+    println!(
+        "cargo:rustc-env=GIT_HASH={}",
+        git_output(&["rev-parse", "HEAD"])
+    );
+    println!(
+        "cargo:rustc-env=GIT_TAG={}",
+        git_output(&["describe", "--tags"])
+    );
     println!("cargo:rustc-env=BUILD_DATE={}", build_date_iso8601());
 }
 
@@ -20,7 +26,9 @@ fn git_output(args: &[&str]) -> String {
         .ok()
         .and_then(|o| {
             if o.status.success() {
-                String::from_utf8(o.stdout).ok().map(|s| s.trim().to_string())
+                String::from_utf8(o.stdout)
+                    .ok()
+                    .map(|s| s.trim().to_string())
             } else {
                 None
             }

--- a/src/earth_orientation_params.rs
+++ b/src/earth_orientation_params.rs
@@ -388,7 +388,9 @@ mod tests {
     fn loaded() {
         ensure_default_loaded();
         let guard = EOP.read().unwrap();
-        let eop = guard.as_ref().expect("default EOP load should succeed in tests");
+        let eop = guard
+            .as_ref()
+            .expect("default EOP load should succeed in tests");
         assert!(eop[0].mjd_utc >= 0.0);
     }
 

--- a/src/frametransform/error.rs
+++ b/src/frametransform/error.rs
@@ -4,8 +4,8 @@ use std::num::{ParseFloatError, ParseIntError};
 
 use thiserror::Error;
 
-use crate::Frame;
 use super::ierstable::IersTableId;
+use crate::Frame;
 
 /// Errors produced by the
 /// [`frametransform`](crate::frametransform) module.

--- a/src/frametransform/mod.rs
+++ b/src/frametransform/mod.rs
@@ -36,7 +36,10 @@ pub use error::{Error, Result};
 
 /// Convenience re-exports for the IERS-table init API. See
 /// [`ierstable`] for details.
-pub use ierstable::{init_from_bytes as init_iers_table_from_bytes, init_from_path as init_iers_table_from_path, IersTableId};
+pub use ierstable::{
+    init_from_bytes as init_iers_table_from_bytes, init_from_path as init_iers_table_from_path,
+    IersTableId,
+};
 
 use crate::{TimeLike, TimeScale};
 use std::f64::consts::PI;

--- a/src/jplephem.rs
+++ b/src/jplephem.rs
@@ -214,8 +214,7 @@ fn resolve_default_path() -> std::path::PathBuf {
                 continue;
             };
             // DE-version suffix: 3 digits starting with '4' (covers DE4XX family).
-            if ext.len() != 3 || !ext.starts_with('4') || !ext.chars().all(|c| c.is_ascii_digit())
-            {
+            if ext.len() != 3 || !ext.starts_with('4') || !ext.chars().all(|c| c.is_ascii_digit()) {
                 continue;
             }
             let Ok(de_version) = ext.parse::<u32>() else {

--- a/tests/earthgravity_init.rs
+++ b/tests/earthgravity_init.rs
@@ -37,9 +37,8 @@ fn init_from_bytes_then_query_and_double_init_errors() {
     );
 
     // 3. Second init for the same model is rejected.
-    let err = earthgravity::init_from_bytes(GravityModel::EGM96, &bytes).expect_err(
-        "second init_from_bytes(EGM96) should return AlreadyInitialized",
-    );
+    let err = earthgravity::init_from_bytes(GravityModel::EGM96, &bytes)
+        .expect_err("second init_from_bytes(EGM96) should return AlreadyInitialized");
     assert!(matches!(
         err,
         earthgravity::Error::AlreadyInitialized(GravityModel::EGM96)

--- a/tests/spaceweather_init.rs
+++ b/tests/spaceweather_init.rs
@@ -28,8 +28,7 @@ fn init_from_bytes_replaces_and_query_works() {
     };
 
     // 1. First init populates the singleton.
-    spaceweather::init_from_bytes(&bytes)
-        .expect("init_from_bytes should succeed on first call");
+    spaceweather::init_from_bytes(&bytes).expect("init_from_bytes should succeed on first call");
 
     // 2. Query against the just-installed records.
     let tm = Instant::from_datetime(2023, 11, 14, 0, 0, 0.0).unwrap();


### PR DESCRIPTION
## Summary

- The PyPI 0.17.0 sdist failed to include the root `build.rs` because `MANIFEST.in` listed `python/build.rs` but not the top-level one. `cargo build` from the sdist (conda-forge, plain `pip install ./satkit-0.17.0.tar.gz`, etc.) panicked with *"environment variable GIT_HASH not defined at compile time"* — that env var is set by the root build.rs, which simply wasn't shipped.
- Two small fixes: add `include build.rs` to `MANIFEST.in`, and rewrite the root `build.rs` to fall back to `"unknown"` for `GIT_HASH` / `GIT_TAG` when there's no `.git/` (matching the pattern already in `python/build.rs`).
- Surfaced while validating the in-progress conda-forge recipe locally — but the fix is generally useful for any non-git sdist consumer.

## Test plan

- [x] `cargo build --release` and `cargo test --release` on the branch — all 226 tests pass
- [x] `python -m build --sdist` produces a tarball that includes `build.rs` at the root
- [x] Local `conda build` against the fixed sdist compiles the satkit Rust extension cleanly and the Moon-position smoke test passes (398,940,201 m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)