### PR TITLE
Fix update_datafiles(overwrite=true) skipping EOP/SW refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 
+## Unreleased
+
+### Fixed
+
+- **`update_datafiles(overwrite=true)` now actually re-downloads EOP/SW files.** The `If-Modified-Since` conditional-GET added in #99 was only ever reached on the `overwrite_if_exists=true` path (the `overwrite=false` path short-circuits on file existence). Because the request used the local file's mtime — set to *download* time, not the server's `Last-Modified` — the server returned `304 Not Modified` and the daily-updated `EOP-All.csv` / `SW-All.csv` were never refreshed. Removed the conditional-GET block so `download_file` unconditionally fetches when called; `overwrite=true` again forces a fresh copy. Resolves [#115](https://github.com/ssmichael1/satkit/issues/115). (The `%a` `strftime` specifier added alongside #99 is retained.)
+
+
 ## 0.18.0 - 2026-05-25
 
 ### Solid Earth tides (IERS 2010 §6.2 Step 1) in the high-precision propagator

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -68,36 +68,7 @@ pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -
     }
 
     let agent = ureq::Agent::new_with_defaults();
-    let mut req = agent.get(url);
-
-    // If we already have a local copy, ask the server to only send
-    // the body if it has changed since we wrote it.
-    let if_modified_since = fullpath
-        .metadata()
-        .ok()
-        .and_then(|m| m.modified().ok())
-        .and_then(|mtime| {
-            let unix = mtime
-                .duration_since(std::time::UNIX_EPOCH)
-                .ok()?
-                .as_secs_f64();
-            crate::time::Instant::from_unixtime(unix)
-                .strftime("%a, %d %b %Y %H:%M:%S GMT")
-                .ok()
-        });
-    if let Some(ref date) = if_modified_since {
-        req = req.header("If-Modified-Since", date.as_str());
-    }
-
-    let mut resp = req.call()?;
-
-    if resp.status().as_u16() == 304 {
-        println!(
-            "File {} unchanged on server; skipping download",
-            fname.to_str().unwrap()
-        );
-        return Ok(false);
-    }
+    let mut resp = agent.get(url).call()?;
 
     println!("Downloading {}", fname.to_str().unwrap());
     let mut dest = std::fs::File::create(fullpath)?;


### PR DESCRIPTION
## Summary

`update_datafiles(overwrite=true)` was not re-downloading the daily-updated EOP/SW data files, as reported in #115.

**Root cause:** The `If-Modified-Since` conditional-GET added in #99 is self-defeating given the control flow in `download_file` (`src/utils/download.rs`):

- When a file exists **and** `overwrite_if_exists == false`, the function returns early — so the `If-Modified-Since` block is **only ever reached when `overwrite_if_exists == true`**, exactly the case where the caller explicitly asked for a fresh copy.
- The EOP/SW refresh files always use `overwrite=true` (hardcoded in `download_from_url_json`, `src/utils/update_data.rs`).
- The request used the local file's **mtime**, which is set to *download* time (current time), not the server's `Last-Modified`. So the `If-Modified-Since` timestamp is always newer than the server's content date → server returns **304 Not Modified** → download skipped.

Net effect: `overwrite=true` became a no-op for any file already on disk, and `EOP-All.csv` / `SW-All.csv` never refreshed after the first download.

## Change

- Remove the conditional-GET block from `download_file` so it unconditionally fetches when called. This restores the pre-#99 behavior for this function; `overwrite=true` again forces a fresh copy.
- The `%a` `strftime` specifier added alongside #99 (`src/time/instantparse.rs`) is **retained** — it's standalone and harmless.
- CHANGELOG entry under `Unreleased › Fixed`.

Builds clean with `--features download`; `cargo fmt`-clean.

Resolves #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)