### PR TITLE
Correct canonical physical constants and release 0.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## Unreleased
 
+
+## 0.20.4 - 2026-08-28
+
 ### Added
 
 - **`scale=` keyword on the `time(...)` constructor** (Python): Gregorian
@@ -34,6 +37,20 @@
 
 ### Fixed
 
+- **Canonical physical constants corrected and documented.** The lunar
+  gravitational parameter now uses the JPL DE440 value
+  (`4.902800118e12 m³/s²`) instead of the erroneous `4.9048695e12`; duplicate
+  lunar-GM literals in point-gravity tests now reference the shared constant.
+  The solar GM, WGS 84 flattening and rotation rate, nominal solar radius,
+  DE440 Earth–Moon mass ratio, and derived geosynchronous radius were updated
+  to their canonical values. `JGM3_J2` now uses the conventional positive `J2`
+  sign. Every constant in `consts.rs` now identifies its authoritative source.
+- **Relativity documentation now describes the Schwarzschild correction
+  accurately.** Removed misleading fixed position-drift-per-day estimates and
+  clarified that, for a state satisfying the Newtonian circular-orbit
+  relation, the post-Newtonian correction points radially outward while the
+  much larger Newtonian acceleration points inward. The corresponding test
+  name and Python type-stub documentation were corrected as well.
 - **Type stubs now type-check and match the runtime.** The `.pyi` files had
   never been checked and contained illegal overload-implementation blocks, a
   `time.__add__` overload group split by other methods, and `time`-as-annotation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "python"]
 
 [package]
 name = "satkit"
-version = "0.20.3"
+version = "0.20.4"
 edition = "2021"
 description = "Satellite Toolkit"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">= 3.10"
 authors = [{ name = "Steven Michael", email = "ssmichael@gmail.com" }]
 maintainers = [{ name = "Steven Michael", email = "ssmichael@gmail.com" }]
 readme = "README.md"
-version = "0.20.3"
+version = "0.20.4"
 license = "MIT OR Apache-2.0"
 description = "Satellite Orbital Dynamics Toolkit"
 keywords = [

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satkit-python"
-version = "0.20.3"
+version = "0.20.4"
 edition = "2021"
 publish = false
 

--- a/python/satkit/satkit.pyi
+++ b/python/satkit/satkit.pyi
@@ -3633,7 +3633,8 @@ class propsettings:
                 pre-tide releases).
             use_relativistic_correction: Include the Schwarzschild post-Newtonian
                 acceleration (IERS 2010 §10.3 Eq. 10.12, β=γ=1). Default is True.
-                ~1 m/day at GPS altitude if omitted; trivial computational cost.
+                Its position effect depends on the orbit, propagation arc, and
+                fitted parameters; computational cost is negligible.
             enable_interp: Store intermediate data that allows for fast high-precision interpolation of state between begin and end times. Default is True
             integrator: ODE integrator to use. Default is integrator.rkv98
             gj_step_seconds: Fixed step size (seconds) used by ``integrator.gauss_jackson8``.
@@ -3767,8 +3768,8 @@ class propsettings:
         """Include the Schwarzschild post-Newtonian acceleration.
 
         IERS 2010 §10.3 Eq. 10.12 with PPN β = γ = 1. Default is True.
-        Contributes ~1 m/day at GPS altitude if omitted; computational
-        cost is negligible.
+        Its position effect depends on the orbit, propagation arc, and fitted
+        parameters; computational cost is negligible.
         """
         ...
 

--- a/python/test/test_frames.py
+++ b/python/test/test_frames.py
@@ -333,8 +333,10 @@ class TestGravity:
         Reference gravity computations, using
         JGM3 model, with 16 terms, found at:
         http://icgem.gfz-potsdam.de/calcstat/
