### PR TITLE
Breaking API cleanup (0.21): typed sgp4 error, time(scale=), lambert::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@
   Additionally, the `SGP4Error` enum has moved from `sgp4::sgp4_impl` to
   `sgp4::error`; it remains re-exported at `satkit::sgp4::SGP4Error`, so the
   public path is unchanged.
+- **`LambertError` renamed to `lambert::Error`** to match the per-module
+  `module::Error` convention used everywhere else in the crate. The old name
+  remains as a `#[deprecated]` type alias, so existing code compiles with a
+  deprecation warning; update `satkit::lambert::LambertError` →
+  `satkit::lambert::Error`. A `lambert::Result<T>` alias was also added.
 - **`itrfcoord(...)`, `sgp4(...)`, and `satstate.propagate(...)` now reject
   unknown keyword arguments** instead of silently ignoring them. Previously a
   typo such as `itrfcoord(..., alttiude=100)` was dropped, leaving the ground

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@
 
 ### Changed
 
+- **BREAKING: `sgp4::Error::SatRecInit` now carries a typed `SGP4Error`
+  instead of a raw `i32`.** The raw Vallado init error code is mapped to the
+  corresponding `SGP4Error` variant (eccentricity, mean motion, perturbed
+  eccentricity, semi-latus rectum, orbit decay) at construction, so the
+  `Display` output is now a description rather than a bare number.
+  Additionally, the `SGP4Error` enum has moved from `sgp4::sgp4_impl` to
+  `sgp4::error`; it remains re-exported at `satkit::sgp4::SGP4Error`, so the
+  public path is unchanged.
 - **`itrfcoord(...)`, `sgp4(...)`, and `satstate.propagate(...)` now reject
   unknown keyword arguments** instead of silently ignoring them. Previously a
   typo such as `itrfcoord(..., alttiude=100)` was dropped, leaving the ground
@@ -49,6 +57,18 @@
   - `time.from_rfc3339`: `s` → `rfc3339`;  `time.from_datetime`: `tm` → `dt`
   - `time.strftime`: `fmt` → `format`;  `time.strptime`: `(s, fmt)` → `(date_string, format)`
   - `kepler.from_pv`: `(r, v)` → `(pos, vel)`
+=======
+### Changed
+
+- **BREAKING: `sgp4::Error::SatRecInit` now carries a typed `SGP4Error`
+  instead of a raw `i32`.** The raw Vallado init error code is mapped to the
+  corresponding `SGP4Error` variant (eccentricity, mean motion, perturbed
+  eccentricity, semi-latus rectum, orbit decay) at construction, so the
+  `Display` output is now a description rather than a bare number.
+  Additionally, the `SGP4Error` enum has moved from `sgp4::sgp4_impl` to
+  `sgp4::error`; it remains re-exported at `satkit::sgp4::SGP4Error`, so the
+  public path is unchanged.
+>>>>>>> c87373c (feat(sgp4)!: make Error::SatRecInit carry typed SGP4Error)
 
 
 ## 0.20.2 - 2026-07-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ### Added
 
+- **`scale=` keyword on the `time(...)` constructor** (Python): Gregorian
+  date/time components passed to `satkit.time(year, month, day[, hour, minute,
+  second])` can now be interpreted in an explicit time scale, e.g.
+  `satkit.time(2020, 1, 1, scale=satkit.timescale.TAI)`, mirroring the existing
+  `time.from_mjd(..., scale=...)` / `time.from_jd(..., scale=...)` API. The
+  keyword defaults to `satkit.timescale.UTC`, so all existing calls are
+  unchanged. Backed by a new scale-aware core constructor
+  `Instant::from_datetime_with_scale`.
 - **`SGP4InitArgs::from_mean_elements`** — a constructor that performs the
   rev/day → rad/min and degree → radian conversions from catalog units. Both
   the `TLE` and CCSDS `OMM` SGP4 sources now build their init args through it,
@@ -57,18 +65,6 @@
   - `time.from_rfc3339`: `s` → `rfc3339`;  `time.from_datetime`: `tm` → `dt`
   - `time.strftime`: `fmt` → `format`;  `time.strptime`: `(s, fmt)` → `(date_string, format)`
   - `kepler.from_pv`: `(r, v)` → `(pos, vel)`
