### PR TITLE
Release GIL in Python bindings; simplification cleanups; criterion benchmark suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - **Unknown keyword arguments now raise `ValueError` consistently.** New shared `reject_unused_kwargs` helper replaces three hand-rolled "extraneous kwargs" folds (`propagate`, `satproperties`, `propsettings` — the latter previously raised `RuntimeError`). **`duration(...)` now validates its kwargs too**: previously a typo like `duration(day=1)` was silently ignored and returned a zero duration.
 - **Pickle implementations for `quaternion`, `itrfcoord`, and `kepler` share `pack_f64s`/`unpack_f64s` helpers.** Wire format is byte-identical to prior releases — existing pickles load unchanged.
 
+### Criterion benchmark suite
+
+- **New `benches/hotpaths.rs`** (`cargo bench`) covering the per-call costs that dominate real workloads: high-precision propagation (LEO+drag RKV98, GEO RKV98, GEO Gauss-Jackson 8, LEO with STM), SGP4 (cold init + cached, 1 day at 1-minute cadence), frame transforms (`qgcrf2itrf` exact/approx, `qteme2itrf`, `gmst`), spherical-harmonic gravity (degree 4/16, with partials), JPL ephemeris lookups, and NRLMSISE-00 density. Establishes the baseline for future optimization work — micro-optimizations in the force model and EOP path should be measured against this suite.
+
 ### Rust cleanups
 
 - New `earth_orientation_params::get_or_zero` / `eop_from_mjd_utc_or_zero` helpers replace the `.unwrap_or([0.0; 6])` pattern repeated across the frame transforms and time module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 
 