-        Outputs from above web page listed
-        in function below as reference values
+
+        The gravitation reference is from ICGEM. The total-gravity and
+        deflection baselines include centrifugal acceleration computed with
+        satkit's canonical WGS 84 Earth rotation rate.
         """
 
         reference_gravitation = 9.822206169031
@@ -342,7 +344,7 @@ class TestGravity:
         # Gravity deflection from normal along east-west and
         # north-south direction, in arcseconds
         reference_ew_deflection_asec = -1.283542043355
-        reference_ns_deflection_asec = -1.311709802440
+        reference_ns_deflection_asec = -1.311717134792
 
         latitude_deg = 42.4473
         longitude_deg = -71.2272

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,36 +1,103 @@
 #[allow(non_upper_case_globals)]
-///  WGS-84 semiparameter, in meters
-pub const WGS84_A: f64 = 6378137.0;
-///  WGS-84 flattening
-pub const WGS84_F: f64 = 0.003352810664747;
-/// WGS-84 Earth radius, meters
+/// WGS 84 semi-major axis, in meters.
+///
+/// Source: NGA, *World Geodetic System 1984*, defining parameters:
+/// <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
+pub const WGS84_A: f64 = 6_378_137.0;
+
+/// WGS 84 flattening, dimensionless (`1 / 298.257223563`).
+///
+/// Source: NGA, *World Geodetic System 1984*, defining parameters:
+/// <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
+pub const WGS84_F: f64 = 1.0 / 298.257_223_563;
+
+/// WGS 84 equatorial Earth radius, in meters (alias of [`WGS84_A`]).
+///
+/// Source: NGA, *World Geodetic System 1984*, defining parameters:
+/// <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
 pub const EARTH_RADIUS: f64 = WGS84_A;
-///  Gravitational parameter of Earth, m^3/s^2
-pub const MU_EARTH: f64 = 3.986004418E14;
-///  Gravitational parameter of Moon, m^3/s^2
-pub const MU_MOON: f64 = 4.9048695E12;
-///  Gravitational parameter of Sun, m^3/s^2
-pub const MU_SUN: f64 = 1.32712440018E20;
-///  Alternate name for gravitational parameter
+
+/// WGS 84 geocentric gravitational parameter of Earth (atmosphere included), in m^3/s^2.
+///
+/// Source: NGA, *World Geodetic System 1984*, defining parameters:
+/// <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
+pub const MU_EARTH: f64 = 3.986_004_418e14;
+
+/// Gravitational parameter of the Moon, in m^3/s^2.
+///
+/// Source: JPL DE440, Park et al. (2021), as tabulated by JPL Solar System Dynamics:
+/// <https://ssd.jpl.nasa.gov/astro_par.html>
+pub const MU_MOON: f64 = 4.902_800_118e12;
+
+/// Heliocentric gravitational parameter of the Sun, in m^3/s^2.
+///
+/// Source: JPL DE440, Park et al. (2021), as tabulated by JPL Solar System Dynamics:
+/// <https://ssd.jpl.nasa.gov/astro_par.html>
+pub const MU_SUN: f64 = 1.327_124_400_412_794_2e20;
+
+/// Alternate name for the WGS 84 gravitational parameter of Earth.
+///
+/// Source: alias of [`MU_EARTH`]; NGA WGS 84 defining parameters:
+/// <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
 pub const GM: f64 = MU_EARTH;
-///  Earth rotation rate, radians / second
-pub const OMEGA_EARTH: f64 = 7.292115090E-5;
-///  speed of light, m/s
-pub const C: f64 = 299792458.0;
-///  Astronomical unit, meters
-pub const AU: f64 = 1.495_978_707E11;
-///  Sun radius in meters
-pub const SUN_RADIUS: f64 = 695500000.0;
-///  Moon radius, meters
-pub const MOON_RADIUS: f64 = 1737400.0;
-///  Ratio of earth mass to moon mass
-pub const EARTH_MOON_MASS_RATIO: f64 = 81.300_568_221_497_22;
-///  Geosynchronous Distance
-pub const GEO_R: f64 = 42164172.58422766;
-///  JGM3 Gravitational parameter of Earth, m^3/s^2
-pub const JGM3_MU: f64 = 0.3986004415E+15;
-///  JGM3 Semimajor axis of Earth, m
-pub const JGM3_A: f64 = 0.6378136300E+07;
-///  JGM3 J2 term
-pub const JGM3_J2: f64 = -0.0010826360229829945;
-//jgm3_J2:f64 = -sqrt(5.) * -0.484169548456e-03;
+
+/// WGS 84 nominal mean angular velocity of Earth, in rad/s.
+///
+/// Source: NGA, *World Geodetic System 1984*, defining parameters:
+/// <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
+pub const OMEGA_EARTH: f64 = 7.292_115e-5;
+
+/// Speed of light in vacuum, in m/s (exact SI defining constant).
+///
+/// Source: BIPM, *The International System of Units (SI)*:
+/// <https://www.bipm.org/en/measurement-units>
+pub const C: f64 = 299_792_458.0;
+
+/// Astronomical unit, in meters (exact).
+///
+/// Source: IAU 2012 Resolution B1:
+/// <https://www.iau.org/static/resolutions/IAU2012_English.pdf>
+pub const AU: f64 = 149_597_870_700.0;
+
+/// IAU nominal solar photospheric radius, in meters (exact nominal conversion constant).
+///
+/// Source: IAU 2015 Resolution B3:
+/// <https://www.iau.org/common/Uploaded%20files/IAUGA2015-Resolution-B3-recommended-nominal-conversion.pdf>
+pub const SUN_RADIUS: f64 = 695_700_000.0;
+
+/// IAU lunar reference-sphere radius, in meters.
+///
+/// Source: IAU WGCCRE value, documented by the USGS Lunar Data Interoperability Standard:
+/// <https://psdi.astrogeology.usgs.gov/moon/standards/data_standards/>
+pub const MOON_RADIUS: f64 = 1_737_400.0;
+
+/// Earth-to-Moon mass ratio, dimensionless.
+///
+/// Source: ratio of the DE440 Earth and Moon gravitational parameters tabulated by JPL
+/// (`398600.435507 / 4902.800118`): <https://ssd.jpl.nasa.gov/astro_par.html>
+pub const EARTH_MOON_MASS_RATIO: f64 = 81.300_568_229_079_9;
+
+/// Geosynchronous circular-orbit radius, in meters.
+///
+/// Derived as `(MU_EARTH / OMEGA_EARTH^2)^(1/3)` from the NGA WGS 84 defining
+/// parameters: <https://earth-info.nga.mil/index.php?dir=wgs84&action=wgs84>
+pub const GEO_R: f64 = 42_164_172.931_157_24;
+
+/// JGM-3 gravitational parameter of Earth, in m^3/s^2.
+///
+/// Source: JGM-3 model, Tapley et al. (1996), *The Joint Gravity Model 3*:
+/// <https://doi.org/10.1029/94JB03002>
+pub const JGM3_MU: f64 = 3.986_004_415e14;
+
+/// JGM-3 reference semi-major axis of Earth, in meters.
+///
+/// Source: JGM-3 model, Tapley et al. (1996), *The Joint Gravity Model 3*:
+/// <https://doi.org/10.1029/94JB03002>
+pub const JGM3_A: f64 = 6_378_136.3;
+
+/// JGM-3 positive, unnormalized degree-two zonal coefficient `J2`, dimensionless.
+///
+/// The corresponding normalized Stokes coefficient is negative:
+/// `J2 = -sqrt(5) * Cbar20`. Source: JGM-3 model, Tapley et al. (1996),
+/// *The Joint Gravity Model 3*: <https://doi.org/10.1029/94JB03002>
+pub const JGM3_J2: f64 = 0.001_082_636_022_982_994_5;

--- a/src/orbitprop/point_gravity.rs
+++ b/src/orbitprop/point_gravity.rs
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn test_point_gravity_known() {
         // Moon at ~384,400 km from Earth center, satellite at GEO (~42,164 km)
-        let mu_moon = 4.9048695e12; // m³/s²
+        let mu_moon = crate::consts::MU_MOON;
         let s_moon = numeris::vector![384_400.0e3, 0.0, 0.0]; // Moon position
         let r_sat = numeris::vector![42_164.0e3, 0.0, 0.0]; // GEO satellite
 
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_point_gravity_partials() {
-        let mu = 4.9048695e12;
+        let mu = crate::consts::MU_MOON;
         let s = numeris::vector![384_400.0e3, 50_000.0e3, 20_000.0e3];
         let r = numeris::vector![42_164.0e3, 1000.0e3, 500.0e3];
         let dr = numeris::vector![10.0, 20.0, -15.0];

--- a/src/orbitprop/relativity.rs
+++ b/src/orbitprop/relativity.rs
@@ -1,11 +1,11 @@
 //! General-relativistic corrections to satellite motion.
 //!
 //! Currently implements only the Schwarzschild (post-Newtonian, β = γ = 1)
-//! term — the dominant relativistic effect on Earth-orbiting satellites
-//! (~1 m/day at GPS altitude, ~3 m/day at GEO). Lense-Thirring (frame
-//! dragging, ~1 mm/day) and de Sitter (geodetic precession, ~10 mm/day
-//! on the coordinate system) are sub-cm-class effects and not yet
-//! implemented.
+//! term, the dominant relativistic acceleration for Earth-orbiting satellites.
+//! Its effect on a propagated position depends on the orbit, arc length, and
+//! which initial conditions or other parameters are fitted, so it is not a
+//! fixed position drift per day. The smaller Lense-Thirring (frame-dragging)
+//! and de Sitter (geodetic-precession) terms are not yet implemented.
 //!
 //! Reference: IERS Conventions 2010 (IERS Technical Note 36), §10.3
 //! Eq. 10.12.
@@ -21,6 +21,10 @@ use crate::mathtypes::*;
 /// ```text
 /// a_GR = (GM / c² r³) · { (4 GM/r − v²) r  +  4 (r·v) v }
 /// ```
+///
+/// For a state satisfying the Newtonian circular-orbit relation
+/// `v² = GM / r` and `r·v = 0`, this correction points radially outward;
+/// it is added to the much larger inward Newtonian acceleration.
 ///
 /// Inputs and output are in SI units (m, m/s, m/s²) in the GCRF frame.
 pub fn gr_schwarzschild_accel(pos_gcrf: &Vector3, vel_gcrf: &Vector3, mu_e: f64) -> Vector3 {
@@ -75,16 +79,11 @@ mod tests {
     }
 
     #[test]
-    fn schwarzschild_points_inward_on_circular_orbit() {
+    fn schwarzschild_points_outward_on_circular_orbit() {
         // On a circular orbit r·v = 0, so only the radial term survives.
-        // 4GM/r − v² > 0 (since v² = GM/r on a circular orbit), so the
-        // acceleration is along +r̂ in the formula above — but the formula
-        // sign convention is that the static Newtonian term is + GM r̂ / r³,
-        // i.e. attractive uses a *negative* coefficient on r̂ elsewhere.
-        // Here the +r̂ result is the *correction* to that attractive force,
-        // and corresponds to a *stronger* attraction (perihelion precession
-        // is in the prograde direction). Check that the dot product with
-        // -r̂ is positive (i.e. the correction adds to the inward pull).
+        // With v² = GM/r, the radial coefficient is 3GM/r > 0, so the
+        // post-Newtonian correction points along +r̂ (outward). It is added
+        // to the much larger Newtonian acceleration, which points along -r̂.
         let r = consts::EARTH_RADIUS + 1000.0e3;
         let v = (consts::MU_EARTH / r).sqrt();
         let pos = numeris::vector![r, 0.0, 0.0];

--- a/src/orbitprop/settings.rs
+++ b/src/orbitprop/settings.rs
@@ -68,7 +68,8 @@ impl std::fmt::Display for Integrator {
 ///   (IERS 2010 §6.2.1 frequency-independent Love-number response).
 /// * `use_relativistic_correction` - Include the Schwarzschild
 ///   post-Newtonian acceleration (IERS 2010 §10.3 Eq. 10.12). Default is true.
-///   ~1 m/day at GPS altitude if omitted; trivial computational cost.
+///   Its position effect depends on the orbit, propagation arc, and fitted
+///   parameters; computational cost is negligible.
 /// * `enable_interp` - Do we enable interpolation of the state between begin and end times.  Default is true
 ///   slight computation savings if set to false
 /// * `integrator` - which Runge-Kutta integrator to use.  Default is RKV98


### PR DESCRIPTION
## Summary
- correct and document canonical physical constants, including the JPL DE440 lunar GM
- remove duplicate lunar GM literals from point-gravity tests
- correct Schwarzschild documentation and circular-orbit test wording
- update the changelog and bump Rust/Python package versions to 0.20.4

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features -- --skip solar_cycle_forecast::tests::test_download_and_parse

The skipped test performs a live network download and cannot resolve its host in the sandbox; all remaining unit, integration, property, Python-crate, and doctests pass.