### PR TITLE
Unify propagator force model; cap gravity coefficient table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
 
+## Unreleased
+
+### High-precision propagator: force model unified across all integrators
+
+- **A single `force_model()` replaces four duplicated force closures.** The RKV `ydot`, the RODAS4 `ydot_vec` and `jac_fn`, and the Gauss-Jackson 8 `accel_fn` each carried a near-identical copy of the acceleration physics (Earth gravity, Sun/Moon third-body, solid Earth tides, GR Schwarzschild, SRP, drag, thrust) — ~200 lines duplicated four ways. Adding a force term (as 0.18.0's tides and GR did) meant editing every copy in lockstep and risked them drifting apart. The physics now lives in one `force_model()` function in `orbitprop::propagator`; each integrator closure is a thin adapter that unpacks its own state layout (`Matrix<6, C>` / `Vector<f64, 6>` / separate `(r, v)`), calls `force_model()`, and packs the result. **No behavior change** — end states are bit-identical and the full Rust suite (including the ESA SP3 GPS regression) passes unchanged.
+- **`ForceEval` mode selector** (`Accel` / `AccelAndPartials` / `PartialsOnly`) keeps each integrator's cost identical to the prior hand-specialized code. Every call site passes a compile-time-constant mode and `force_model` is `#[inline]`, so the compiler constant-folds the partials/accel branches away and regenerates the original specialization — no extra call, no runtime dispatch on the enum. The RODAS4 Jacobian path (`PartialsOnly`) still skips the tide/GR/SRP/thrust terms — they contribute no partials — so it does not regress.
+- **Drag altitude gate uses `norm_squared()`** against a precomputed squared limit (`DRAG_RADIUS_LIMIT_M`) instead of `norm()`, removing a square root from every force evaluation regardless of whether drag is active.
+
+### Earth gravity: stored coefficient table capped at the evaluation degree
+
+- **`Gravity::parse` caps the coefficient table at degree 44** (`MAX_COEFF_DIM`) rather than storing the file's full resolution. The evaluator dispatches at degree ≤ 40 and the Cunningham recursion / divisor tables are 44×44, so higher-degree coefficients were never used — yet the default EGM96 model (file degree 360) was holding a 361×361 `DMatrix` (~1 MB). Capping it drops that to ~15 KB and, more importantly, shrinks the column-major stride from 361 to 44 so the strided S-coefficient reads `coeffs[(m-1, n)]` stay resident in L1 instead of scattering across ~3 KB jumps. **Results are bit-identical** (coefficients for n,m ≤ 43 are untouched, and computation never exceeds degree 40); a microbenchmark on EGM96 shows ~5–15% faster `accel` / `accel_and_partials` and, notably, eliminates the cache-miss timing variance in the hot loop. The cap is coupled to the pre-existing degree-40 dispatch and 44×44 divisor-table limits, and is documented as such so a future degree bump touches all three together.
+
+
 ## 0.18.0 - 2026-05-25
 
 ### Solid Earth tides (IERS 2010 §6.2 Step 1) in the high-precision propagator

--- a/src/earthgravity.rs
+++ b/src/earthgravity.rs
@@ -55,6 +55,16 @@ type CoeffTable = DMatrix<f64>;
 
 type DivisorTable = Matrix<44, 44>;
 
+/// Largest table dimension the evaluator can ever index. Acceleration and
+/// partials are dispatched at degree ≤ 40 (see `dispatch_degree!`) and the
+/// Cunningham recursion uses NP4 = degree + 4 ≤ 44, matching the 44×44
+/// divisor tables. Storing coefficients beyond this is not just wasted
+/// memory — for high-resolution models (EGM96 is degree 360) it inflates the
+/// column-major stride of `coeffs`, scattering the S-coefficient reads
+/// `coeffs[(m-1, n)]` across ~3 KB strides and thrashing the cache in the
+/// hot loops. Capping the stored table keeps the working set in L1.
+const MAX_COEFF_DIM: usize = 44;
+
 use std::sync::OnceLock;
 
 ///
@@ -693,8 +703,12 @@ impl Gravity {
             return Err(Error::MissingMaxDegree);
         }
 
-        // Create matrix with lookup values
-        let mut cs: CoeffTable = CoeffTable::zeros(max_degree + 1, max_degree + 1);
+        // Create matrix with lookup values. Cap the stored table at the
+        // largest degree the evaluator can use (see `MAX_COEFF_DIM`); higher
+        // coefficients in the file are unused and would only hurt cache
+        // locality.
+        let table_dim = (max_degree + 1).min(MAX_COEFF_DIM);
+        let mut cs: CoeffTable = CoeffTable::zeros(table_dim, table_dim);
 
         for line in &lines[header_cnt..] {
             let s: Vec<&str> = line.split_whitespace().collect();
@@ -704,6 +718,10 @@ impl Gravity {
 
             let n: usize = s[1].parse()?;
             let m: usize = s[2].parse()?;
+            // Skip coefficients beyond the stored/evaluated degree.
+            if n >= table_dim {
+                continue;
+            }
             let v1: f64 = s[3].parse()?;
             cs[(n, m)] = v1;
             if m > 0 {
@@ -713,7 +731,7 @@ impl Gravity {
         }
 
         // Convert from normalized coefficients to actual coefficients
-        for n in 0..(max_degree + 1) {
+        for n in 0..table_dim {
             for m in 0..(n + 1) {
                 let mut scale: f64 = 1.0;
                 for k in (n - m + 1)..(n + m + 1) {

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -101,6 +101,180 @@ fn solar_pressure_accel(
             / sun_gcrf.norm())
 }
 
+/// GCRF radius (meters) above which atmospheric density is negligible and
+/// drag is skipped. Comparing `pos.norm_squared()` against the square of this
+/// value lets the force model avoid a square root on every evaluation.
+const DRAG_RADIUS_LIMIT_M: f64 = 700.0e3 + consts::EARTH_RADIUS;
+
+/// Selects what [`force_model`] computes, so the single physics
+/// implementation can serve every integrator.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ForceEval {
+    /// Acceleration only — explicit integrators' state derivative
+    /// (RK with `C == 1`, RODAS4 `ydot`, Gauss-Jackson).
+    Accel,
+    /// Acceleration plus ∂a/∂r and ∂a/∂v — RK state-transition matrix
+    /// (`C == 7`).
+    AccelAndPartials,
+    /// Partials only — RODAS4 Jacobian. The acceleration-only terms (tides,
+    /// GR, SRP, thrust) are skipped because the caller discards the
+    /// acceleration, and those terms contribute no partials anyway.
+    PartialsOnly,
+}
+
+/// The complete force model, shared by every integrator.
+///
+/// The integrators differ only in state layout and in whether they need
+/// partials; they all funnel the physics through here so a force term lives
+/// in exactly one place. Returns `(accel, dadr, dadv)` in GCRF.
+///
+/// * `dadr`/`dadv` are zero unless `eval` requests partials. They include
+///   the dominant terms only — Earth gravity, Sun/Moon third-body, and drag.
+///   Solid-tide, relativistic, and SRP partials are negligible against J2's
+///   (≲1e-12, ~1e-15/m, and SRP respectively) and are intentionally omitted
+///   from the Jacobian, matching the prior per-integrator implementations.
+///
+/// Marked `#[inline]` so that, since every call site passes a compile-time
+/// constant `eval`, the compiler constant-folds the `need_partials` /
+/// `need_accel` branches away and reproduces the previously hand-specialized
+/// per-integrator code (no extra call, no runtime dispatch).
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn force_model(
+    x: f64,
+    pos_gcrf: &Vector3,
+    vel_gcrf: &Vector3,
+    begin: &Instant,
+    interp: &Precomputed,
+    gravity: &crate::earthgravity::Gravity,
+    settings: &PropSettings,
+    satprops: Option<&dyn SatProperties>,
+    eval: ForceEval,
+) -> (Vector3, Matrix3, Matrix3) {
+    let time: Instant = *begin + Duration::from_seconds(x);
+    let (qgcrf2itrf, sun_gcrf, moon_gcrf) = interp.interp(&time).unwrap();
+    let qitrf2gcrf = qgcrf2itrf.conjugate();
+    let pos_itrf = qgcrf2itrf * *pos_gcrf;
+
+    let need_partials = eval != ForceEval::Accel;
+    // Acceleration-only terms (tides, GR, SRP, thrust) carry no partials, so
+    // the Jacobian-only pass skips them entirely.
+    let need_accel = eval != ForceEval::PartialsOnly;
+
+    // Earth gravity (spherical harmonics), evaluated in ITRF and rotated to
+    // GCRF. When partials are needed, a single Legendre pass yields both the
+    // acceleration and its gradient.
+    let (mut accel, mut dadr, mut dadv) = if need_partials {
+        let (ga, gp) = gravity.accel_and_partials(
+            &pos_itrf,
+            settings.gravity_degree as usize,
+            settings.gravity_order as usize,
+        );
+        let ritrf2gcrf = qitrf2gcrf.to_rotation_matrix();
+        (
+            qitrf2gcrf * ga,
+            ritrf2gcrf * gp * ritrf2gcrf.transpose(),
+            Matrix3::zeros(),
+        )
+    } else {
+        (
+            qitrf2gcrf
+                * gravity.accel(
+                    &pos_itrf,
+                    settings.gravity_degree as usize,
+                    settings.gravity_order as usize,
+                ),
+            Matrix3::zeros(),
+            Matrix3::zeros(),
+        )
+    };
+
+    // Sun / Moon third-body perturbations.
+    if settings.use_sun_gravity {
+        if need_partials {
+            let (a, p) = point_gravity_and_partials(pos_gcrf, &sun_gcrf, consts::MU_SUN);
+            accel += a;
+            dadr += p;
+        } else {
+            accel += point_gravity(pos_gcrf, &sun_gcrf, consts::MU_SUN);
+        }
+    }
+    if settings.use_moon_gravity {
+        if need_partials {
+            let (a, p) = point_gravity_and_partials(pos_gcrf, &moon_gcrf, consts::MU_MOON);
+            accel += a;
+            dadr += p;
+        } else {
+            accel += point_gravity(pos_gcrf, &moon_gcrf, consts::MU_MOON);
+        }
+    }
+
+    // Solid Earth tides. Partials are negligible and omitted from the STM.
+    if need_accel && settings.tide_model != TideModel::None {
+        let sun_itrf = qgcrf2itrf * sun_gcrf;
+        let moon_itrf = qgcrf2itrf * moon_gcrf;
+        let deltas = tides::solid_tide_deltas(&sun_itrf, &moon_itrf, &time, settings.tide_model);
+        accel += qitrf2gcrf
+            * tides::tide_accel(&pos_itrf, &deltas, gravity.gravity_constant, gravity.radius);
+    }
+
+    // General-relativistic Schwarzschild correction. Partials skipped.
+    if need_accel && settings.use_relativistic_correction {
+        accel += gr_schwarzschild_accel(pos_gcrf, vel_gcrf, gravity.gravity_constant);
+    }
+
+    if let Some(props) = satprops {
+        // Reconstruct a SimpleState from (r, v) for the state-aware property
+        // queries (area/mass, drag coefficient, radiation susceptibility).
+        let mut ss: SimpleState = SimpleState::zeros();
+        ss.set_block(0, 0, pos_gcrf);
+        ss.set_block(3, 0, vel_gcrf);
+
+        if need_accel {
+            accel += solar_pressure_accel(&sun_gcrf, pos_gcrf, &time, props, &ss);
+        }
+
+        // Atmospheric drag below ~700 km altitude. The squared-radius gate
+        // avoids a square root on every evaluation.
+        if pos_gcrf.norm_squared() < DRAG_RADIUS_LIMIT_M * DRAG_RADIUS_LIMIT_M {
+            let cd_a_over_m = props.cd_a_over_m(&time, &ss);
+            if cd_a_over_m > 1e-6 {
+                if need_partials {
+                    let (drag_a, drag_dr, drag_dv) = drag_and_partials(
+                        pos_gcrf,
+                        &qgcrf2itrf,
+                        vel_gcrf,
+                        &time,
+                        cd_a_over_m,
+                        settings.use_spaceweather,
+                    );
+                    accel += drag_a;
+                    dadr += drag_dr;
+                    dadv += drag_dv;
+                } else {
+                    accel += drag_force(
+                        pos_gcrf,
+                        &pos_itrf,
+                        vel_gcrf,
+                        &time,
+                        cd_a_over_m,
+                        settings.use_spaceweather,
+                    );
+                }
+            }
+        }
+
+        // Continuous thrust acceleration.
+        if need_accel {
+            if let Some(a_thrust) = props.thrust_accel(&time, pos_gcrf, vel_gcrf) {
+                accel += a_thrust;
+            }
+        }
+    }
+
+    (accel, dadr, dadv)
+}
+
 ///
 /// High-precision propagation of a satellite state from a given begin time
 /// to a given end time, with input settings and
@@ -283,122 +457,38 @@ pub fn propagate<const C: usize, T: TimeLike>(
     let gravity = settings.gravity_model.get();
 
     let ydot = |x: f64, y: &Matrix<6, C>| -> Matrix<6, C> {
-        let time: Instant = begin + Duration::from_seconds(x);
         let pos_gcrf: Vector3 = y.block::<3, 1>(0, 0);
         let vel_gcrf: Vector3 = y.block::<3, 1>(3, 0);
 
-        let (qgcrf2itrf, sun_gcrf, moon_gcrf) = interp.interp(&time).unwrap();
-        let qitrf2gcrf = qgcrf2itrf.conjugate();
-        let pos_itrf = qgcrf2itrf * pos_gcrf;
-
-        // Decide whether to compute partials:
-        // - C == 7: always (state transition matrix)
-        // - C == 1: never (explicit integrators don't need partials in ydot)
-        let need_partials = C == 7;
-
-        let (mut accel, mut dadr, mut dadv) = if need_partials {
-            let (ga, gp) = gravity.accel_and_partials(
-                &pos_itrf,
-                settings.gravity_degree as usize,
-                settings.gravity_order as usize,
-            );
-            let ritrf2gcrf = qitrf2gcrf.to_rotation_matrix();
-            (
-                qitrf2gcrf * ga,
-                ritrf2gcrf * gp * ritrf2gcrf.transpose(),
-                Matrix3::zeros(),
-            )
-        } else {
-            (
-                qitrf2gcrf
-                    * gravity.accel(
-                        &pos_itrf,
-                        settings.gravity_degree as usize,
-                        settings.gravity_order as usize,
-                    ),
-                Matrix3::zeros(),
-                Matrix3::zeros(),
-            )
-        };
-
-        if settings.use_sun_gravity {
-            if need_partials {
-                let (a, p) = point_gravity_and_partials(&pos_gcrf, &sun_gcrf, consts::MU_SUN);
-                accel += a;
-                dadr += p;
-            } else {
-                accel += point_gravity(&pos_gcrf, &sun_gcrf, consts::MU_SUN);
-            }
-        }
-        if settings.use_moon_gravity {
-            if need_partials {
-                let (a, p) = point_gravity_and_partials(&pos_gcrf, &moon_gcrf, consts::MU_MOON);
-                accel += a;
-                dadr += p;
-            } else {
-                accel += point_gravity(&pos_gcrf, &moon_gcrf, consts::MU_MOON);
-            }
-        }
-
-        // Solid Earth tides. Partials w.r.t. position are negligible
-        // (≲1e-12 of J2 partials) and are omitted from the STM update.
-        if settings.tide_model != TideModel::None {
-            let sun_itrf = qgcrf2itrf * sun_gcrf;
-            let moon_itrf = qgcrf2itrf * moon_gcrf;
-            let deltas =
-                tides::solid_tide_deltas(&sun_itrf, &moon_itrf, &time, settings.tide_model);
-            accel += qitrf2gcrf
-                * tides::tide_accel(&pos_itrf, &deltas, gravity.gravity_constant, gravity.radius);
-        }
-
-        // General-relativistic Schwarzschild correction. Partials are
-        // ~1e-15/m vs J2's ~1e-7/m; skipped in the STM update.
-        if settings.use_relativistic_correction {
-            accel += gr_schwarzschild_accel(&pos_gcrf, &vel_gcrf, gravity.gravity_constant);
-        }
-
-        if let Some(props) = satprops {
-            let ss: SimpleState = y.block::<6, 1>(0, 0);
-            accel += solar_pressure_accel(&sun_gcrf, &pos_gcrf, &time, props, &ss);
-            if pos_gcrf.norm() < 700.0e3 + consts::EARTH_RADIUS {
-                let cd_a_over_m = props.cd_a_over_m(&time, &ss);
-                if cd_a_over_m > 1e-6 {
-                    if need_partials {
-                        let (drag_a, drag_dr, drag_dv) = drag_and_partials(
-                            &pos_gcrf,
-                            &qgcrf2itrf,
-                            &vel_gcrf,
-                            &time,
-                            cd_a_over_m,
-                            settings.use_spaceweather,
-                        );
-                        accel += drag_a;
-                        dadr += drag_dr;
-                        dadv = drag_dv;
-                    } else {
-                        accel += drag_force(
-                            &pos_gcrf,
-                            &pos_itrf,
-                            &vel_gcrf,
-                            &time,
-                            cd_a_over_m,
-                            settings.use_spaceweather,
-                        );
-                    }
-                }
-            }
-            // Continuous thrust acceleration
-            if let Some(a_thrust) = props.thrust_accel(&time, &pos_gcrf, &vel_gcrf) {
-                accel += a_thrust;
-            }
-        }
-
         if C == 1 {
+            // Explicit integrators don't need partials in ydot.
+            let (accel, _, _) = force_model(
+                x,
+                &pos_gcrf,
+                &vel_gcrf,
+                &begin,
+                interp,
+                gravity,
+                settings,
+                satprops,
+                ForceEval::Accel,
+            );
             let mut dy = Matrix::<6, C>::zeros();
             dy.set_block(0, 0, &vel_gcrf);
             dy.set_block(3, 0, &accel);
             dy
         } else if C == 7 {
+            let (accel, dadr, dadv) = force_model(
+                x,
+                &pos_gcrf,
+                &vel_gcrf,
+                &begin,
+                interp,
+                gravity,
+                settings,
+                satprops,
+                ForceEval::AccelAndPartials,
+            );
             // Equation 7.42: dfdy * state_transition_matrix
             let mut dfdy = Matrix::<6, 6>::zeros();
             dfdy.set_block(0, 3, &Matrix3::eye());
@@ -418,50 +508,20 @@ pub fn propagate<const C: usize, T: TimeLike>(
 
     // Jacobian closure for RODAS4: computes the 6x6 df/dy matrix
     let jac_fn = |x: f64, y: &numeris::Vector<f64, 6>| -> Matrix<6, 6> {
-        let time: Instant = begin + Duration::from_seconds(x);
         let pos_gcrf: Vector3 = y.block::<3, 1>(0, 0);
         let vel_gcrf: Vector3 = y.block::<3, 1>(3, 0);
 
-        let (qgcrf2itrf, sun_gcrf, moon_gcrf) = interp.interp(&time).unwrap();
-        let qitrf2gcrf = qgcrf2itrf.conjugate();
-        let pos_itrf = qgcrf2itrf * pos_gcrf;
-
-        let (_, gp) = gravity.accel_and_partials(
-            &pos_itrf,
-            settings.gravity_degree as usize,
-            settings.gravity_order as usize,
+        let (_, dadr, dadv) = force_model(
+            x,
+            &pos_gcrf,
+            &vel_gcrf,
+            &begin,
+            interp,
+            gravity,
+            settings,
+            satprops,
+            ForceEval::PartialsOnly,
         );
-        let ritrf2gcrf = qitrf2gcrf.to_rotation_matrix();
-        let mut dadr = ritrf2gcrf * gp * ritrf2gcrf.transpose();
-        let mut dadv = Matrix3::zeros();
-
-        if settings.use_sun_gravity {
-            let (_, p) = point_gravity_and_partials(&pos_gcrf, &sun_gcrf, consts::MU_SUN);
-            dadr += p;
-        }
-        if settings.use_moon_gravity {
-            let (_, p) = point_gravity_and_partials(&pos_gcrf, &moon_gcrf, consts::MU_MOON);
-            dadr += p;
-        }
-
-        if let Some(props) = satprops {
-            let ss: SimpleState = y.block::<6, 1>(0, 0);
-            if pos_gcrf.norm() < 700.0e3 + consts::EARTH_RADIUS {
-                let cd_a_over_m = props.cd_a_over_m(&time, &ss);
-                if cd_a_over_m > 1e-6 {
-                    let (_, drag_dr, drag_dv) = drag_and_partials(
-                        &pos_gcrf,
-                        &qgcrf2itrf,
-                        &vel_gcrf,
-                        &time,
-                        cd_a_over_m,
-                        settings.use_spaceweather,
-                    );
-                    dadr += drag_dr;
-                    dadv = drag_dv;
-                }
-            }
-        }
 
         // Build the 6x6 Jacobian: df/dy where f = [vel; accel]
         let mut dfdy = Matrix::<6, 6>::zeros();
@@ -486,67 +546,20 @@ pub fn propagate<const C: usize, T: TimeLike>(
             // At this point C==1 is guaranteed (C==7 was rejected above)
             let y0_vec: numeris::Vector<f64, 6> = state.block::<6, 1>(0, 0);
             let ydot_vec = |x: f64, y: &numeris::Vector<f64, 6>| -> numeris::Vector<f64, 6> {
-                let time: Instant = begin + Duration::from_seconds(x);
                 let pos_gcrf: Vector3 = y.block::<3, 1>(0, 0);
                 let vel_gcrf: Vector3 = y.block::<3, 1>(3, 0);
 
-                let (qgcrf2itrf, sun_gcrf, moon_gcrf) = interp.interp(&time).unwrap();
-                let qitrf2gcrf = qgcrf2itrf.conjugate();
-                let pos_itrf = qgcrf2itrf * pos_gcrf;
-
-                let mut accel = qitrf2gcrf
-                    * gravity.accel(
-                        &pos_itrf,
-                        settings.gravity_degree as usize,
-                        settings.gravity_order as usize,
-                    );
-
-                if settings.use_sun_gravity {
-                    accel += point_gravity(&pos_gcrf, &sun_gcrf, consts::MU_SUN);
-                }
-                if settings.use_moon_gravity {
-                    accel += point_gravity(&pos_gcrf, &moon_gcrf, consts::MU_MOON);
-                }
-
-                if settings.tide_model != TideModel::None {
-                    let sun_itrf = qgcrf2itrf * sun_gcrf;
-                    let moon_itrf = qgcrf2itrf * moon_gcrf;
-                    let deltas =
-                        tides::solid_tide_deltas(&sun_itrf, &moon_itrf, &time, settings.tide_model);
-                    accel += qitrf2gcrf
-                        * tides::tide_accel(
-                            &pos_itrf,
-                            &deltas,
-                            gravity.gravity_constant,
-                            gravity.radius,
-                        );
-                }
-
-                if settings.use_relativistic_correction {
-                    accel += gr_schwarzschild_accel(&pos_gcrf, &vel_gcrf, gravity.gravity_constant);
-                }
-
-                if let Some(props) = satprops {
-                    let ss: SimpleState = y.block::<6, 1>(0, 0);
-                    accel += solar_pressure_accel(&sun_gcrf, &pos_gcrf, &time, props, &ss);
-                    if pos_gcrf.norm() < 700.0e3 + consts::EARTH_RADIUS {
-                        let cd_a_over_m = props.cd_a_over_m(&time, &ss);
-                        if cd_a_over_m > 1e-6 {
-                            accel += drag_force(
-                                &pos_gcrf,
-                                &pos_itrf,
-                                &vel_gcrf,
-                                &time,
-                                cd_a_over_m,
-                                settings.use_spaceweather,
-                            );
-                        }
-                    }
-                    // Continuous thrust acceleration
-                    if let Some(a_thrust) = props.thrust_accel(&time, &pos_gcrf, &vel_gcrf) {
-                        accel += a_thrust;
-                    }
-                }
+                let (accel, _, _) = force_model(
+                    x,
+                    &pos_gcrf,
+                    &vel_gcrf,
+                    &begin,
+                    interp,
+                    gravity,
+                    settings,
+                    satprops,
+                    ForceEval::Accel,
+                );
 
                 let mut dy = numeris::Vector::<f64, 6>::zeros();
                 dy.set_block(0, 0, &vel_gcrf);
@@ -586,71 +599,17 @@ pub fn propagate<const C: usize, T: TimeLike>(
             let v0: Vector3 = state.block::<3, 1>(3, 0);
 
             let accel_fn = |x: f64, r: &Vector3, v: &Vector3| -> Vector3 {
-                let time: Instant = begin + Duration::from_seconds(x);
-                let (qgcrf2itrf, sun_gcrf, moon_gcrf) = interp.interp(&time).unwrap();
-                let qitrf2gcrf = qgcrf2itrf.conjugate();
-                let pos_itrf = qgcrf2itrf * *r;
-
-                let mut accel = qitrf2gcrf
-                    * gravity.accel(
-                        &pos_itrf,
-                        settings.gravity_degree as usize,
-                        settings.gravity_order as usize,
-                    );
-
-                if settings.use_sun_gravity {
-                    accel += point_gravity(r, &sun_gcrf, consts::MU_SUN);
-                }
-                if settings.use_moon_gravity {
-                    accel += point_gravity(r, &moon_gcrf, consts::MU_MOON);
-                }
-
-                if settings.tide_model != TideModel::None {
-                    let sun_itrf = qgcrf2itrf * sun_gcrf;
-                    let moon_itrf = qgcrf2itrf * moon_gcrf;
-                    let deltas =
-                        tides::solid_tide_deltas(&sun_itrf, &moon_itrf, &time, settings.tide_model);
-                    accel += qitrf2gcrf
-                        * tides::tide_accel(
-                            &pos_itrf,
-                            &deltas,
-                            gravity.gravity_constant,
-                            gravity.radius,
-                        );
-                }
-
-                if settings.use_relativistic_correction {
-                    accel += gr_schwarzschild_accel(r, v, gravity.gravity_constant);
-                }
-
-                if let Some(props) = satprops {
-                    // Reconstruct SimpleState from (r, v) for the force model's
-                    // state-aware methods (area/mass, drag coefficient, etc.)
-                    let mut ss: SimpleState = SimpleState::zeros();
-                    ss.set_block(0, 0, r);
-                    ss.set_block(3, 0, v);
-
-                    accel += solar_pressure_accel(&sun_gcrf, r, &time, props, &ss);
-
-                    if r.norm() < 700.0e3 + consts::EARTH_RADIUS {
-                        let cd_a_over_m = props.cd_a_over_m(&time, &ss);
-                        if cd_a_over_m > 1e-6 {
-                            accel += drag_force(
-                                r,
-                                &pos_itrf,
-                                v,
-                                &time,
-                                cd_a_over_m,
-                                settings.use_spaceweather,
-                            );
-                        }
-                    }
-
-                    if let Some(a_thrust) = props.thrust_accel(&time, r, v) {
-                        accel += a_thrust;
-                    }
-                }
-
+                let (accel, _, _) = force_model(
+                    x,
+                    r,
+                    v,
+                    &begin,
+                    interp,
+                    gravity,
+                    settings,
+                    satprops,
+                    ForceEval::Accel,
+                );
                 accel
             };
 


### PR DESCRIPTION
## Summary

Two internal refactor/perf changes to the high-precision propagator and Earth-gravity model. **No behavior change — end states are bit-identical and the full Rust test suite (including the ESA SP3 GPS regression) passes unchanged.**

### 1. Force model unified across all integrators

The RKV `ydot`, RODAS4 `ydot_vec`/`jac_fn`, and Gauss-Jackson `accel_fn` each carried a near-identical copy of the acceleration physics (gravity, Sun/Moon, solid tides, GR, SRP, drag, thrust) — ~200 lines duplicated four ways, where adding a force term meant editing every copy in lockstep.

- A single `force_model()` now holds the physics; each integrator closure is a thin adapter over its own state layout (`Matrix<6, C>` / `Vector<f64, 6>` / `(r, v)`).
- A `ForceEval` mode selector (`Accel` / `AccelAndPartials` / `PartialsOnly`) preserves each integrator's cost. Every call site passes a compile-time-constant mode and `force_model` is `#[inline]`, so the branches constant-fold away — no extra call, no runtime dispatch. The RODAS4 Jacobian path skips the tide/GR/SRP/thrust terms (no partials), so it does not regress.
- Drag altitude gate uses `norm_squared()` against a precomputed squared limit instead of `norm()`, dropping a sqrt from every force eval.

### 2. Earth gravity: coefficient table capped at the evaluation degree

The evaluator dispatches at degree ≤ 40 (divisor tables are 44×44), so higher coefficients were never used — yet the default EGM96 model (file degree 360) stored a 361×361 `DMatrix` (~1 MB).

- `Gravity::parse` now caps the stored table at degree 44 (`MAX_COEFF_DIM`). Drops EGM96 to ~15 KB and shrinks the column stride 361 → 44, keeping the strided S-coefficient reads `coeffs[(m-1, n)]` resident in L1.
- Coefficients for n,m ≤ 43 are untouched → bit-identical results. Microbenchmark shows ~5–15% faster `accel`/`accel_and_partials` on EGM96 and removes the cache-miss timing variance in the hot loop.

## Test plan

- [x] `cargo test` full suite with `SATKIT_DATA` + test vectors — zero failures
- [x] `earthgravity` unit tests 10/10
- [x] Force-model results verified bit-identical (benchmark sink values matched across the change)
- [x] `cargo fmt --all` clean
- [ ] Python suite not run (needs `pip install -e .` rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)