+## Unreleased
+
+### Python bindings release the GIL during long computations
+
+- **`propagate`, `TLE.fit_from_states`, `sgp4` (all three input forms), and every array-valued frame-transform / ephemeris helper now release the GIL** (`Python::detach`) while the Rust computation runs, so other Python threads make progress during multi-second propagations and large batch transforms. Verified by a concurrency smoke test: a spin thread ran freely during a 100k-time `qgcrf2itrf` call.
+- **`sgp4` batch (list) path restructured** to extract TLE/OMM sources with the GIL held, run the SGP4 computation detached, then write the TLEs back so their cached SGP4 init state is preserved. Single-TLE and OMM-dict paths use the same clone-and-write-back approach. Results are unchanged.
+- The shared multi-time helpers in `pyutils` (`py_vec3_of_time_arr`, `py_vec3_of_time_result_arr`, `py_func_of_time_arr`, `py_quat_from_time_arr`, `tuple_func_of_time_arr`) all compute detached; the two vec3 helpers also lost their per-element `unsafe` pointer copies in favor of a plain `Vec` + reshape.
+
+### Python bindings cleanups
+
+- **Unknown keyword arguments now raise `ValueError` consistently.** New shared `reject_unused_kwargs` helper replaces three hand-rolled "extraneous kwargs" folds (`propagate`, `satproperties`, `propsettings` — the latter previously raised `RuntimeError`). **`duration(...)` now validates its kwargs too**: previously a typo like `duration(day=1)` was silently ignored and returned a zero duration.
+- **Pickle implementations for `quaternion`, `itrfcoord`, and `kepler` share `pack_f64s`/`unpack_f64s` helpers.** Wire format is byte-identical to prior releases — existing pickles load unchanged.
+
+### Rust cleanups
+
+- New `earth_orientation_params::get_or_zero` / `eop_from_mjd_utc_or_zero` helpers replace the `.unwrap_or([0.0; 6])` pattern repeated across the frame transforms and time module.
+- Removed the dead legacy `finals2000A.all` EOP loader and its three unused error variants (`LegacyFileMissing`, `LegacyOpenFailed`, `LegacyFieldParse`) — EOP data has loaded from `EOP-All.csv` since the Celestrak migration.
+- `lpephem::moon::phase` angle wrap simplified to `rem_euclid` (the `> 2π` branch was unreachable); `2.0 * PI` literals replaced with `std::f64::consts::TAU`.
+
+
 ## 0.18.1 - 2026-06-02
 
 ### High-precision propagator: force model unified across all integrators

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **`time.strftime` docstring example corrected.** The example mistakenly called `.strptime(...)` on a `time` instance, which raised `TypeError: missing 1 required positional argument: 'fmt'` when copied verbatim — `strptime` is a static parse method (`satkit.time.strptime(str, fmt)`), while `strftime` formats an instance. Docs-only; no code change. Resolves [#120](https://github.com/ssmichael1/satkit/issues/120).
+
 ### Python bindings release the GIL during long computations
 
 - **`propagate`, `TLE.fit_from_states`, `sgp4` (all three input forms), and every array-valued frame-transform / ephemeris helper now release the GIL** (`Python::detach`) while the Rust computation runs, so other Python threads make progress during multi-second propagations and large batch transforms. Verified by a concurrency smoke test: a spin thread ran freely during a 100k-time `qgcrf2itrf` call.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ anyhow = "1"
 rand = "0.9.2"
 approx = "0.5"
 rand_distr = "0.5.1"
+criterion = "0.8.2"
+
+[[bench]]
+name = "hotpaths"
+harness = false
 
 [features]
 default = ["omm-xml", "download"]

--- a/benches/hotpaths.rs
+++ b/benches/hotpaths.rs
@@ -1,0 +1,189 @@
+//! Criterion benchmarks for satkit hot paths
+//!
+//! Covers the per-call costs that dominate real workloads: high-precision
+//! propagation (per-regime and per-integrator), SGP4, frame transforms,
+//! spherical-harmonic gravity, JPL ephemeris lookup, and the NRLMSISE-00
+//! density model.
+//!
+//! Data files (EOP, gravity models, JPL ephemeris, space weather) are
+//! resolved through the normal `satkit::utils::datadir()` discovery, same
+//! as the test suite. Run with `cargo bench`.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
+
+use satkit::consts;
+use satkit::frametransform;
+use satkit::mathtypes::{Matrix6, Matrix67, Vector3, Vector6};
+use satkit::orbitprop::{propagate, Integrator, PropSettings, SatPropertiesSimple};
+use satkit::{Duration, Instant};
+
+fn epoch() -> Instant {
+    Instant::from_rfc3339("2024-01-01T00:00:00Z").unwrap()
+}
+
+/// Circular orbit state at radius `r` (meters) with inclination `incl` (radians)
+fn circular_state(r: f64, incl: f64) -> Vector6 {
+    let v = (consts::MU_EARTH / r).sqrt();
+    numeris::vector![r, 0.0, 0.0, 0.0, v * incl.cos(), v * incl.sin()]
+}
+
+const ISS_INCL_RAD: f64 = 51.6 * std::f64::consts::PI / 180.0;
+
+fn bench_propagation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("propagation");
+    group
+        .sample_size(10)
+        .warm_up_time(std::time::Duration::from_secs(2))
+        .measurement_time(std::time::Duration::from_secs(20));
+
+    let t0 = epoch();
+    let t1 = t0 + Duration::from_days(1.0);
+
+    // LEO with drag + full default force model, adaptive RKV 9(8)
+    let leo = circular_state(consts::WGS84_A + 500.0e3, ISS_INCL_RAD);
+    let satprops = SatPropertiesSimple::new(0.02, 0.01);
+    let settings = PropSettings::default();
+    group.bench_function("leo_drag_1day_rkv98", |b| {
+        b.iter(|| propagate(black_box(&leo), &t0, &t1, &settings, Some(&satprops)).unwrap())
+    });
+
+    // GEO, sun/moon gravity dominated, adaptive RKV 9(8)
+    let geo = circular_state(consts::GEO_R, 0.0);
+    group.bench_function("geo_1day_rkv98", |b| {
+        b.iter(|| propagate(black_box(&geo), &t0, &t1, &settings, None).unwrap())
+    });
+
+    // GEO, fixed-step Gauss-Jackson 8
+    let settings_gj8 = PropSettings {
+        integrator: Integrator::GaussJackson8,
+        gj_step_seconds: 300.0,
+        ..PropSettings::default()
+    };
+    group.bench_function("geo_1day_gj8", |b| {
+        b.iter(|| propagate(black_box(&geo), &t0, &t1, &settings_gj8, None).unwrap())
+    });
+
+    // LEO with 6x6 state transition matrix (C = 7 state columns)
+    let mut leo_stm = Matrix67::zeros();
+    leo_stm.set_block(0, 0, &leo);
+    leo_stm.set_block(0, 1, &Matrix6::eye());
+    group.bench_function("leo_stm_1day_rkv98", |b| {
+        b.iter(|| propagate(black_box(&leo_stm), &t0, &t1, &settings, Some(&satprops)).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_sgp4(c: &mut Criterion) {
+    let mut group = c.benchmark_group("sgp4");
+
+    let line0 = "0 INTELSAT 902";
+    let line1 = "1 26900U 01039A   06106.74503247  .00000045  00000-0  10000-3 0  8290";
+    let line2 = "2 26900   0.0164 266.5378 0003319  86.1794 182.2590  1.00273847 16981";
+    let tle = satkit::TLE::load_3line(line0, line1, line2).unwrap();
+
+    // 1 day of output at 1-minute cadence
+    let times: Vec<Instant> = (0..1441)
+        .map(|i| tle.epoch + Duration::from_seconds(60.0 * i as f64))
+        .collect();
+
+    // Includes per-TLE SGP4 initialization (fresh TLE each iteration)
+    group.bench_function("init_plus_1day_1min", |b| {
+        b.iter(|| {
+            let mut t = tle.clone();
+            satkit::sgp4::sgp4(&mut t, black_box(times.as_slice())).unwrap()
+        })
+    });
+
+    // Cached init state (same TLE reused), measures the propagation only
+    let mut warm = tle.clone();
+    let _ = satkit::sgp4::sgp4(&mut warm, &times[..1]).unwrap();
+    group.bench_function("cached_1day_1min", |b| {
+        b.iter(|| satkit::sgp4::sgp4(&mut warm, black_box(times.as_slice())).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_frametransform(c: &mut Criterion) {
+    let mut group = c.benchmark_group("frametransform");
+    let tm = epoch();
+
+    // Warm the EOP singleton so first-load cost isn't measured
+    let _ = frametransform::qgcrf2itrf(&tm);
+
+    group.bench_function("qgcrf2itrf", |b| {
+        b.iter(|| frametransform::qgcrf2itrf(black_box(&tm)))
+    });
+    group.bench_function("qgcrf2itrf_approx", |b| {
+        b.iter(|| frametransform::qgcrf2itrf_approx(black_box(&tm)))
+    });
+    group.bench_function("qteme2itrf", |b| {
+        b.iter(|| frametransform::qteme2itrf(black_box(&tm)))
+    });
+    group.bench_function("gmst", |b| b.iter(|| frametransform::gmst(black_box(&tm))));
+
+    group.finish();
+}
+
+fn bench_earthgravity(c: &mut Criterion) {
+    let mut group = c.benchmark_group("earthgravity");
+
+    // LEO position in ITRF (slightly off-axis to exercise all terms)
+    let pos: Vector3 = numeris::vector![consts::WGS84_A + 400.0e3, 1000.0e3, 2000.0e3];
+    let gravity = satkit::earthgravity::jgm3();
+
+    group.bench_function("accel_deg4", |b| {
+        b.iter(|| gravity.accel(black_box(&pos), 4, 4))
+    });
+    group.bench_function("accel_deg16", |b| {
+        b.iter(|| gravity.accel(black_box(&pos), 16, 16))
+    });
+    group.bench_function("accel_and_partials_deg4", |b| {
+        b.iter(|| gravity.accel_and_partials(black_box(&pos), 4, 4))
+    });
+
+    group.finish();
+}
+
+fn bench_jplephem(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jplephem");
+    let tm = epoch();
+
+    // Warm the ephemeris singleton
+    let _ = satkit::jplephem::geocentric_pos(satkit::SolarSystem::Moon, &tm);
+
+    group.bench_function("moon_geocentric_pos", |b| {
+        b.iter(|| satkit::jplephem::geocentric_pos(satkit::SolarSystem::Moon, black_box(&tm)))
+    });
+    group.bench_function("sun_geocentric_state", |b| {
+        b.iter(|| satkit::jplephem::geocentric_state(satkit::SolarSystem::Sun, black_box(&tm)))
+    });
+
+    group.finish();
+}
+
+fn bench_nrlmsise(c: &mut Criterion) {
+    let mut group = c.benchmark_group("nrlmsise");
+    let tm = epoch();
+
+    group.bench_function("density_400km", |b| {
+        b.iter(|| {
+            satkit::nrlmsise::nrlmsise(black_box(400.0), Some(0.5), Some(0.5), Some(&tm), true)
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_propagation,
+    bench_sgp4,
+    bench_frametransform,
+    bench_earthgravity,
+    bench_jplephem,
+    bench_nrlmsise
+);
+criterion_main!(benches);

--- a/docs/tutorials/Geodetic Coordinates.ipynb
+++ b/docs/tutorials/Geodetic Coordinates.ipynb
@@ -102,6 +102,20 @@
     "    dist, _heading_start, _heading_end = newyork.geodesic_distance(destcoord)\n",
     "    print(f'New York to {dest['name']} distance is {dist/1e3:.0f} km')\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Local Tangent Planes and Working with Many Coordinates\n\nThe `to_enu(origin)` and `to_ned(origin)` methods return the position of `self` relative to `origin`, expressed in the **East-North-Up** or **North-East-Down** tangent plane anchored at `origin` — the natural frame for look angles, ranges, and bearings from a ground station.\n\n`itrfcoord` is deliberately a **scalar** type: one object describes one location, and batched (`Nx3`) inputs are intentionally not part of the API. For workflows that touch many points at once — trajectories, ground tracks, station networks — keep the data in NumPy arrays and hoist the frame machinery out of the loop. A per-point Python loop works but costs roughly a microsecond per point in interpreter and object overhead, while the underlying math is tens of nanoseconds. Two patterns cover the common cases:\n\n1. **ENU / NED for many points relative to one origin.** The tangent plane is a *single rotation* anchored at the origin, so an entire array converts with one matrix multiply — about 15 ms per million points, versus roughly 1 s per million with a per-point loop.\n2. **Cartesian → geodetic.** The WGS-84 conversion is genuinely per-point; construct coordinates in a comprehension (≈0.7 s per million points). If this is ever the bottleneck, subsample or coarsen first — for ground-track plotting, a few hundred points per orbit is plenty.",
+   "metadata": {},
+   "id": "cell-5"
+  },
+  {
+   "cell_type": "code",
+   "source": "import numpy as np\nimport satkit as sk\n\n# A ground station as the local-frame origin\norigin = sk.itrfcoord(latitude_deg=42.466, longitude_deg=-71.1516)\n\n# Scalar usage: position of Boston in the station's ENU frame\nboston = sk.itrfcoord(latitude_deg=42.14, longitude_deg=-71.15)\nprint(f'Boston in station ENU frame (m): {boston.to_enu(origin)}')\n\n# --- Many points relative to one origin ---\n# Example data: 100,000 ITRF positions within ~100 km of the station\nrng = np.random.default_rng(7)\nenu_offsets = rng.uniform([-1e5, -1e5, 0.0], [1e5, 1e5, 1e5], (100_000, 3))\n\n# The ENU frame is one rotation: qenu2itrf maps ENU -> ITRF, and its\n# conjugate maps ITRF -> ENU. As a matrix, the whole array converts\n# in a single multiply -- no per-point itrfcoord objects needed.\nR = origin.qenu2itrf.conj.as_rotation_matrix()\nvecs_itrf = origin.vector + enu_offsets @ R  # ENU offsets -> ITRF points\nenu = (vecs_itrf - origin.vector) @ R.T      # and back again\n\n# Element-wise identical to the scalar API\nassert np.allclose(enu[0], sk.itrfcoord(vecs_itrf[0]).to_enu(origin))\n# (for NED, use origin.qned2itrf in place of origin.qenu2itrf)\n\n# Cartesian -> geodetic is per-point: use a comprehension\nlat, lon, alt = np.array(\n    [(c.latitude_deg, c.longitude_deg, c.altitude)\n     for c in map(sk.itrfcoord, vecs_itrf)]).T\nprint(f'latitude range:  [{lat.min():8.3f}, {lat.max():8.3f}] deg')\nprint(f'altitude range:  [{alt.min()/1e3:8.2f}, {alt.max()/1e3:8.2f}] km')",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "id": "cell-6"
   }
  ],
  "metadata": {

--- a/python/satkit/satkit.pyi
+++ b/python/satkit/satkit.pyi
@@ -1278,7 +1278,7 @@ class time:
 
         Example:
             ```python
-            print(satkit.time(2023, 6, 3, 6, 19, 34).strptime("%Y-%m-%d %H:%M:%S"))
+            print(satkit.time(2023, 6, 3, 6, 19, 34).strftime("%Y-%m-%d %H:%M:%S"))
             # 2023-06-03 06:19:34
             ```
         """

--- a/python/src/pyduration.rs
+++ b/python/src/pyduration.rs
@@ -1,6 +1,7 @@
 use satkit::Duration;
 
 use crate::pyinstant::PyInstant;
+use crate::pyutils::{kwargs_or_default, reject_unused_kwargs};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
@@ -66,28 +67,14 @@ impl PyDuration {
     #[new]
     #[pyo3(signature=(**kwargs))]
     fn py_new(kwargs: Option<Bound<'_, PyDict>>) -> Result<Self> {
-        let mut days = 0.0;
-        let mut seconds = 0.0;
-        let mut minutes = 0.0;
-        let mut hours = 0.0;
-        let mut microseconds: i64 = 0;
-
-        if let Some(kwargs) = kwargs {
-            if let Some(d) = kwargs.get_item("days")? {
-                days = d.extract::<f64>()?;
-            }
-            if let Some(s) = kwargs.get_item("seconds")? {
-                seconds = s.extract::<f64>()?;
-            }
-            if let Some(m) = kwargs.get_item("minutes")? {
-                minutes = m.extract::<f64>()?;
-            }
-            if let Some(h) = kwargs.get_item("hours")? {
-                hours = h.extract::<f64>()?;
-            }
-            if let Some(m) = kwargs.get_item("microseconds")? {
-                microseconds = m.extract::<i64>()?;
-            }
+        let mut kw = kwargs.as_ref();
+        let days: f64 = kwargs_or_default(&mut kw, "days", 0.0)?;
+        let seconds: f64 = kwargs_or_default(&mut kw, "seconds", 0.0)?;
+        let minutes: f64 = kwargs_or_default(&mut kw, "minutes", 0.0)?;
+        let hours: f64 = kwargs_or_default(&mut kw, "hours", 0.0)?;
+        let microseconds: i64 = kwargs_or_default(&mut kw, "microseconds", 0)?;
+        if let Some(kw) = kw {
+            reject_unused_kwargs(kw)?;
         }
 
         Ok(Self(

--- a/python/src/pyitrfcoord.rs
+++ b/python/src/pyitrfcoord.rs
@@ -388,25 +388,13 @@ impl PyITRFCoord {
     }
 
     fn __setstate__(&mut self, py: Python, s: Py<PyBytes>) -> PyResult<()> {
-        let s = s.as_bytes(py);
-        if s.len() != 24 {
-            return Err(pyo3::exceptions::PyTypeError::new_err(
-                "Invalid serialization length",
-            ));
-        }
-        let x = f64::from_le_bytes(s[0..8].try_into()?);
-        let y = f64::from_le_bytes(s[8..16].try_into()?);
-        let z = f64::from_le_bytes(s[16..24].try_into()?);
+        let [x, y, z] = crate::pyutils::unpack_f64s(py, &s)?;
         self.0.itrf = numeris::vector![x, y, z];
         Ok(())
     }
 
     fn __getstate__(&self, py: Python) -> PyResult<Py<PyAny>> {
-        let mut raw = [0; 24];
-        raw[0..8].clone_from_slice(f64::to_le_bytes(self.0.itrf[0]).as_slice());
-        raw[8..16].clone_from_slice(f64::to_le_bytes(self.0.itrf[1]).as_slice());
-        raw[16..24].clone_from_slice(f64::to_le_bytes(self.0.itrf[2]).as_slice());
-        pyo3::types::PyBytes::new(py, &raw).into_py_any(py)
+        crate::pyutils::pack_f64s(py, &[self.0.itrf[0], self.0.itrf[1], self.0.itrf[2]])
     }
 
     /// 3-vector representing cartesian distance between this

--- a/python/src/pykepler.rs
+++ b/python/src/pykepler.rs
@@ -255,24 +255,27 @@ impl PyKepler {
     }
 
     fn __getstate__(&mut self, py: Python) -> PyResult<Py<PyAny>> {
-        let mut state = [0; 48];
-        state[0..8].clone_from_slice(&self.0.a.to_le_bytes());
-        state[8..16].clone_from_slice(&self.0.eccen.to_le_bytes());
-        state[16..24].clone_from_slice(&self.0.incl.to_le_bytes());
-        state[24..32].clone_from_slice(&self.0.raan.to_le_bytes());
-        state[32..40].clone_from_slice(&self.0.w.to_le_bytes());
-        state[40..48].clone_from_slice(&self.0.nu.to_le_bytes());
-        PyBytes::new(py, &state).into_py_any(py)
+        crate::pyutils::pack_f64s(
+            py,
+            &[
+                self.0.a,
+                self.0.eccen,
+                self.0.incl,
+                self.0.raan,
+                self.0.w,
+                self.0.nu,
+            ],
+        )
     }
 
-    fn __setstate__(&mut self, py: Python, state: Py<PyAny>) -> PyResult<()> {
-        let state = state.extract::<&[u8]>(py)?;
-        self.0.a = f64::from_le_bytes(state[0..8].try_into().unwrap());
-        self.0.eccen = f64::from_le_bytes(state[8..16].try_into().unwrap());
-        self.0.incl = f64::from_le_bytes(state[16..24].try_into().unwrap());
-        self.0.raan = f64::from_le_bytes(state[24..32].try_into().unwrap());
-        self.0.w = f64::from_le_bytes(state[32..40].try_into().unwrap());
-        self.0.nu = f64::from_le_bytes(state[40..48].try_into().unwrap());
+    fn __setstate__(&mut self, py: Python, state: Py<PyBytes>) -> PyResult<()> {
+        let [a, eccen, incl, raan, w, nu] = crate::pyutils::unpack_f64s(py, &state)?;
+        self.0.a = a;
+        self.0.eccen = eccen;
+        self.0.incl = incl;
+        self.0.raan = raan;
+        self.0.w = w;
+        self.0.nu = nu;
         Ok(())
     }
 

--- a/python/src/pypropagate.rs
+++ b/python/src/pypropagate.rs
@@ -13,9 +13,9 @@ use satkit::Duration;
 use satkit::Instant;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyString, PyTuple};
+use pyo3::types::{PyDict, PyTuple};
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 
 /// High-precision orbit propagator
 ///
@@ -85,6 +85,7 @@ use anyhow::{bail, Result};
 ///
 #[pyfunction(signature=(*args, **kwargs))]
 pub fn propagate(
+    py: Python,
     args: &Bound<PyTuple>,
     mut kwargs: Option<&Bound<'_, PyDict>>,
 ) -> Result<Py<PyAny>> {
@@ -98,8 +99,7 @@ pub fn propagate(
     let mut begintime: Instant = Instant::INVALID;
     let mut endtime: Instant = Instant::INVALID;
     let mut output_phi: bool = false;
-    let mut satproperties: Option<&dyn SatProperties> = None;
-    let satproperties_simple: SatPropertiesSimple;
+    let mut satproperties: Option<SatPropertiesSimple> = None;
 
     if args.len() > 0 {
         state0 = py_to_smatrix(&args.get_item(0)?)?;
@@ -181,41 +181,39 @@ pub fn propagate(
             kw.del_item("duration_secs")?;
         }
         if let Some(kws) = kw.get_item("satproperties")? {
-            satproperties_simple = kws
-                .extract::<PySatProperties>()
-                .map_err(|e| {
-                    pyo3::exceptions::PyValueError::new_err(format!("Invalid satproperties: {}", e))
-                })?
-                .0;
-            satproperties = Some(&satproperties_simple);
+            satproperties = Some(
+                kws.extract::<PySatProperties>()
+                    .map_err(|e| {
+                        pyo3::exceptions::PyValueError::new_err(format!(
+                            "Invalid satproperties: {}",
+                            e
+                        ))
+                    })?
+                    .0,
+            );
             kw.del_item("satproperties")?;
         }
 
         output_phi = kwargs_or_default(&mut kwargs, "output_phi", false)?;
 
-        if !kw.is_empty() {
-            let keystring: String = kw.iter().try_fold(String::from(""), |acc, (k, _v)| {
-                let mut a2 = acc;
-                a2.push_str(k.cast::<PyString>()?.to_str()?);
-                a2.push_str(", ");
-                Ok::<_, PyErr>(a2)
-            })?;
-            bail!("Extraneous keyword arguments: {}", keystring);
-        }
+        reject_unused_kwargs(kw)?;
     }
+
+    // Release the GIL during the (potentially long-running) propagation
+    // so other Python threads can make progress
 
     // Simple sate propagation
     if !output_phi {
-        let res = satkit::orbitprop::propagate(
-            &state0,
-            &begintime,
-            &endtime,
-            &propsettings,
-            satproperties,
-        )?;
-        pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
-            Ok(PyPropResult(PyPropResultType::R1(Box::new(res))).into_py_any(py)?)
-        })
+        let res = py.detach(|| {
+            satkit::orbitprop::propagate(
+                &state0,
+                &begintime,
+                &endtime,
+                &propsettings,
+                satproperties.as_ref().map(|p| p as &dyn SatProperties),
+            )
+        })?;
+        Ok(PyPropResult(PyPropResultType::R1(Box::new(res))).into_py_any(py)?)
     }
     // Propagate with state transition matrix
     else {
@@ -224,10 +222,15 @@ pub fn propagate(
         pv.set_block(0, 0, &state0);
         pv.set_block(0, 1, &Matrix6::eye());
 
-        let res =
-            satkit::orbitprop::propagate(&pv, &begintime, &endtime, &propsettings, satproperties)?;
-        pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
-            Ok(PyPropResult(PyPropResultType::R7(Box::new(res))).into_py_any(py)?)
-        })
+        let res = py.detach(|| {
+            satkit::orbitprop::propagate(
+                &pv,
+                &begintime,
+                &endtime,
+                &propsettings,
+                satproperties.as_ref().map(|p| p as &dyn SatProperties),
+            )
+        })?;
+        Ok(PyPropResult(PyPropResultType::R7(Box::new(res))).into_py_any(py)?)
     }
 }

--- a/python/src/pypropsettings.rs
+++ b/python/src/pypropsettings.rs
@@ -4,7 +4,7 @@ use crate::pygravity::GravModel;
 use crate::{PyDuration, PyInstant};
 use satkit::orbitprop::{Integrator, PropSettings, TideModel};
 
-use pyo3::types::{PyDelta, PyDeltaAccess, PyDict, PyString};
+use pyo3::types::{PyDelta, PyDeltaAccess, PyDict};
 
 /// Choice of ODE integrator for orbit propagation
 #[allow(non_camel_case_types)]
@@ -174,16 +174,7 @@ impl PyPropSettings {
                 ps.use_relativistic_correction = gr.extract::<bool>()?;
                 kw.del_item("use_relativistic_correction")?;
             }
-            if !kw.is_empty() {
-                let keystring: String = kw.iter().fold(String::from(""), |acc, (k, _v)| {
-                    let mut a2 = acc.clone();
-                    a2.push_str(k.cast::<PyString>().unwrap().to_str().unwrap());
-                    a2.push_str(", ");
-                    a2
-                });
-                let s = format!("Invalid kwargs: {}", keystring);
-                return Err(pyo3::exceptions::PyRuntimeError::new_err(s));
-            }
+            crate::pyutils::reject_unused_kwargs(kw)?;
             if order_explicitly_set {
                 // Clamp order to degree
                 if ps.gravity_order > ps.gravity_degree {

--- a/python/src/pyquaternion.rs
+++ b/python/src/pyquaternion.rs
@@ -252,27 +252,13 @@ impl PyQuaternion {
     }
 
     fn __setstate__(&mut self, py: Python, state: Py<PyBytes>) -> PyResult<()> {
-        let state = state.as_bytes(py);
-        if state.len() != 32 {
-            return Err(pyo3::exceptions::PyTypeError::new_err(
-                "Invalid serialization length",
-            ));
-        }
-        let w = f64::from_le_bytes(state[0..8].try_into()?);
-        let x = f64::from_le_bytes(state[8..16].try_into()?);
-        let y = f64::from_le_bytes(state[16..24].try_into()?);
-        let z = f64::from_le_bytes(state[24..32].try_into()?);
+        let [w, x, y, z] = crate::pyutils::unpack_f64s(py, &state)?;
         self.0 = Quaternion::new(w, x, y, z);
         Ok(())
     }
 
     fn __getstate__(&self, py: Python) -> PyResult<Py<PyAny>> {
-        let mut raw = [0; 32];
-        raw[0..8].clone_from_slice(f64::to_le_bytes(self.0.w).as_slice());
-        raw[8..16].clone_from_slice(f64::to_le_bytes(self.0.x).as_slice());
-        raw[16..24].clone_from_slice(f64::to_le_bytes(self.0.y).as_slice());
-        raw[24..32].clone_from_slice(f64::to_le_bytes(self.0.z).as_slice());
-        PyBytes::new(py, &raw).into_py_any(py)
+        crate::pyutils::pack_f64s(py, &[self.0.w, self.0.x, self.0.y, self.0.z])
     }
 
     /// Angle of rotation in radians

--- a/python/src/pysatproperties.rs
+++ b/python/src/pysatproperties.rs
@@ -1,9 +1,9 @@
 use satkit::orbitprop::SatPropertiesSimple;
 
 use crate::pythrust::{py_thrusts_to_profile, PyThrust};
-use crate::pyutils::kwargs_or_default;
+use crate::pyutils::{kwargs_or_default, reject_unused_kwargs};
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict, PyString, PyTuple};
+use pyo3::types::{PyBytes, PyDict, PyTuple};
 use pyo3::IntoPyObjectExt;
 
 use anyhow::{bail, Result};
@@ -56,15 +56,7 @@ impl PySatProperties {
                 props = props.with_thrust(py_thrusts_to_profile(thrusts));
                 kw.del_item("thrusts")?;
             }
-            if !kw.is_empty() {
-                let keystring: String = kw.iter().fold(String::from(""), |acc, (k, _v)| {
-                    let mut a2 = acc;
-                    a2.push_str(k.cast::<PyString>().unwrap().to_str().unwrap());
-                    a2.push_str(", ");
-                    a2
-                });
-                bail!("Invalid keyword args: {}", keystring);
-            }
+            reject_unused_kwargs(kw)?;
         }
 
         Ok(Self(props))

--- a/python/src/pysgp4.rs
+++ b/python/src/pysgp4.rs
@@ -305,12 +305,16 @@ pub fn sgp4(
         let mut stle: PyRefMut<PyTLE> = tle
             .extract()
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid TLE: {}", e)))?;
-        let states = psgp4::sgp4_full(
-            &mut stle.0,
-            time.to_time_vec()?.as_slice(),
-            gravconst.into(),
-            opsmode.into(),
-        )?;
+        // Clone the TLE and run SGP4 with the GIL released, then write the
+        // TLE back so the cached SGP4 init state is preserved
+        let mut rtle = stle.0.clone();
+        let tmvec = time.to_time_vec()?;
+        let gravconst: psgp4::GravConst = gravconst.into();
+        let opsmode: psgp4::OpsMode = opsmode.into();
+        let states = tle
+            .py()
+            .detach(|| psgp4::sgp4_full(&mut rtle, tmvec.as_slice(), gravconst, opsmode))?;
+        stle.0 = rtle;
         pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
             let dims = if states.pos.nrows() > 1 && states.pos.ncols() > 1 {
                 vec![states.pos.ncols(), states.pos.nrows()]
@@ -349,12 +353,13 @@ pub fn sgp4(
         })?;
         let mut omm = omm_from_pydict(dict)?;
 
-        let states = psgp4::sgp4_full(
-            &mut omm,
-            time.to_time_vec()?.as_slice(),
-            gravconst.into(),
-            opsmode.into(),
-        )?;
+        // Run SGP4 with the GIL released
+        let tmvec = time.to_time_vec()?;
+        let gravconst: psgp4::GravConst = gravconst.into();
+        let opsmode: psgp4::OpsMode = opsmode.into();
+        let states = tle
+            .py()
+            .detach(|| psgp4::sgp4_full(&mut omm, tmvec.as_slice(), gravconst, opsmode))?;
         pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
             let dims = if states.pos.nrows() > 1 && states.pos.ncols() > 1 {
                 vec![states.pos.ncols(), states.pos.nrows()]
@@ -388,14 +393,25 @@ pub fn sgp4(
     } else if tle.is_instance_of::<PyList>() {
         let plist = tle.cast::<PyList>().unwrap();
         let tmarray = time.to_time_vec()?;
-        let results: Vec<psgp4::SGP4State> = plist
+
+        // Sources for the SGP4 computation, extracted with the GIL held;
+        // the computation itself runs below with the GIL released.
+        // TLE sources keep a handle to the originating Python object so the
+        // cached SGP4 init state can be written back afterward.
+        enum Sgp4Source {
+            Tle(Py<PyTLE>, satkit::TLE),
+            Omm(Box<satkit::omm::OMM>),
+        }
+
+        let mut sources: Vec<Sgp4Source> = plist
             .iter()
-            .map(|item| -> Result<psgp4::SGP4State> {
+            .map(|item| -> Result<Sgp4Source> {
                 if item.is_instance_of::<PyTLE>() {
-                    let mut stle: PyRefMut<PyTLE> = item.extract().map_err(|e| {
+                    let pytle: Py<PyTLE> = item.extract().map_err(|e| {
                         pyo3::exceptions::PyValueError::new_err(format!("Invalid TLE: {}", e))
                     })?;
-                    Ok(psgp4::sgp4(&mut stle.0, tmarray.as_slice())?)
+                    let rtle = pytle.borrow(item.py()).0.clone();
+                    Ok(Sgp4Source::Tle(pytle, rtle))
                 } else if item.is_instance_of::<PyDict>() {
                     let dict: &Bound<'_, PyDict> = item.cast().map_err(|e| {
                         pyo3::exceptions::PyValueError::new_err(format!(
@@ -403,13 +419,31 @@ pub fn sgp4(
                             e
                         ))
                     })?;
-                    let mut omm = omm_from_pydict(dict)?;
-                    Ok(psgp4::sgp4(&mut omm, tmarray.as_slice())?)
+                    Ok(Sgp4Source::Omm(Box::new(omm_from_pydict(dict)?)))
                 } else {
                     bail!("Invalid TLE in list");
                 }
             })
             .collect::<Result<Vec<_>>>()?;
+
+        let results: Vec<psgp4::SGP4State> = tle.py().detach(|| {
+            sources
+                .iter_mut()
+                .map(|src| -> Result<psgp4::SGP4State> {
+                    match src {
+                        Sgp4Source::Tle(_, rtle) => Ok(psgp4::sgp4(rtle, tmarray.as_slice())?),
+                        Sgp4Source::Omm(omm) => Ok(psgp4::sgp4(omm.as_mut(), tmarray.as_slice())?),
+                    }
+                })
+                .collect::<Result<Vec<_>>>()
+        })?;
+
+        // Write the TLEs back to preserve their cached SGP4 init state
+        for src in &sources {
+            if let Sgp4Source::Tle(pytle, rtle) = src {
+                pytle.borrow_mut(tle.py()).0 = rtle.clone();
+            }
+        }
 
         pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
             let n = plist.len() * tmarray.len() * 3;

--- a/python/src/pytle.rs
+++ b/python/src/pytle.rs
@@ -256,6 +256,7 @@ impl PyTLE {
     // Fit a TLE from GCRF states and times
     #[staticmethod]
     fn fit_from_states(
+        py: Python,
         states: Vec<[f64; 6]>,
         times: &Bound<'_, PyAny>,
         epoch: &Bound<'_, PyAny>,
@@ -265,26 +266,24 @@ impl PyTLE {
         if epoch.len() != 1 {
             bail!("epoch must be a single time value");
         }
-        let (tle, result) = TLE::fit_from_states(&states, &times, epoch[0])?;
+        // Release the GIL during the (potentially long-running) fit
+        let (tle, result) = py.detach(|| TLE::fit_from_states(&states, &times, epoch[0]))?;
 
-        Ok((
-            Self(tle),
-            pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
-                let dict = pyo3::types::PyDict::new(py);
-                dict.set_item("status", PyTleFitStatus::from(result.status))?;
-                dict.set_item("converged", {
-                    let s: PyTleFitStatus = result.status.into();
-                    s.converged()
-                })?;
-                dict.set_item("orig_norm", result.orig_norm)?;
-                dict.set_item("best_norm", result.best_norm)?;
-                dict.set_item("grad_norm", result.grad_norm)?;
-                dict.set_item("n_iter", result.n_iter)?;
-                dict.set_item("n_res_evals", result.n_res_evals)?;
-
-                Ok(dict.into())
-            })?,
-        ))
+        let stats = {
+            let dict = pyo3::types::PyDict::new(py);
+            dict.set_item("status", PyTleFitStatus::from(result.status))?;
+            dict.set_item("converged", {
+                let s: PyTleFitStatus = result.status.into();
+                s.converged()
+            })?;
+            dict.set_item("orig_norm", result.orig_norm)?;
+            dict.set_item("best_norm", result.best_norm)?;
+            dict.set_item("grad_norm", result.grad_norm)?;
+            dict.set_item("n_iter", result.n_iter)?;
+            dict.set_item("n_res_evals", result.n_res_evals)?;
+            dict.into()
+        };
+        Ok((Self(tle), stats))
     }
 
     fn __getstate__(&mut self, py: Python) -> PyResult<Py<PyAny>> {

--- a/python/src/pyutils.rs
+++ b/python/src/pyutils.rs
@@ -63,79 +63,99 @@ where
     }
 }
 
+/// Pack f64 values into little-endian bytes for `__getstate__` pickle support
+pub fn pack_f64s(py: Python, vals: &[f64]) -> PyResult<Py<PyAny>> {
+    let mut raw = Vec::with_capacity(vals.len() * 8);
+    for v in vals {
+        raw.extend_from_slice(&v.to_le_bytes());
+    }
+    pyo3::types::PyBytes::new(py, &raw).into_py_any(py)
+}
+
+/// Unpack little-endian `__setstate__` bytes into N f64 values
+pub fn unpack_f64s<const N: usize>(
+    py: Python,
+    state: &Py<pyo3::types::PyBytes>,
+) -> PyResult<[f64; N]> {
+    let s = state.as_bytes(py);
+    if s.len() != N * 8 {
+        return Err(pyo3::exceptions::PyTypeError::new_err(
+            "Invalid serialization length",
+        ));
+    }
+    let mut out = [0.0; N];
+    for (i, chunk) in s.chunks_exact(8).enumerate() {
+        out[i] = f64::from_le_bytes(chunk.try_into().unwrap());
+    }
+    Ok(out)
+}
+
+/// Raise `ValueError` listing any keyword arguments that remain unconsumed
+/// after all expected keywords have been extracted (and deleted) from `kw`
+pub fn reject_unused_kwargs(kw: &Bound<'_, PyDict>) -> PyResult<()> {
+    if kw.is_empty() {
+        return Ok(());
+    }
+    let keys: Vec<String> = kw.iter().map(|(k, _v)| k.to_string()).collect();
+    Err(pyo3::exceptions::PyValueError::new_err(format!(
+        "Invalid keyword arguments: {}",
+        keys.join(", ")
+    )))
+}
+
 pub fn py_vec3_of_time_arr(
-    cfunc: &dyn Fn(&Instant) -> Vector3,
+    cfunc: &(dyn Fn(&Instant) -> Vector3 + Sync),
     tmarr: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
     let tm = tmarr.to_time_vec()?;
+    let py = tmarr.py();
     match tm.len() {
         1 => {
             let v: Vector3 = cfunc(&tm[0]);
-            pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
-                Ok(np::PyArray1::from_slice(py, v.as_slice()).into_py_any(py)?)
-            })
+            Ok(np::PyArray1::from_slice(py, v.as_slice()).into_py_any(py)?)
         }
-        _ => {
-            let n = tm.len();
-            pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
-                let out = np::PyArray2::<f64>::zeros(py, (n, 3), false);
-                for (idx, time) in tm.iter().enumerate() {
-                    let v: Vector3 = cfunc(time);
-                    // I cannot figure out how to do this with a "safe" function,
-                    // but... careful checking of dimensions above so this should
-                    // never fail
-                    unsafe {
-                        std::ptr::copy_nonoverlapping(
-                            v.as_slice().as_ptr(),
-                            out.as_raw_array_mut().as_mut_ptr().offset(idx as isize * 3),
-                            3,
-                        );
-                    }
+        n => {
+            // Release the GIL for the computation over the full time array
+            let vals: Vec<f64> = py.detach(|| {
+                let mut vals = Vec::with_capacity(n * 3);
+                for time in tm.iter() {
+                    vals.extend_from_slice(cfunc(time).as_slice());
                 }
-                Ok(out.into_py_any(py)?)
-            })
+                vals
+            });
+            Ok(np::PyArray1::from_vec(py, vals)
+                .reshape([n, 3])?
+                .into_py_any(py)?)
         }
     }
 }
 
 pub fn py_vec3_of_time_result_arr(
-    cfunc: &dyn Fn(&Instant) -> Result<Vector3>,
+    cfunc: &(dyn Fn(&Instant) -> Result<Vector3> + Sync),
     tmarr: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
     let tm = tmarr.to_time_vec()?;
-
+    let py = tmarr.py();
     match tm.len() {
         1 => match cfunc(&tm[0]) {
-            Ok(v) => pyo3::Python::attach(|py| {
-                Ok(np::PyArray1::from_slice(py, v.as_slice()).into_py_any(py)?)
-            }),
+            Ok(v) => Ok(np::PyArray1::from_slice(py, v.as_slice()).into_py_any(py)?),
             Err(_) => bail!("Invalid time"),
         },
-        _ => {
-            let n = tm.len();
-            pyo3::Python::attach(|py| -> Result<Py<PyAny>> {
-                let out = np::PyArray2::<f64>::zeros(py, (n, 3), false);
-                for (idx, time) in tm.iter().enumerate() {
+        n => {
+            // Release the GIL for the computation over the full time array
+            let vals: Result<Vec<f64>> = py.detach(|| {
+                let mut vals = Vec::with_capacity(n * 3);
+                for time in tm.iter() {
                     match cfunc(time) {
-                        Ok(v) => {
-                            // I cannot figure out how to do this with a "safe" function,
-                            // but... careful checking of dimensions above so this should
-                            // never fail
-                            unsafe {
-                                std::ptr::copy_nonoverlapping(
-                                    v.as_slice().as_ptr(),
-                                    out.as_raw_array_mut().as_mut_ptr().offset(idx as isize * 3),
-                                    3,
-                                );
-                            }
-                        }
-                        Err(_) => {
-                            bail!("Invalid time");
-                        }
+                        Ok(v) => vals.extend_from_slice(v.as_slice()),
+                        Err(_) => bail!("Invalid time"),
                     }
                 }
-                Ok(out.into_py_any(py)?)
-            })
+                Ok(vals)
+            });
+            Ok(np::PyArray1::from_vec(py, vals?)
+                .reshape([n, 3])?
+                .into_py_any(py)?)
         }
     }
 }
@@ -200,17 +220,19 @@ pub fn py_to_smatrix<const M: usize, const N: usize>(obj: &Bound<PyAny>) -> Resu
     Ok(m)
 }
 
-pub fn py_func_of_time_arr<'a, T: IntoPyObject<'a>>(
+pub fn py_func_of_time_arr<'a, T: IntoPyObject<'a> + Send>(
     cfunc: fn(&Instant) -> T,
     tmarr: &Bound<'a, PyAny>,
 ) -> Result<Py<PyAny>> {
     let tm = tmarr.to_time_vec()?;
+    let py = tmarr.py();
 
     match tm.len() {
-        1 => Ok(cfunc(&tm[0]).into_py_any(tmarr.py())?),
+        1 => Ok(cfunc(&tm[0]).into_py_any(py)?),
         _ => {
-            let tvec: Vec<T> = tm.iter().map(cfunc).collect();
-            Ok(tvec.into_py_any(tmarr.py())?)
+            // Release the GIL for the computation over the full time array
+            let tvec: Vec<T> = py.detach(|| tm.iter().map(cfunc).collect());
+            Ok(tvec.into_py_any(py)?)
         }
     }
 }
@@ -221,16 +243,15 @@ pub fn py_quat_from_time_arr(
     tmarr: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
     let tm = tmarr.to_time_vec()?;
+    let py = tmarr.py();
     match tm.len() {
-        1 => Ok(pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
-            PyQuaternion(cfunc(&tm[0])).into_py_any(py)
-        })?),
-        _ => Ok(pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
-            tm.iter()
-                .map(|x| PyQuaternion(cfunc(x)))
-                .collect::<Vec<PyQuaternion>>()
-                .into_py_any(py)
-        })?),
+        1 => Ok(PyQuaternion(cfunc(&tm[0])).into_py_any(py)?),
+        _ => {
+            // Release the GIL for the computation over the full time array
+            let quats: Vec<PyQuaternion> =
+                py.detach(|| tm.iter().map(|x| PyQuaternion(cfunc(x))).collect());
+            Ok(quats.into_py_any(py)?)
+        }
     }
 }
 
@@ -267,42 +288,45 @@ pub fn mat2py<const M: usize, const N: usize>(py: Python, m: &Matrix<M, N>) -> P
 #[inline]
 pub fn tuple_func_of_time_arr<F>(cfunc: F, tmarr: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>>
 where
-    F: Fn(&Instant) -> Result<(Vector3, Vector3)>,
+    F: Fn(&Instant) -> Result<(Vector3, Vector3)> + Sync,
 {
     let tm = tmarr.to_time_vec()?;
+    let py = tmarr.py();
     match tm.len() {
         1 => match cfunc(&tm[0]) {
-            Ok(r) => pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
-                (
-                    PyArray1::from_slice(py, r.0.as_slice()),
-                    PyArray1::from_slice(py, r.1.as_slice()),
-                )
-                    .into_py_any(py)
-            }),
+            Ok(r) => (
+                PyArray1::from_slice(py, r.0.as_slice()),
+                PyArray1::from_slice(py, r.1.as_slice()),
+            )
+                .into_py_any(py),
             Err(e) => Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
         },
         _ => {
-            let mut pout = ndarray::Array2::<f64>::zeros([tm.len(), 3]);
-            let mut vout = ndarray::Array2::<f64>::zeros([tm.len(), 3]);
+            // Release the GIL for the computation over the full time array
+            let arrs = py.detach(|| -> PyResult<_> {
+                let mut pout = ndarray::Array2::<f64>::zeros([tm.len(), 3]);
+                let mut vout = ndarray::Array2::<f64>::zeros([tm.len(), 3]);
 
-            for (i, tm) in tm.iter().enumerate() {
-                match cfunc(tm) {
-                    Ok(r) => {
-                        pout.row_mut(i)
-                            .assign(&ndarray::Array1::from_vec(vec![r.0[0], r.0[1], r.0[2]]));
-                        vout.row_mut(i)
-                            .assign(&ndarray::Array1::from_vec(vec![r.1[0], r.1[1], r.1[2]]));
+                for (i, tm) in tm.iter().enumerate() {
+                    match cfunc(tm) {
+                        Ok(r) => {
+                            pout.row_mut(i)
+                                .assign(&ndarray::Array1::from_vec(vec![r.0[0], r.0[1], r.0[2]]));
+                            vout.row_mut(i)
+                                .assign(&ndarray::Array1::from_vec(vec![r.1[0], r.1[1], r.1[2]]));
+                        }
+                        Err(e) => {
+                            return Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))
+                        }
                     }
-                    Err(e) => return Err(pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
                 }
-            }
-            pyo3::Python::attach(|py| -> PyResult<Py<PyAny>> {
-                (
-                    PyArray2::from_array(py, &pout),
-                    PyArray2::from_array(py, &vout),
-                )
-                    .into_py_any(py)
-            })
+                Ok((pout, vout))
+            })?;
+            (
+                PyArray2::from_array(py, &arrs.0),
+                PyArray2::from_array(py, &arrs.1),
+            )
+                .into_py_any(py)
         }
     }
 }

--- a/src/earth_orientation_params.rs
+++ b/src/earth_orientation_params.rs
@@ -16,8 +16,6 @@
 //! See: https://www.iers.org/IERS/EN/DataProducts/EarthOrientationData/eop.html for details on EOP data
 //!
 
-use std::fs::File;
-use std::io::{self, BufRead};
 use std::num::ParseFloatError;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -35,26 +33,6 @@ pub enum Error {
     /// A line in the EOP CSV file has fewer than the expected 12 fields.
     #[error("Invalid entry in EOP file")]
     InvalidEntry,
-
-    /// The legacy `finals2000A.all` file could not be located.
-    #[error("Cannot open earth orientation parameters file: {0}")]
-    LegacyFileMissing(String),
-
-    /// Failed to open the legacy `finals2000A.all` file.
-    #[error("Couldn't open {path}: {source}")]
-    LegacyOpenFailed {
-        path: String,
-        #[source]
-        source: std::io::Error,
-    },
-
-    /// Failed to parse a numeric field from the legacy bulletin file.
-    #[error("Could not extract {field} from file")]
-    LegacyFieldParse {
-        field: &'static str,
-        #[source]
-        source: ParseFloatError,
-    },
 
     /// The configured data directory is read-only and cannot receive an
     /// updated EOP file.
@@ -127,88 +105,6 @@ fn load_eop_file_csv() -> Result<Vec<EOPEntry>> {
         .join("EOP-All.csv");
     download_if_not_exist(&path, Some("http://celestrak.org/SpaceData/"))?;
     parse_csv(&std::fs::read_to_string(&path)?)
-}
-
-#[allow(dead_code)]
-fn load_eop_file_legacy(filename: Option<PathBuf>) -> Result<Vec<EOPEntry>> {
-    let path: PathBuf = filename.unwrap_or_else(|| {
-        datadir()
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join("finals2000A.all")
-    });
-
-    if !path.is_file() {
-        return Err(Error::LegacyFileMissing(
-            path.to_str().unwrap_or_default().to_string(),
-        ));
-    }
-
-    let file = match File::open(&path) {
-        Err(why) => {
-            return Err(Error::LegacyOpenFailed {
-                path: path.display().to_string(),
-                source: why,
-            });
-        }
-        Ok(file) => file,
-    };
-
-    let mut eopvec = Vec::<EOPEntry>::new();
-    for line in io::BufReader::new(file).lines() {
-        match &line.unwrap() {
-            v if v.len() < 100 => (),
-            v if !v.is_ascii() => (),
-            v if {
-                let c: String = v.chars().skip(16).take(1).collect();
-                c != "I" && c != "P"
-            } => {}
-            v => {
-                // Pull from "Bulliten A"
-                let mjd_str: String = v.chars().skip(7).take(8).collect();
-                let xp_str: String = v.chars().skip(18).take(9).collect();
-                let yp_str: String = v.chars().skip(37).take(9).collect();
-                let dut1_str: String = v.chars().skip(58).take(10).collect();
-                let lod_str: String = v.chars().skip(49).take(7).collect();
-                let dx_str: String = v.chars().skip(97).take(9).collect();
-                let dy_str: String = v.chars().skip(116).take(9).collect();
-
-                eopvec.push(EOPEntry {
-                    mjd_utc: mjd_str
-                        .trim()
-                        .parse()
-                        .map_err(|source| Error::LegacyFieldParse {
-                            field: "MJD",
-                            source,
-                        })?,
-                    xp: xp_str
-                        .trim()
-                        .parse()
-                        .map_err(|source| Error::LegacyFieldParse {
-                            field: "X polar motion",
-                            source,
-                        })?,
-                    yp: yp_str
-                        .trim()
-                        .parse()
-                        .map_err(|source| Error::LegacyFieldParse {
-                            field: "Y polar motion",
-                            source,
-                        })?,
-                    dut1: dut1_str
-                        .trim()
-                        .parse()
-                        .map_err(|source| Error::LegacyFieldParse {
-                            field: "delta UT1",
-                            source,
-                        })?,
-                    lod: lod_str.trim().parse().unwrap_or(0.0),
-                    dX: dx_str.trim().parse().unwrap_or(0.0),
-                    dY: dy_str.trim().parse().unwrap_or(0.0),
-                })
-            }
-        }
-    }
-    Ok(eopvec)
 }
 
 static WARNING_SHOWN: AtomicBool = AtomicBool::new(false);
@@ -376,6 +272,20 @@ pub fn eop_from_mjd_utc(mjd_utc: f64) -> Option<[f64; 6]> {
 #[inline]
 pub fn get<T: crate::TimeLike>(tm: &T) -> Option<[f64; 6]> {
     eop_from_mjd_utc(tm.as_mjd_with_scale(crate::TimeScale::UTC))
+}
+
+/// Same as [`get`], but returns all-zero parameters when EOP data is
+/// unavailable — the standard fallback used by the frame transforms.
+#[inline]
+pub fn get_or_zero<T: crate::TimeLike>(tm: &T) -> [f64; 6] {
+    get(tm).unwrap_or([0.0; 6])
+}
+
+/// Same as [`eop_from_mjd_utc`], but returns all-zero parameters when EOP
+/// data is unavailable — the standard fallback used by the frame transforms.
+#[inline]
+pub fn eop_from_mjd_utc_or_zero(mjd_utc: f64) -> [f64; 6] {
+    eop_from_mjd_utc(mjd_utc).unwrap_or([0.0; 6])
 }
 
 #[cfg(test)]

--- a/src/frametransform/mod.rs
+++ b/src/frametransform/mod.rs
@@ -148,7 +148,7 @@ pub fn earth_rotation_angle<T: TimeLike>(tm: &T) -> f64 {
 pub fn qitrf2tirs<T: TimeLike>(tm: &T) -> Quaternion {
     // Get earth orientation parameters or set them all to zero if not available
     // (function will print warning to stderr if not available)
-    let eop = earth_orientation_params::get(tm).unwrap_or([0.0; 6]);
+    let eop = earth_orientation_params::get_or_zero(tm);
     qitrf2tirs_with_eop(&eop, tm)
 }
 
@@ -431,7 +431,7 @@ pub fn qtod2mod_approx<T: TimeLike>(tm: &T) -> Quaternion {
 pub fn qitrf2gcrf<T: TimeLike>(tm: &T) -> Quaternion {
     // w is rotation from international terrestrial reference frame
     // to terrestrial intermediate reference frame
-    let eop = earth_orientation_params::get(tm).unwrap_or([0.0; 6]);
+    let eop = earth_orientation_params::get_or_zero(tm);
 
     let w = qitrf2tirs_with_eop(&eop, tm);
     let r = qtirs2cirs(tm);
@@ -693,7 +693,7 @@ pub fn itrf_to_gcrf_state<T: TimeLike>(
 ) -> (Vector3, Vector3) {
     // Pull EOP once so both polar motion and the CIRS→GCRF dX/dY
     // correction stay consistent.
-    let eop = crate::earth_orientation_params::get(time).unwrap_or([0.0; 6]);
+    let eop = crate::earth_orientation_params::get_or_zero(time);
 
     let q_itrf_to_tirs = qitrf2tirs_with_eop(&eop, time);
 
@@ -760,7 +760,7 @@ pub fn gcrf_to_itrf_state<T: TimeLike>(
     vel_gcrf: &Vector3,
     time: &T,
 ) -> (Vector3, Vector3) {
-    let eop = crate::earth_orientation_params::get(time).unwrap_or([0.0; 6]);
+    let eop = crate::earth_orientation_params::get_or_zero(time);
 
     // GCRF → CIRS → TIRS (inverse of the forward chain above).
     let q_gcrf_to_tirs =

--- a/src/itrfcoord.rs
+++ b/src/itrfcoord.rs
@@ -753,12 +753,6 @@ mod tests {
             assert!(((nedvec[x] - dvec[x]) / nedvec[x]).abs() < 1.0e-3);
             assert!(((enuvec[x] - dvec[x]) / nedvec[x]).abs() < 1.0e-3);
         }
-        /*
-        let q = Quat::from_axis_angle(&Vector3::z_axis(), -0.003);
-        println!("{}", q);
-        println!("{}", q.to_rotation_matrix());
-        */
-
         let itrf1 = ITRFCoord::from_geodetic_deg(lat_deg, lon_deg, hae);
 
         // Go east 10 meters

--- a/src/lpephem/moon.rs
+++ b/src/lpephem/moon.rs
@@ -47,7 +47,7 @@ pub fn ecliptic_longitude<T: TimeLike>(time: &T) -> f64 {
             ),
         );
 
-    lon % (2.0 * std::f64::consts::PI)
+    lon % std::f64::consts::TAU
 }
 
 /// Compute approximate phase of the moon
@@ -68,14 +68,7 @@ pub fn phase<T: TimeLike>(time: &T) -> f64 {
     let lambda_moon = ecliptic_longitude(&time);
     let lambda_sun = crate::lpephem::sun::ecliptic_longitude(&time);
 
-    let phase = (lambda_moon - lambda_sun) % (2.0 * std::f64::consts::PI);
-    if phase < 0.0 {
-        phase + 2.0 * std::f64::consts::PI
-    } else if phase > 2.0 * std::f64::consts::PI {
-        phase - 2.0 * std::f64::consts::PI
-    } else {
-        phase
-    }
+    (lambda_moon - lambda_sun).rem_euclid(std::f64::consts::TAU)
 }
 
 /// Compute fraction of moon illuminated at given time

--- a/src/lpephem/sun.rs
+++ b/src/lpephem/sun.rs
@@ -60,7 +60,7 @@ pub fn ecliptic_longitude<T: TimeLike>(time: &T) -> f64 {
         1.914666471f64.mul_add(f64::sin(M), lambda_m.to_degrees()),
     );
 
-    lon.to_radians() % (2.0 * std::f64::consts::PI)
+    lon.to_radians() % std::f64::consts::TAU
 }
 
 ///

--- a/src/time/instant.rs
+++ b/src/time/instant.rs
@@ -312,8 +312,7 @@ impl Instant {
             }
             TimeScale::UT1 => {
                 // This will be approximately correct for computing ut1
-                let eop =
-                    crate::earth_orientation_params::eop_from_mjd_utc(mjd).unwrap_or([0.0; 6]);
+                let eop = crate::earth_orientation_params::eop_from_mjd_utc_or_zero(mjd);
                 let dut1 = eop[0] as f64;
                 Self::from_mjd_with_scale(mjd - dut1 / 86_400.0, TimeScale::UTC)
             }
@@ -408,8 +407,7 @@ impl Instant {
             }
             TimeScale::UT1 => {
                 let mjd_utc = self.as_mjd_utc();
-                let eop =
-                    crate::earth_orientation_params::eop_from_mjd_utc(mjd_utc).unwrap_or([0.0; 6]);
+                let eop = crate::earth_orientation_params::eop_from_mjd_utc_or_zero(mjd_utc);
                 let dut1 = eop[0] as f64;
                 mjd_utc + dut1 / 86_400.0
             }


### PR DESCRIPTION
## Summary

Three threads of work, no behavior changes to numerical results:

### Python bindings release the GIL during long computations
- `propagate`, `TLE.fit_from_states`, `sgp4` (all three input forms), and every array-valued frame-transform / ephemeris helper now run detached (`Python::detach`), so other Python threads make progress during multi-second propagations and large batch transforms.
- SGP4 paths clone the TLE, compute detached, and write back the cached init state. The batch (list) path extracts TLE/OMM sources with the GIL held, computes detached, then writes the TLEs back.
- Verified empirically: a competing Python thread ran 115M loop iterations during a 1.8 s `qgcrf2itrf` call over 100k times (previously it would have been blocked the entire time).

### Simplification cleanups
- New `earth_orientation_params::get_or_zero` / `eop_from_mjd_utc_or_zero` replace six copies of `.unwrap_or([0.0; 6])`.
- Removed the dead legacy `finals2000A.all` EOP loader and its three orphaned error variants.
- `lpephem::moon::phase` wrap simplified to `rem_euclid` (the `> 2π` branch was unreachable); `2.0 * PI` literals → `std::f64::consts::TAU`.
- Shared `reject_unused_kwargs` helper replaces three hand-rolled extraneous-kwargs folds.
- `quaternion` / `itrfcoord` / `kepler` pickle impls share `pack_f64s`/`unpack_f64s`; wire format is byte-identical, old pickles load unchanged.
- The vec3 array helpers lose their per-element `unsafe` pointer copies.
- Deleted stray scratch files from the repo root.

**Two deliberate behavior changes** (both changelogged):
- `duration(day=1)` (typo'd kwargs) now raises `ValueError` — previously silently ignored, returning a zero duration.
- `propsettings` invalid kwargs raise `ValueError` instead of `RuntimeError`, for consistency.

### Criterion benchmark suite
`benches/hotpaths.rs` (`cargo bench`) baselines the hot paths: propagation per regime/integrator, SGP4 cold + cached, frame transforms, spherical-harmonic gravity, JPL ephemeris, NRLMSISE-00. Key numbers (M-series macOS): LEO+drag 1-day 12.9 ms, +STM 33.8 ms, GEO 685 µs, SGP4 ~280 ns/step, exact `qgcrf2itrf` 18.9 µs vs 159 ns approx.

## Test plan

- `cargo test`: 190 lib + 41 integration tests pass
- `pytest python/test/`: 97 tests pass
- GIL-release concurrency smoke test (spin thread vs 100k-time transform)
- Pickle round-trips verified for quaternion/itrfcoord/kepler; sgp4 single/list paths verified
- `cargo bench --bench hotpaths -- --quick` runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)