-=======
-### Changed
-
-- **BREAKING: `sgp4::Error::SatRecInit` now carries a typed `SGP4Error`
-  instead of a raw `i32`.** The raw Vallado init error code is mapped to the
-  corresponding `SGP4Error` variant (eccentricity, mean motion, perturbed
-  eccentricity, semi-latus rectum, orbit decay) at construction, so the
-  `Display` output is now a description rather than a bare number.
-  Additionally, the `SGP4Error` enum has moved from `sgp4::sgp4_impl` to
-  `sgp4::error`; it remains re-exported at `satkit::sgp4::SGP4Error`, so the
-  public path is unchanged.
->>>>>>> c87373c (feat(sgp4)!: make Error::SatRecInit carry typed SGP4Error)
 
 
 ## 0.20.2 - 2026-07-03

--- a/python/src/pyinstant.rs
+++ b/python/src/pyinstant.rs
@@ -205,18 +205,36 @@ impl PyInstant {
         Self(Instant::UNIX_EPOCH)
     }
 
+    /// Create a satkit.time object
+    ///
+    /// Args:
+    ///     *args: Either no arguments (current time), a single string, or
+    ///         Gregorian components (year, month, day) or
+    ///         (year, month, day, hour, minute, second)
+    ///     scale (satkit.timescale, optional): Time scale in which the Gregorian
+    ///         components are interpreted. Default is satkit.timescale.UTC.
+    ///         Ignored when constructing from a string or with no arguments.
+    ///
     /// Returns:
     ///     satkit.time: Time object representing input date and time, or if no arguments, the current date and time
     #[new]
-    #[pyo3(signature=(*py_args))]
-    fn py_new(py_args: &Bound<'_, PyTuple>) -> Result<Self> {
+    #[pyo3(signature=(*py_args, scale=&PyTimeScale::UTC))]
+    fn py_new(py_args: &Bound<'_, PyTuple>, scale: &PyTimeScale) -> Result<Self> {
         if py_args.is_empty() {
             Ok(Self(Instant::now()))
         } else if py_args.len() == 3 {
             let year = py_args.get_item(0)?.extract::<i32>()?;
             let month = py_args.get_item(1)?.extract::<i32>()?;
             let day = py_args.get_item(2)?.extract::<i32>()?;
-            Self::from_date(year, month, day)
+            Ok(Self(Instant::from_datetime_with_scale(
+                year,
+                month,
+                day,
+                0,
+                0,
+                0.0,
+                scale.into(),
+            )?))
         } else if py_args.len() == 6 {
             let year = py_args.get_item(0)?.extract::<i32>()?;
             let month = py_args.get_item(1)?.extract::<i32>()?;
@@ -225,8 +243,14 @@ impl PyInstant {
             let min = py_args.get_item(4)?.extract::<i32>()?;
             let sec = py_args.get_item(5)?.extract::<f64>()?;
 
-            Ok(Self(Instant::from_datetime(
-                year, month, day, hour, min, sec,
+            Ok(Self(Instant::from_datetime_with_scale(
+                year,
+                month,
+                day,
+                hour,
+                min,
+                sec,
+                scale.into(),
             )?))
         } else if py_args.len() == 1 {
             let item = py_args.get_item(0)?;

--- a/src/lambert.rs
+++ b/src/lambert.rs
@@ -33,7 +33,7 @@ use std::f64::consts::PI;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum LambertError {
+pub enum Error {
     #[error("Time of flight must be positive, got {0}")]
     InvalidTof(f64),
     #[error("Position vectors must be non-zero")]
@@ -43,6 +43,12 @@ pub enum LambertError {
     #[error("Convergence failure for revolution {0}")]
     ConvergenceFailed(u32),
 }
+
+/// Result type for Lambert's problem.
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[deprecated(note = "use lambert::Error instead")]
+pub type LambertError = Error;
 
 /// Result of Lambert's problem: departure and arrival velocity vectors.
 pub type LambertSolution = (Vector3, Vector3);
@@ -74,18 +80,18 @@ pub fn lambert(
     tof: f64,
     mu: f64,
     prograde: bool,
-) -> Result<Vec<LambertSolution>, LambertError> {
+) -> Result<Vec<LambertSolution>> {
     if tof <= 0.0 {
-        return Err(LambertError::InvalidTof(tof));
+        return Err(Error::InvalidTof(tof));
     }
     if mu <= 0.0 {
-        return Err(LambertError::InvalidMu(mu));
+        return Err(Error::InvalidMu(mu));
     }
 
     let r1_norm = r1.norm();
     let r2_norm = r2.norm();
     if r1_norm < 1.0e-10 || r2_norm < 1.0e-10 {
-        return Err(LambertError::ZeroPosition);
+        return Err(Error::ZeroPosition);
     }
 
     // Chord and semiperimeter
@@ -144,7 +150,7 @@ pub fn lambert(
 
     // --- Zero-revolution solution ---
     let x0 = initial_guess_0rev(lambda, t_norm);
-    let x = householder(lambda, t_norm, x0, 0).ok_or(LambertError::ConvergenceFailed(0))?;
+    let x = householder(lambda, t_norm, x0, 0).ok_or(Error::ConvergenceFailed(0))?;
     solutions.push(build_velocity(
         &ir1, &ir2, &it1, &it2, r1_norm, r2_norm, lambda, gamma, rho, sigma, x,
     ));

--- a/src/sgp4/error.rs
+++ b/src/sgp4/error.rs
@@ -2,15 +2,61 @@
 
 use thiserror::Error;
 
+/// Typed SGP4 error codes, following the legacy Vallado convention.
+#[derive(Debug, Clone, Error, PartialEq, Eq, Copy)]
+pub enum SGP4Error {
+    #[error("Success")]
+    SGP4Success = 0,
+    #[error("Eccentricity > 1 or < 0")]
+    SGP4ErrorEccen = 1,
+    #[error("Mean motion < 0")]
+    SGP4ErrorMeanMotion = 2,
+    #[error("Perturbed Eccentricity > 1 or < 0")]
+    SGP4ErrorPerturbEccen = 3,
+    #[error("Semi-Latus Rectum < 0")]
+    SGP4ErrorSemiLatusRectum = 4,
+    #[error("Unused")]
+    SGP4ErrorUnused = 5,
+    #[error("Orbit Decayed")]
+    SGP4ErrorOrbitDecay = 6,
+}
+impl From<i32> for SGP4Error {
+    fn from(val: i32) -> Self {
+        match val {
+            0 => Self::SGP4Success,
+            1 => Self::SGP4ErrorEccen,
+            2 => Self::SGP4ErrorMeanMotion,
+            3 => Self::SGP4ErrorPerturbEccen,
+            4 => Self::SGP4ErrorSemiLatusRectum,
+            6 => Self::SGP4ErrorOrbitDecay,
+            _ => Self::SGP4ErrorUnused,
+        }
+    }
+}
+
+impl From<SGP4Error> for i32 {
+    fn from(val: SGP4Error) -> Self {
+        match val {
+            SGP4Error::SGP4ErrorEccen => 1,
+            SGP4Error::SGP4ErrorMeanMotion => 2,
+            SGP4Error::SGP4ErrorOrbitDecay => 6,
+            SGP4Error::SGP4ErrorPerturbEccen => 3,
+            SGP4Error::SGP4ErrorSemiLatusRectum => 4,
+            SGP4Error::SGP4ErrorUnused => -1,
+            SGP4Error::SGP4Success => 0,
+        }
+    }
+}
+
 /// Errors that can occur while initialising or evaluating SGP4.
 #[derive(Debug, Error)]
 pub enum Error {
     /// `sgp4init` returned a non-zero error code while constructing the
-    /// internal `SatRec`. The numeric code matches the legacy Vallado
-    /// convention (1 = eccentricity, 2 = mean motion, 3 = perturbed
-    /// eccentricity, 4 = semi-latus rectum, 6 = orbit decay).
-    #[error("SGP4 init error code {0}")]
-    SatRecInit(i32),
+    /// internal `SatRec`. Carries the typed [`SGP4Error`] describing the
+    /// failure (eccentricity, mean motion, perturbed eccentricity,
+    /// semi-latus rectum, or orbit decay).
+    #[error("SGP4 init error: {0}")]
+    SatRecInit(SGP4Error),
 
     /// Wraps an error surfaced by an [`SGP4Source`](super::SGP4Source)
     /// implementation while building [`SGP4InitArgs`](super::SGP4InitArgs)

--- a/src/sgp4/mod.rs
+++ b/src/sgp4/mod.rs
@@ -40,10 +40,9 @@ mod sgp4_impl;
 mod sgp4_lowlevel;
 mod sgp4init;
 
-pub use error::{Error, Result};
+pub use error::{Error, Result, SGP4Error};
 pub use sgp4_impl::sgp4;
 pub use sgp4_impl::sgp4_full;
-pub use sgp4_impl::SGP4Error;
 pub use sgp4_impl::SGP4State;
 
 /// Canonical inputs required to initialize an SGP4 `SatRec`.

--- a/src/sgp4/sgp4_impl.rs
+++ b/src/sgp4/sgp4_impl.rs
@@ -1,55 +1,9 @@
 use super::sgp4_lowlevel::sgp4_lowlevel; // propagator
 use super::sgp4init::sgp4init;
 
+use super::SGP4Error;
 use crate::mathtypes::DMatrix;
 use crate::TimeLike;
-
-use thiserror::Error;
-
-#[derive(Debug, Clone, Error, PartialEq, Eq, Copy)]
-pub enum SGP4Error {
-    #[error("Success")]
-    SGP4Success = 0,
-    #[error("Eccentricity > 1 or < 0")]
-    SGP4ErrorEccen = 1,
-    #[error("Mean motion < 0")]
-    SGP4ErrorMeanMotion = 2,
-    #[error("Perturbed Eccentricity > 1 or < 0")]
-    SGP4ErrorPerturbEccen = 3,
-    #[error("Semi-Latus Rectum < 0")]
-    SGP4ErrorSemiLatusRectum = 4,
-    #[error("Unused")]
-    SGP4ErrorUnused = 5,
-    #[error("Orbit Decayed")]
-    SGP4ErrorOrbitDecay = 6,
-}
-impl From<i32> for SGP4Error {
-    fn from(val: i32) -> Self {
-        match val {
-            0 => Self::SGP4Success,
-            1 => Self::SGP4ErrorEccen,
-            2 => Self::SGP4ErrorMeanMotion,
-            3 => Self::SGP4ErrorPerturbEccen,
-            4 => Self::SGP4ErrorSemiLatusRectum,
-            6 => Self::SGP4ErrorOrbitDecay,
-            _ => Self::SGP4ErrorUnused,
-        }
-    }
-}
-
-impl From<SGP4Error> for i32 {
-    fn from(val: SGP4Error) -> Self {
-        match val {
-            SGP4Error::SGP4ErrorEccen => 1,
-            SGP4Error::SGP4ErrorMeanMotion => 2,
-            SGP4Error::SGP4ErrorOrbitDecay => 6,
-            SGP4Error::SGP4ErrorPerturbEccen => 3,
-            SGP4Error::SGP4ErrorSemiLatusRectum => 4,
-            SGP4Error::SGP4ErrorUnused => -1,
-            SGP4Error::SGP4Success => 0,
-        }
-    }
-}
 
 pub struct SGP4State {
     pub pos: DMatrix<f64>,
@@ -224,7 +178,7 @@ pub fn sgp4_full<T: TimeLike>(
                 args.no,
                 args.nodeo,
             )
-            .map_err(super::Error::SatRecInit)?,
+            .map_err(|code| super::Error::SatRecInit(code.into()))?,
         );
     }
 

--- a/src/time/instant.rs
+++ b/src/time/instant.rs
@@ -663,6 +663,81 @@ impl Instant {
         Ok(Self { raw })
     }
 
+    /// Construct an instant from a given Gregorian date and time interpreted
+    /// in the specified time scale
+    ///
+    /// For `TimeScale::UTC` this is identical to [`Self::from_datetime`],
+    /// including leap-second handling.  For the uniform (non-leap-second) time
+    /// scales the Gregorian components are interpreted directly in that scale.
+    ///
+    /// # Arguments
+    /// * `year` - The year
+    /// * `month` - The month
+    /// * `day` - The day
+    /// * `hour` - The hour
+    /// * `minute` - The minute
+    /// * `second` - The second
+    /// * `scale` - The time scale in which the components are expressed
+    ///
+    /// # Returns
+    /// A new Instant object representing the given date and time, or error if invalid
+    pub fn from_datetime_with_scale(
+        year: i32,
+        month: i32,
+        day: i32,
+        hour: i32,
+        minute: i32,
+        second: f64,
+        scale: TimeScale,
+    ) -> Result<Self> {
+        // UTC preserves the exact existing behavior, including leap-second handling
+        if scale == TimeScale::UTC {
+            return Self::from_datetime(year, month, day, hour, minute, second);
+        }
+
+        // Bounds checking on input.  Uniform time scales have no leap seconds,
+        // so the second must be in [0, 60).
+        if !(1..=12).contains(&month) {
+            return Err(InstantError::InvalidMonth(month));
+        }
+        let max_day = if month == 2 {
+            if (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0) {
+                29
+            } else {
+                28
+            }
+        } else {
+            MDAYS[(month - 1) as usize]
+        };
+        if day < 1 || day > max_day as i32 {
+            return Err(InstantError::InvalidDay(day));
+        }
+        if !(0..=23).contains(&hour) {
+            return Err(InstantError::InvalidHour(hour));
+        }
+        if !(0..=59).contains(&minute) {
+            return Err(InstantError::InvalidMinute(minute));
+        }
+        if !(0.0..60.0).contains(&second) {
+            return Err(InstantError::InvalidSecondF(second));
+        }
+
+        use gregorian_coefficients as gc;
+        let h = month as i64 - gc::m;
+        let g = year as i64 + gc::y - (gc::n - h) / gc::n;
+        let f = (h - 1 + gc::n) % gc::n;
+        let e = (gc::p * g) / gc::r + day as i64 - 1 - gc::j;
+        let mut jd = e + (gc::s * f + gc::t) / gc::u;
+        jd = jd - (3 * ((g + gc::A) / 100)) / 4 - gc::C;
+
+        // Note, JD is the given julian day at noon on given date,
+        // so we subtract an additional 0.5 to get midnight
+        let jd = jd as f64 - 0.5;
+        let mjd = jd - 2400000.5 + (hour as f64 * 3600.0 + minute as f64 * 60.0 + second) / 86400.0;
+
+        Ok(Self::from_mjd_with_scale(mjd, scale))
+    }
+
     /// Current time
     ///
     /// # Returns


### PR DESCRIPTION
The breaking / pre-1.0 API cleanup batch, kept separate from the non-breaking polish in #122 (this PR is stacked on `ci-stubtest`; retarget to `main` once #122 merges). These are the items worth inflicting on downstream exactly once.

## Breaking
- **`sgp4::Error::SatRecInit(i32)` → `SatRecInit(SGP4Error)`** — the raw Vallado init code is mapped to the typed variant (eccentricity, mean motion, perturbed eccentricity, semi-latus rectum, orbit decay) at construction, so `Display` is now descriptive. `SGP4Error` moved from `sgp4::sgp4_impl` to `sgp4::error`; still re-exported at `satkit::sgp4::SGP4Error`, so the public path is unchanged.
- **`LambertError` → `lambert::Error`** — matches the `module::Error` convention used everywhere else (the last straggler from the thiserror migration). The old name stays as a `#[deprecated]` type alias, so downstream compiles with a warning; also added `lambert::Result<T>`.

## Added (non-breaking)
- **`scale=` keyword on `time(...)`** — Gregorian components can be interpreted in an explicit time scale, e.g. `satkit.time(2020, 1, 1, scale=satkit.timescale.TAI)`, mirroring `time.from_mjd(..., scale=...)`. Defaults to UTC, so all existing calls are unchanged. Backed by a new core `Instant::from_datetime_with_scale`.

## Deliberately dropped
- **OMM.epoch String→Instant** — OMM's JSON/XML wire has no native time type (EPOCH is an ISO-8601 string), so keeping the Rust field a `String` matches the wire; the typed-field win didn't justify the deserializer + Python-dict-contract work.

## Validation
Verified UTC−TAI = 37.0 s / UTC−GPS = 18.0 s for the `scale=` path; no-scale calls unchanged. 206 Rust tests, 114 Python tests, clippy `-D warnings`, `cargo fmt --check`, and `mypy.stubtest` all clean on the integrated branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)