### PR TITLE
Bump numeris to 0.5.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## Unreleased
 
+### Changed
+
+- **numeris 0.5.14 → 0.5.17.** Picks up the ODE fix that clamps the
+  initial step to the propagation span; no measurable change to any test
+  baseline or GMAT residual.
+
 ### Fixed
 
 - **Orbit propagator frame accuracy.** The propagator's precomputed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "satkit"
 
 
 [dependencies]
-numeris = { version = "0.5.14", features = ["serde", "ode"] }
+numeris = { version = "0.5.17", features = ["serde", "ode"] }
 thiserror = "2.0"
 ureq = { version = "3.1.2", optional = true }
 process_path = "0.1.4"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Seamless conversion between UTC, TAI, TT, TDB, UT1, and GPS time scales with ful
 SatKit uses [numeris](https://crates.io/crates/numeris) for all linear algebra (vectors, matrices, quaternions, ODE integration). If you also use nalgebra in your project, enable the `nalgebra` feature on numeris for zero-cost `From`/`Into` conversions between types:
 
 ```toml
-numeris = { version = "0.5.14", features = ["nalgebra"] }
+numeris = { version = "0.5.17", features = ["nalgebra"] }
 ```
 
 ### Cargo Features

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 satkit = { path = "..", features = ["download"] }
 pyo3 = { version = "0.29", features = ["extension-module", "anyhow"] }
 numpy = "0.29"
-numeris = { version = "0.5.14", features = ["serde", "ode"] }
+numeris = { version = "0.5.17", features = ["serde", "ode"] }
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde-pickle = "1.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //! feature on `numeris` for zero-cost `From`/`Into` conversions:
 //!
 //! ```toml
-//! numeris = { version = "0.5.7", features = ["nalgebra"] }
+//! numeris = { version = "0.5.17", features = ["nalgebra"] }
 //! ```
 //!
 //! ## Optional Features


### PR DESCRIPTION
Bumps `numeris` 0.5.14 → 0.5.17 in both crates and the doc/README examples (the crate docs still quoted 0.5.7).

Upstream changes since 0.5.14: `fix(ode): clamp initial step to |tf - t0|`, unsafe-confinement hardening, SIMD convolution perf. No measurable change: full Rust suite (`--features chrono`), 149 Python tests, and all 17 GMAT residuals are identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE