### PR TITLE
Add conda-forge recipes for satkit + satkit-data

### DIFF
--- a/recipes/conda/README.md
+++ b/recipes/conda/README.md
@@ -74,9 +74,9 @@ rattler-build build --recipe recipes/conda/satkit-data/meta.yaml
 rattler-build build --recipe recipes/conda/satkit/meta.yaml
 ```
 
-The `satkit` recipe's source-tarball `sha256:` is a TODO — fill in
-with the `pip hash satkit-0.17.0.tar.gz` output against the actual
-PyPI release tarball before submission.
+The `satkit` recipe pulls the 0.18.0 sdist from PyPI directly. When
+bumping for a future release, refresh the `sha256:` via
+`pip hash satkit-<version>.tar.gz` against the new tarball.
 
 ## Submission
 

--- a/recipes/conda/README.md
+++ b/recipes/conda/README.md
@@ -1,0 +1,87 @@
+# conda-forge recipes
+
+Draft conda-forge recipes for the satkit ecosystem. These are the
+files that will be submitted to
+[`conda-forge/staged-recipes`](https://github.com/conda-forge/staged-recipes)
+to bootstrap the two feedstocks; iteration happens here in-tree so the
+history travels with the source.
+
+## Layout
+
+| Path | Package | What it ships |
+|---|---|---|
+| [`satkit/meta.yaml`](satkit/meta.yaml) | `satkit` | The Python package — Rust extension built via PyO3 / setuptools-rust |
+| [`satkit-data/meta.yaml`](satkit-data/meta.yaml) | `satkit-data` | Noarch Python data-only package: JPL DE421, gravity models, IERS tables, leap seconds, NRLMSIS parameters |
+
+`satkit` depends on `satkit-data ≥ 0.10` at runtime, so installing
+`satkit` from conda-forge will pull in `satkit-data` automatically.
+
+## DE421 vs DE440 — different payloads, same name, same version
+
+The two channel builds of `satkit-data` ship intentionally different
+JPL ephemeris files:
+
+| Channel | JPL file | Size | Span |
+|---|---|---|---|
+| PyPI | `linux_p1550p2650.440` (DE440 full) | ~98 MB | 1550–2650 |
+| conda-forge | `lnxp1900p2053.421` (DE421) | ~13 MB | 1900–2053 |
+
+The `satkit-data` *version* tracks the upstream PyPI version (currently
+0.9.0); the JPL-file substitution is a **channel-specific build
+choice, not a version bump**. Conda's run-dep solver works with this
+because users on conda-forge get the conda-forge artifact and never
+mix; users on PyPI get the PyPI wheel.
+
+Why DE421 on conda-forge:
+
+* conda-forge has a 100 MB soft cap per package; DE440 squeaks under
+  it but reviewers grumble.
+* For satellite-orbit work (Earth third-body, Sun/Moon ephemerides),
+  the accuracy difference between DE421 and DE440 is unmeasurable —
+  Sun/Moon positions agree at the sub-meter level at modern epochs.
+* The 1900–2053 span covers virtually every active satellite use case.
+
+Callers who need longer span or higher outer-planet precision can
+install DE440 via `satkit.utils.update_datafiles()` post-install (it
+lands in `datadir()` alongside DE421; the autodetect in
+`jplephem::resolve_default_path` picks the highest DE-version
+available).
+
+## EOP / space-weather
+
+`EOP-All.csv` and `SW-All.csv` are **not** bundled in the conda data
+package. CelesTrak republishes them daily and shipping a stale
+snapshot would mislead users. After install, run:
+
+```python
+import satkit
+satkit.utils.update_datafiles()
+```
+
+…to download the current copies into `datadir()`.
+
+## Local validation
+
+Before submitting to staged-recipes, validate each recipe builds:
+
+```bash
+# conda-build (legacy meta.yaml format these recipes use)
+conda build recipes/conda/satkit-data
+conda build recipes/conda/satkit
+
+# rattler-build (newer alternative)
+rattler-build build --recipe recipes/conda/satkit-data/meta.yaml
+rattler-build build --recipe recipes/conda/satkit/meta.yaml
+```
+
+The `satkit` recipe's source-tarball `sha256:` is a TODO — fill in
+with the `pip hash satkit-0.17.0.tar.gz` output against the actual
+PyPI release tarball before submission.
+
+## Submission
+
+When ready, fork
+[conda-forge/staged-recipes](https://github.com/conda-forge/staged-recipes),
+copy each recipe into the fork's `recipes/<name>/` directory, and open
+a single PR with both. Reviewers will then split out the two
+feedstocks (`satkit-feedstock`, `satkit-data-feedstock`) on merge.

--- a/recipes/conda/satkit-data/meta.yaml
+++ b/recipes/conda/satkit-data/meta.yaml
@@ -1,0 +1,118 @@
+{% set name = "satkit-data" %}
+{% set version = "0.9.0" %}
+
+# satkit-data is a noarch Python package that ships the static data files
+# satkit needs at runtime: gravity coefficients, IERS precession-nutation
+# tables, leap-seconds, NRLMSIS-2.1 parameters, and a JPL planetary
+# ephemeris.
+#
+# The PyPI build of `satkit-data` at the same version ships DE440
+# full-span (`linux_p1550p2650.440`, ~98 MB, 1550–2650) — that's the
+# upstream payload. The conda-forge build of `satkit-data` is
+# intentionally a different payload: we ship DE421 (~13 MB, 1900–2053)
+# instead, so the package stays under conda-forge's 100 MB soft cap.
+# Version numbers track the upstream `satkit-data` version; the JPL-file
+# substitution is a channel-specific choice, not a version bump.
+# For the longer DE440 span at the cost of file size, users can call
+# `satkit.utils.update_datafiles()` after install — the autodetect in
+# `jplephem::resolve_default_path` then prefers DE440 over DE421.
+#
+# EOP-All.csv and SW-All.csv (Earth orientation parameters, space
+# weather) are NOT bundled — they're republished daily by CelesTrak and
+# bundling a stale snapshot would mislead users. They're fetched on
+# demand via `satkit.utils.update_datafiles()` or
+# `satkit.earth_orientation_params::update()`.
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # JPL DE421 — short-span planetary ephemeris (1900–2053, ~13 MB).
+  # JPL's Linux subdirectory ships the little-endian native binary.
+  - url: https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de421/lnxp1900p2053.421
+    sha256: 5b3f81dd0c505925055a389431fd2bc5e0ae2fd02d85db37fa4d4fe54dfb4096
+    folder: data
+  # Earth gravity-model coefficients (ICGEM-format text).
+  - url: https://storage.googleapis.com/astrokit-astro-data/EGM96.gfc
+    sha256: 5247a9e9c316dd2c8f8fd491d53be0e163cb5cb3676b021754240cc9e44cb43b
+    folder: data
+  - url: https://storage.googleapis.com/astrokit-astro-data/JGM2.gfc
+    sha256: 0779cf74f216d5b38c7a4c4a1a25d596b659605deb7731f00874c17e9ed3f5af
+    folder: data
+  - url: https://storage.googleapis.com/astrokit-astro-data/JGM3.gfc
+    sha256: 2ec791eec795689291974dd3602b304029da93d3fea30096daa3b368fb231d03
+    folder: data
+  - url: https://storage.googleapis.com/astrokit-astro-data/ITU_GRACE16.gfc
+    sha256: b6bea9c78ad168f1e206fc7211f90b64fba54325c832f4473f6c05a07adbc718
+    folder: data
+  # IERS 2010 IAU precession-nutation tables (Tech Note 36 §5).
+  - url: https://storage.googleapis.com/astrokit-astro-data/tab5.2a.txt
+    sha256: 19549252df9eb77c8237dbf5b749de82b7fd7713a8b60b35371538cd36b6aa1d
+    folder: data
+  - url: https://storage.googleapis.com/astrokit-astro-data/tab5.2b.txt
+    sha256: 1f17a3a6ad0b468705b3323bfe72d0320ce996798ec7cba0cdde4405d88f14d9
+    folder: data
+  - url: https://storage.googleapis.com/astrokit-astro-data/tab5.2d.txt
+    sha256: fe94c83e1ef6f92b15b3f007779ae70c0984c06ee45d5511b4c821ee9a0ecded
+    folder: data
+  # Leap-second history (IETF / IERS).
+  - url: https://storage.googleapis.com/astrokit-astro-data/leap-seconds.list
+    sha256: 14b4faab51b1885680a704744863bda8b5728a0f0a5e07a15c8469532318b305
+    folder: data
+  # NRLMSIS 2.1 atmospheric model parameters.
+  - url: https://storage.googleapis.com/astrokit-astro-data/msis21.parm
+    sha256: a322a749f368e73117dd20f3fdcf7389dabc5509f4c27073cc5580999381b508
+    folder: data
+
+build:
+  number: 0
+  noarch: python
+  # Lay the downloaded files out as a `satkit_data` Python package, mirroring
+  # the on-PyPI sibling so satkit's existing `$SITE_PACKAGES/satkit_data/data`
+  # data-directory resolver finds them without configuration.
+  script: |
+    mkdir -p "$SP_DIR/satkit_data/data"
+    cp -v data/* "$SP_DIR/satkit_data/data/"
+    : > "$SP_DIR/satkit_data/__init__.py"
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - satkit_data
+  commands:
+    - python -c "from importlib.resources import files; d = files('satkit_data').joinpath('data'); names = sorted(p.name for p in d.iterdir()); assert 'lnxp1900p2053.421' in names, names; assert 'EGM96.gfc' in names, names; print('\n'.join(names))"
+
+about:
+  home: https://github.com/ssmichael1/satkit
+  license: MIT OR Apache-2.0
+  license_family: MIT
+  summary: Static data files for satkit (DE421 ephemeris, gravity, IERS tables, leap seconds)
+  description: |
+    Ships the static data files satkit needs at runtime:
+
+      * **lnxp1900p2053.421** — JPL DE421 planetary ephemeris
+        (1900–2053, ~13 MB). For longer spans use DE440 via
+        `satkit.utils.update_datafiles()`.
+      * **EGM96.gfc, JGM2.gfc, JGM3.gfc, ITU_GRACE16.gfc** — gravity
+        models (ICGEM format).
+      * **tab5.2a.txt, tab5.2b.txt, tab5.2d.txt** — IERS Tech Note 36
+        precession-nutation series.
+      * **leap-seconds.list** — historical leap-second table.
+      * **msis21.parm** — NRLMSIS 2.1 atmospheric model parameters.
+
+    Earth orientation parameters (EOP-All.csv) and space weather
+    (SW-All.csv) are NOT bundled because they're regenerated daily by
+    CelesTrak. Run `satkit.utils.update_datafiles()` after install to
+    fetch them.
+  doc_url: https://satkit.dev/getting-started/datafiles/
+  dev_url: https://github.com/ssmichael1/satkit
+
+extra:
+  recipe-maintainers:
+    - ssmichael1

--- a/recipes/conda/satkit/meta.yaml
+++ b/recipes/conda/satkit/meta.yaml
@@ -1,20 +1,13 @@
 {% set name = "satkit" %}
-{% set version = "0.17.0" %}
+{% set version = "0.18.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # LOCAL VALIDATION ONLY — sourced from a freshly-built sdist that
-  # includes the root build.rs (fix applied in this branch's MANIFEST.in
-  # and slated for the 0.17.1 release). Before submitting to
-  # conda-forge, swap to:
-  #
-  #   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  #   sha256: <hash of 0.17.1 PyPI tarball>
-  url: file:///tmp/satkit-sdist/satkit-0.17.0.tar.gz
-  sha256: 65def9207847a5816255cc528ff7c590b23039f0dd25d46d5ef54b57eb43fd74
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9af912f75d1f6387c988670811c6ca1dfbc31efc1f14153d61546e74f76b7033
 
 build:
   number: 0

--- a/recipes/conda/satkit/meta.yaml
+++ b/recipes/conda/satkit/meta.yaml
@@ -1,0 +1,73 @@
+{% set name = "satkit" %}
+{% set version = "0.17.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # LOCAL VALIDATION ONLY — sourced from a freshly-built sdist that
+  # includes the root build.rs (fix applied in this branch's MANIFEST.in
+  # and slated for the 0.17.1 release). Before submitting to
+  # conda-forge, swap to:
+  #
+  #   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  #   sha256: <hash of 0.17.1 PyPI tarball>
+  url: file:///tmp/satkit-sdist/satkit-0.17.0.tar.gz
+  sha256: 65def9207847a5816255cc528ff7c590b23039f0dd25d46d5ef54b57eb43fd74
+
+build:
+  number: 0
+  # satkit currently requires Python ≥3.10 (set in pyproject.toml).
+  skip: true  # [py<310]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+  host:
+    - python
+    - pip
+    - setuptools
+    - setuptools-rust
+  run:
+    - python
+    - numpy >=1.0
+    - satkit-data >=0.9
+
+test:
+  # PyO3-`wrap_pymodule!` submodules (jplephem, frametransform, ...) are
+  # exposed as attributes on `satkit`, not separately-importable
+  # top-level modules — so only `satkit` itself goes in `imports:`.
+  # The attribute-access exercise lives in run_test.py.
+  imports:
+    - satkit
+  files:
+    - run_test.py
+  commands:
+    - python run_test.py
+
+about:
+  home: https://github.com/ssmichael1/satkit
+  license: MIT OR Apache-2.0
+  license_family: MIT
+  license_file:
+    - LICENSE-MIT
+    - LICENSE-APACHE
+  summary: Satellite orbital mechanics library (SGP4, JPL ephemerides, frame transforms)
+  description: |
+    SatKit is a high-performance orbital mechanics library written in
+    Rust with complete Python bindings via PyO3. It handles coordinate
+    transforms, orbit propagation, time systems, gravity models,
+    atmospheric density, and JPL ephemerides — everything needed for
+    satellite astrodynamics work.
+
+    Companion data package: satkit-data (ships JPL DE421 plus the
+    static gravity / IERS / leap-second / NRLMSIS files).
+  doc_url: https://satkit.dev/
+  dev_url: https://github.com/ssmichael1/satkit
+
+extra:
+  recipe-maintainers:
+    - ssmichael1

--- a/recipes/conda/satkit/run_test.py
+++ b/recipes/conda/satkit/run_test.py
@@ -1,0 +1,22 @@
+"""Smoke test for the satkit conda recipe.
+
+Verifies that with satkit-data installed as a run-dep, the JPL
+ephemeris is discoverable and a Moon position query returns a value of
+the right magnitude (~3.84e8 m).
+"""
+
+import numpy as np
+
+import satkit
+
+
+def main() -> None:
+    t = satkit.time.from_date(2024, 3, 1)
+    r = satkit.jplephem.geocentric_pos(satkit.solarsystem.Moon, t)
+    d = float(np.linalg.norm(r))
+    assert 3.0e8 < d < 5.0e8, f"unexpected Moon distance: {d}"
+    print(f"moon distance OK: {d:.0f} m")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Lands the conda-forge recipe drafts under `recipes/conda/` so they're versioned alongside the source they describe. The actual submission to `conda-forge/staged-recipes` is a separate cross-repo PR; this one just gets the recipe files into main.

Two recipes:

* **`recipes/conda/satkit/meta.yaml`** — Python package, Rust + PyO3 build via `setuptools-rust`, sources the 0.18.0 sdist from PyPI (hash-pinned), depends on `satkit-data >= 0.9`. Includes a `run_test.py` smoke script that verifies the conda-installed satkit-data is discoverable by satkit's autodetect resolver and a Moon-position query returns the correct magnitude (~3.84e8 m).
* **`recipes/conda/satkit-data/meta.yaml`** — Noarch data package; nine individual sources (JPL DE421 from JPL directly + the eight small static files from the GCS mirror), each SHA256-pinned, built as `satkit_data/data/*` to match the PyPI sibling's layout. **Ships DE421 (~13 MB) instead of the PyPI sibling's DE440 (~98 MB)** — under conda-forge's 100 MB soft cap; users wanting the longer DE440 span can install it via `satkit.utils.update_datafiles()` post-install.
* **`recipes/conda/README.md`** — design notes (DE421 vs DE440 rationale, EOP/SW staleness exclusion, local validation steps, submission instructions).

EOP-All.csv and SW-All.csv are NOT bundled — CelesTrak regenerates them daily and a stale snapshot would mislead users. `update_datafiles()` fetches them on demand.

## Test plan

- [x] `conda build recipes/conda/satkit-data` succeeds — noarch package built, import test confirms all 10 data files including `lnxp1900p2053.421`
- [x] `conda build recipes/conda/satkit -c local` succeeds against the just-built satkit-data — Rust extension compiled, end-to-end smoke test (Moon position via DE421) returns 398,940,201 m
- [x] Sdist sha256 verified against `https://pypi.org/packages/source/s/satkit/satkit-0.18.0.tar.gz`
- [ ] Submit to `conda-forge/staged-recipes` (follow-up PR, separate repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)