### PR TITLE
Harden gravity-degree, precompute-size and download inputs; smoke-test wheels; doc fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,11 @@ jobs:
       - name: Test
         run: cargo test --features chrono
 
+      # Network-dependent test, #[ignore]d so an offline `cargo test` passes;
+      # still exercised here where the runner has internet access.
+      - name: Test (network, solar cycle forecast download)
+        run: cargo test --features chrono --lib solar_cycle_forecast -- --ignored
+
       # Already covered by `cargo test` above; re-run with --nocapture so the
       # per-case max residual vs GMAT (tests/gmat/README.md) is visible in the log.
       - name: GMAT regression residuals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,52 @@
 
 ### Changed
 
+- **Gravity degree/order above 40 is now rejected.** The built-in
+  coefficient tables and evaluator are capped at degree 40
+  (`earthgravity::MAX_GRAVITY_DEGREE`); higher requests were accepted and
+  silently evaluated at 40 (degree 60 or 360 gave results bit-identical to
+  40). `PropSettings::set_gravity` returns `Error::InvalidGravityDegree`,
+  `propagate()` validates struct-literal settings on entry, and the Python
+  `gravity_degree`/`gravity_order` setters and constructor raise
+  `ValueError`. Anyone passing a degree above 40 must lower it; results
+  are unchanged for everyone else.
+- **Precomputed table size is capped.** `Precomputed::new_padded` (and
+  `propsettings.precompute_terms`) return `Error::PrecomputeTooLarge`
+  instead of allocating when the span/step would need more than
+  `MAX_PRECOMPUTE_ENTRIES` (16.8 M entries ≈ 1.3 GB, about 30 years at the
+  default 60 s step); non-finite padding returns
+  `Error::InvalidPrecomputePadding`. A 1 µs step previously consumed more
+  than 6 GB before being killed, and a denormal step wrapped to a silent
+  one-entry table.
+- **Data downloads:** the EOP and space-weather lazy-load fallbacks now use
+  `https://celestrak.org`; static-manifest directory keys must be a single
+  plain path component (`Error::InvalidManifestPath`) and refresh-manifest
+  URLs must be `https://` (`Error::InsecureManifestUrl`).
 - **numeris 0.5.14 → 0.5.17.** Picks up the ODE fix that clamps the
   initial step to the propagation span; no measurable change to any test
   baseline or GMAT residual.
 
+### CI
+
+- **Published wheels are smoke-tested.** cibuildwheel's `test-skip = "*"`
+  is replaced by an import + native-call check on every wheel that can run
+  on the build host (macOS x86_64 cross-builds are still skipped).
+- **Network-dependent test isolated.** `solar_cycle_forecast::
+  test_download_and_parse` is `#[ignore]`d so an offline `cargo test`
+  passes; CI runs it explicitly with `-- --ignored`.
+- `python/Cargo.toml` sets `doc = false` on the extension crate so
+  `cargo doc --workspace` no longer fails on the `satkit` name collision.
+
 ### Fixed
 
+- **Documentation:** the Gauss-Jackson 8 integrator docs said it had no
+  dense output (it supports quintic Hermite interpolation); the crate docs
+  described the license as MIT-only (it is MIT OR Apache-2.0);
+  CONTRIBUTING referenced Python 3.8, a nonexistent `python/test/test.py`,
+  and the retired ReadTheDocs site; `docs/index.md` advertised gravity
+  degree 360; the data-file docs described `leap-seconds.list` as a runtime
+  input (the leap-second table is compiled in, current through
+  2017-01-01).
 - **Orbit propagator frame accuracy.** The propagator's precomputed
   GCRF→ITRF table was built from the ~1 arcsec IAU-76/FK5 approximation
   (`qgcrf2itrf_approx`, no polar motion). That tilt of the gravity field
@@ -170,6 +210,13 @@
   - `time.strftime`: `fmt` → `format`;  `time.strptime`: `(s, fmt)` → `(date_string, format)`
   - `kepler.from_pv`: `(r, v)` → `(pos, vel)`
 
+
+## 0.20.3 - 2026-08-21
+
+Released with the panic-hardening audit (PR #124), the `lambert::Error` /
+typed `sgp4::Error::SatRecInit` API cleanups (PR #123) and the stubtest CI
+check (PR #122). Those entries were recorded under 0.20.4 above when 0.20.4
+followed a week later; see that section for details.
 
 ## 0.20.2 - 2026-07-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to Satkit! This document provides gu
 ### Prerequisites
 
 - **Rust**: Install the latest stable Rust toolchain from [rustup.rs](https://rustup.rs/)
-- **Python**: Python 3.8 or later for Python bindings testing
+- **Python**: Python 3.10 or later for Python bindings testing
 - **Git**: For version control
 
 ### Setting Up Your Development Environment
@@ -85,7 +85,7 @@ Thank you for your interest in contributing to Satkit! This document provides gu
 - Follow [PEP 8](https://pep8.org/) style guidelines
 - Provide type hints in `.pyi` stub files for IDE support
 - Include docstrings for all public functions and classes
-- Test Python bindings separately when making changes ; see `python/test/test.py`
+- Test Python bindings separately when making changes; see `python/test/` (`test_*.py`)
 
 ### Testing
 
@@ -156,7 +156,7 @@ pip install setuptools setuptools-rust setuptools-scm pytest
 pip install -e .
 
 # Run Python tests
-python -m pytest python/test/test.py
+python -m pytest python/test/
 ```
 
 When you're done developing, deactivate the virtual environment:
@@ -193,7 +193,7 @@ All pull requests are automatically tested via GitHub Actions:
 - **Test**: Runs full test suite on all platforms
 - **Lint**: Checks code style with clippy
 - **Format**: Verifies formatting with rustfmt
-- **Python**: Tests Python bindings on all supported versions (3.8-3.14)
+- **Python**: Tests Python bindings (editable install, Python 3.13) and checks the `.pyi` stubs with stubtest; release builds smoke-test each published wheel (3.10–3.14)
 
 Ensure all CI checks pass before requesting review.
 
@@ -213,7 +213,7 @@ Satkit is dual-licensed under the MIT license ([LICENSE-MIT](LICENSE-MIT)) and t
 - **Open a GitHub Issue** at [github.com/ssmichael1/satkit/issues](https://github.com/ssmichael1/satkit/issues) for questions about contributing
 - Email the maintainer: ssmichael@gmail.com
 - Review existing issues and pull requests for examples
-- Check the documentation at [satellite-toolkit.readthedocs.io](https://satellite-toolkit.readthedocs.io/)
+- Check the documentation at [satkit.dev](https://satkit.dev/)
 
 ## Resources
 

--- a/docs/getting-started/datafiles.md
+++ b/docs/getting-started/datafiles.md
@@ -2,7 +2,7 @@
 
 The `satkit` package relies upon a number of data files for certain calculations:
 
-- **leap-seconds.list** — A list of the UTC leap seconds since 1972. This is a common file on \*nix platforms and is used to keep track of the number of seconds (currently 37) that UTC lags TAI.
+- **leap-seconds.list** — Downloaded for reference only. The UTC↔TAI leap-second table that `satkit` actually uses is compiled into the library (current through the most recent leap second, 2017-01-01, when UTC began lagging TAI by 37 s); this file is not read at runtime, and a future leap second will require a new `satkit` release.
 
 - **linux_p1550p2650.440** — File containing the precise ephemerides of the planets and 400 large asteroids between the years 1550 and 2650, as modelled by the Jet Propulsion Laboratory (JPL). Note: this file is large (~100 MB) and may take a long time to download. Smaller alternatives (e.g. `lnxp1900p2053.421` from JPL's DE421 release at ~13 MB, 1900–2053) work as well — see [Selecting a JPL ephemeris file](#selecting-a-jpl-ephemeris-file) below.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -106,7 +106,7 @@ Plus ENU, NED, and geodesic distance (Vincenty) utilities.
 
 ### Force Models
 
-- **Earth gravity**: JGM2, JGM3, EGM96, ITU GRACE16 (spherical harmonics up to degree/order 360)
+- **Earth gravity**: JGM2, JGM3, EGM96, ITU GRACE16 (spherical harmonics up to degree/order 40)
 - **Third-body gravity**: Sun and Moon via JPL DE440/441 ephemerides
 - **Atmospheric drag**: NRLMSISE-00 (pure Rust) with automatic space weather data
 - **Solar radiation pressure**: Cannonball model with shadow function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,12 @@ build = [
     "cp310-*",
 ]
 skip = ["pp*", "*_i686", "*_s390x", "*_ppc64le", "*-musllinux*"]
-test-skip = "*"
+# Import + native-call smoke test on every wheel that can run on the build
+# host (same check as the sdist job in build.yml). macOS x86_64 wheels are
+# cross-compiled on the arm64 runner and cannot be executed there.
+test-requires = ["numpy"]
+test-command = "python -c \"import satkit as sk; t = sk.time(2024, 1, 1, 12, 0, 0); q = sk.quaternion.rotz(0.5); assert abs(q.angle - 0.5) < 1e-12; print('wheel OK:', sk.__version__, t)\""
+test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.macos]
 archs = ["x86_64", "arm64"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -7,6 +7,10 @@ publish = false
 [lib]
 name = "satkit"
 crate-type = ["cdylib"]
+# The extension module must be named `satkit`, which collides with the core
+# crate's docs under `cargo doc --workspace`; the bindings are documented via
+# the .pyi stubs instead.
+doc = false
 
 [dependencies]
 satkit = { path = "..", features = ["download"] }

--- a/python/satkit/satkit.pyi
+++ b/python/satkit/satkit.pyi
@@ -3621,8 +3621,8 @@ class propsettings:
         Args:
             abs_error: Maximum absolute value of error for any element in propagated state following ODE integration. Default is 1e-8
             rel_error: Maximum relative error of any element in propagated state following ODE integration. Default is 1e-8
-            gravity_degree: Maximum degree of spherical harmonic gravity model. Default is 4
-            gravity_order: Maximum order of spherical harmonic gravity model. Must be <= gravity_degree. Default is same as gravity_degree
+            gravity_degree: Maximum degree of spherical harmonic gravity model, at most 40 (``ValueError`` above that). Default is 4
+            gravity_order: Maximum order of spherical harmonic gravity model. Must be <= gravity_degree (and so at most 40). Default is same as gravity_degree
             gravity_model: Gravity model to use. Default is gravmodel.egm96
             use_spaceweather: Use space weather data when computing atmospheric density for drag forces. Default is True
             use_sun_gravity: Include sun third-body gravitational perturbation. Default is True

--- a/python/satkit/utils.pyi
+++ b/python/satkit/utils.pyi
@@ -24,7 +24,7 @@ def update_datafiles(**kwargs) -> None:
             - ``tab5.2d.txt`` : Coefficients for GCRS to GCRF conversion
             - ``SW-ALL.csv`` : Space weather data, updated daily
             - ``predicted-solar-cycle.json`` : NOAA/SWPC solar cycle forecast (~5 years of predicted F10.7)
-            - ``leap-seconds.txt`` : Leap seconds (UTC vs TAI)
+            - ``leap-seconds.list`` : Leap seconds (UTC vs TAI); reference only — the runtime table is compiled in
             - ``EOP-All.csv`` : Earth orientation parameters, updated daily
             - ``linux_p1550p2650.440`` : JPL Ephemeris version 440 (~ 100 MB)
 

--- a/python/src/mod_utils.rs
+++ b/python/src/mod_utils.rs
@@ -25,7 +25,7 @@ use anyhow::Result;
 /// * tab5.2b.txt :: Coefficients for GCRS to GCRF conversion
 /// * tab5.2d.txt :: Coefficients for GCRS to GCRF conversion
 /// * SW-All.csv :: Space weather data, updated daily
-/// * leap-seconds.txt :: Leap seconds (UTC vs TAI)
+/// * leap-seconds.list :: Leap seconds (UTC vs TAI); reference only, the runtime table is compiled in
 /// * EOP_All.csv :: Earth orientation parameters,  updated daily
 /// * linux_p1550p2650.440 :: JPL Ephemeris version 440 (~ 100 MB)
 ///

--- a/python/src/pypropsettings.rs
+++ b/python/src/pypropsettings.rs
@@ -97,6 +97,18 @@ impl From<TideModel> for PyTideModel {
 #[derive(Clone, Debug)]
 pub struct PyPropSettings(pub PropSettings);
 
+/// Reject degrees the evaluator cannot honour (it would otherwise silently
+/// evaluate at the maximum). Mirrors `PropSettings::set_gravity`.
+fn check_gravity_degree(val: u16) -> PyResult<u16> {
+    use satkit::earthgravity::MAX_GRAVITY_DEGREE;
+    if val > MAX_GRAVITY_DEGREE {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "gravity degree/order {val} exceeds the maximum supported value ({MAX_GRAVITY_DEGREE})"
+        )));
+    }
+    Ok(val)
+}
+
 #[pymethods]
 impl PyPropSettings {
     #[new]
@@ -114,7 +126,7 @@ impl PyPropSettings {
                 kw.del_item("rel_error")?;
             }
             if let Some(gravdegree) = kw.get_item("gravity_degree")? {
-                ps.gravity_degree = gravdegree.extract::<u16>()?;
+                ps.gravity_degree = check_gravity_degree(gravdegree.extract::<u16>()?)?;
                 kw.del_item("gravity_degree")?;
             }
             if let Some(gravorder) = kw.get_item("gravity_order")? {
@@ -219,7 +231,7 @@ impl PyPropSettings {
 
     #[setter(gravity_degree)]
     fn set_gravity_degree(&mut self, val: u16) -> PyResult<()> {
-        self.0.gravity_degree = val;
+        self.0.gravity_degree = check_gravity_degree(val)?;
         if self.0.gravity_order > val {
             self.0.gravity_order = val;
         }
@@ -233,6 +245,7 @@ impl PyPropSettings {
 
     #[setter(gravity_order)]
     fn set_gravity_order(&mut self, val: u16) -> PyResult<()> {
+        check_gravity_degree(val)?;
         if val > self.0.gravity_degree {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "gravity_order must be <= gravity_degree",

--- a/python/src/pypropsettings.rs
+++ b/python/src/pypropsettings.rs
@@ -26,7 +26,8 @@ pub enum PyIntegrator {
     rodas4 = 5,
     /// Gauss-Jackson 8 — 8th-order fixed-step multistep predictor-corrector
     /// for high-precision orbit propagation. Requires setting
-    /// `gj_step_seconds` on the propsettings. No STM or dense output support.
+    /// `gj_step_seconds` on the propsettings. Supports dense output
+    /// (quintic Hermite interpolation); no STM support.
     gauss_jackson8 = 6,
 }
 

--- a/python/test/test_error_handling.py
+++ b/python/test/test_error_handling.py
@@ -107,3 +107,24 @@ class TestNonContiguousInput:
         s = sk.satstate(t0, np.array([7.0e6, 0, 0]), np.array([0, 7.5e3, 0]))
         s.set_pos_uncertainty(np.ones(9)[::3], sk.frame.RTN)
         assert s.cov is not None
+
+    def test_gravity_degree_above_max_rejected(self):
+        # Degrees above 40 used to be accepted and silently evaluated at 40.
+        s = sk.propsettings()
+        s.gravity_degree = 40
+        s.gravity_order = 40
+        with pytest.raises(ValueError):
+            s.gravity_degree = 41
+        with pytest.raises(ValueError):
+            s.gravity_order = 41
+        with pytest.raises(ValueError):
+            sk.propsettings(gravity_degree=360, gravity_order=360)
+        assert (s.gravity_degree, s.gravity_order) == (40, 40)
+
+    def test_precompute_table_size_cap(self):
+        # A tiny step would need billions of entries; must raise, not OOM.
+        s = sk.propsettings()
+        t0 = sk.time(2023, 5, 16, 20, 0, 0)
+        with pytest.raises(RuntimeError, match="entries"):
+            s.precompute_terms(t0, t0 + sk.duration.from_hours(1), 1e-6)
+

--- a/src/earth_orientation_params.rs
+++ b/src/earth_orientation_params.rs
@@ -103,7 +103,7 @@ fn load_eop_file_csv() -> Result<Vec<EOPEntry>> {
     let path = datadir()
         .unwrap_or_else(|_| PathBuf::from("."))
         .join("EOP-All.csv");
-    download_if_not_exist(&path, Some("http://celestrak.org/SpaceData/"))?;
+    download_if_not_exist(&path, Some("https://celestrak.org/SpaceData/"))?;
     parse_csv(&std::fs::read_to_string(&path)?)
 }
 
@@ -162,7 +162,7 @@ pub fn update() -> Result<()> {
         return Err(Error::DataDirReadOnly);
     }
 
-    let url = "http://celestrak.org/SpaceData/EOP-All.csv";
+    let url = "https://celestrak.org/SpaceData/EOP-All.csv";
     download_file(url, &d, true)?;
 
     EOP.set(load_eop_file_csv()?);

--- a/src/earthgravity.rs
+++ b/src/earthgravity.rs
@@ -64,6 +64,17 @@ type DivisorTable = Matrix<44, 44>;
 /// hot loops. Capping the stored table keeps the working set in L1.
 const MAX_COEFF_DIM: usize = 44;
 
+/// Highest spherical-harmonic degree (and order) the evaluator supports.
+///
+/// The built-in coefficient tables are capped at [`MAX_COEFF_DIM`] rows and
+/// the accelerator dispatches on degree ≤ 40; requests above this are
+/// rejected by [`PropSettings::set_gravity`](crate::orbitprop::PropSettings::set_gravity)
+/// and at [`propagate`](crate::orbitprop::propagate) entry rather than
+/// silently clamped. (EGM96 itself is defined to degree 360; supporting
+/// that would need heap-allocated Legendre tables — see the note on
+/// `MAX_COEFF_DIM`.)
+pub const MAX_GRAVITY_DEGREE: u16 = 40;
+
 use std::sync::OnceLock;
 
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,8 @@
 //!
 //! ## License
 //!
-//! MIT License - See LICENSE file for details
+//! Dual-licensed under MIT OR Apache-2.0, at your option — see the
+//! `LICENSE-MIT` and `LICENSE-APACHE` files for details.
 
 #![warn(clippy::all, clippy::use_self, clippy::cargo)]
 #![allow(clippy::multiple_crate_versions)]

--- a/src/orbitprop/error.rs
+++ b/src/orbitprop/error.rs
@@ -87,6 +87,28 @@ pub enum Error {
     #[error("Gravity order ({order}) must be ≤ degree ({degree})")]
     InvalidGravityOrder { order: u16, degree: u16 },
 
+    /// Returned when the requested gravity degree exceeds what the built-in
+    /// coefficient tables and evaluator support
+    /// ([`MAX_GRAVITY_DEGREE`](crate::earthgravity::MAX_GRAVITY_DEGREE)).
+    /// Previously such requests were silently evaluated at the maximum.
+    #[error("Gravity degree ({degree}) exceeds the maximum supported degree ({max})")]
+    InvalidGravityDegree { degree: u16, max: u16 },
+
+    /// Returned by [`Precomputed::new_padded`](crate::orbitprop::Precomputed::new_padded)
+    /// when the padding is not a finite number.
+    #[error("Precomputed table padding must be finite, got {padding}")]
+    InvalidPrecomputePadding { padding: f64 },
+
+    /// Returned by [`Precomputed::new_padded`](crate::orbitprop::Precomputed::new_padded)
+    /// when the span / step combination would need more table entries than
+    /// [`MAX_PRECOMPUTE_ENTRIES`](crate::orbitprop::MAX_PRECOMPUTE_ENTRIES)
+    /// (≈1.3 GB). Use a larger step or a shorter span.
+    #[error(
+        "Precomputed table would need {entries} entries (max {max}); \
+         use a larger interpolation step or a shorter propagation span"
+    )]
+    PrecomputeTooLarge { entries: u64, max: usize },
+
     /// Returned when a Gauss-Jackson 8 propagation is requested over a span
     /// shorter than its 8-step startup requires. Reduce `gj_step_seconds` or
     /// use an adaptive integrator (e.g. RKV98) for short arcs.

--- a/src/orbitprop/precomputed.rs
+++ b/src/orbitprop/precomputed.rs
@@ -30,6 +30,42 @@ pub const DEFAULT_PADDING_SECS: f64 = 240.0;
 /// and polar-motion factors of the frame rotation stored in the table.
 const SLOW_STEP_SECS: f64 = 3600.0;
 
+/// Upper bound on the number of entries a [`Precomputed`] table may hold.
+///
+/// Each entry is ~80 bytes, so this is ≈1.3 GB — about 30 years at the
+/// default 60 s step. A span/step combination needing more returns
+/// [`Error::PrecomputeTooLarge`] *before* anything is allocated. (An
+/// unbounded table could previously consume all memory for a tiny step or
+/// a very long span, or silently wrap to a one-entry table for a
+/// denormal step.)
+pub const MAX_PRECOMPUTE_ENTRIES: usize = 16_777_216;
+
+/// Number of table entries for a span at a given step, or an error if the
+/// count is not representable or exceeds [`MAX_PRECOMPUTE_ENTRIES`].
+fn table_len(span_secs: f64, step_secs: f64) -> Result<usize> {
+    let n = (span_secs / step_secs).ceil();
+    // `as` would saturate a non-finite or huge value and the `+ 2` below
+    // could then wrap; check in f64 first.
+    if !n.is_finite() || n < 0.0 || n > MAX_PRECOMPUTE_ENTRIES as f64 {
+        return Err(Error::PrecomputeTooLarge {
+            entries: if n.is_finite() {
+                (n as u64).saturating_add(2)
+            } else {
+                u64::MAX
+            },
+            max: MAX_PRECOMPUTE_ENTRIES,
+        });
+    }
+    let entries = n as usize + 2;
+    if entries > MAX_PRECOMPUTE_ENTRIES {
+        return Err(Error::PrecomputeTooLarge {
+            entries: entries as u64,
+            max: MAX_PRECOMPUTE_ENTRIES,
+        });
+    }
+    Ok(entries)
+}
+
 impl Precomputed {
     /// Create a precomputed interp table with default step (60 s) and
     /// default padding ([`DEFAULT_PADDING_SECS`]). Suitable for any
@@ -71,6 +107,11 @@ impl Precomputed {
         if !step_secs.is_finite() || step_secs <= 0.0 {
             return Err(Error::InvalidPrecomputeStep { step: step_secs });
         }
+        if !padding_secs.is_finite() {
+            return Err(Error::InvalidPrecomputePadding {
+                padding: padding_secs,
+            });
+        }
         let step: f64 = step_secs;
         let pad = Duration::from_seconds(padding_secs.max(0.0));
 
@@ -78,6 +119,12 @@ impl Precomputed {
             true => (begin - pad, end + pad),
             false => (end - pad, begin + pad),
         };
+
+        // Size the tables before touching the ephemeris or allocating.
+        let nsteps: usize = table_len((pend - pbegin).as_seconds(), step)?;
+        // The last fine point may lie up to `step` beyond `pend`; size the
+        // slow table from it so the slerp fraction stays within [0, 1].
+        let nslow: usize = table_len(((nsteps - 1) as f64) * step, SLOW_STEP_SECS)?;
 
         Ok(Self {
             begin: pbegin,
@@ -89,7 +136,6 @@ impl Precomputed {
                 jplephem::geocentric_pos(SolarSystem::Sun, &pbegin)?;
                 jplephem::geocentric_pos(SolarSystem::Sun, &pend)?;
 
-                let nsteps: usize = 2 + ((pend - pbegin).as_seconds() / step).ceil() as usize;
                 // The GCRF→ITRF rotation is the full IAU 2006/2000A chain
                 // (precession-nutation with EOP dX/dY, Earth rotation angle,
                 // polar motion) — the same as `frametransform::qgcrf2itrf`.
@@ -99,20 +145,13 @@ impl Precomputed {
                 // while the fast Earth-rotation factor is computed exactly
                 // at each point. Interpolation error is far below a
                 // microarcsecond; see `test_table_matches_full_transform`.
-                // Sized from the last fine point (which may lie up to `step`
-                // beyond `pend`) so `frac` stays within [0, 1].
-                let fine_span = ((nsteps - 1) as f64) * step;
-                let nslow: usize = 2 + (fine_span / SLOW_STEP_SECS).ceil() as usize;
                 let slow: Vec<(Quaternion, Quaternion)> = (0..nslow)
                     .map(|i| {
                         let t = pbegin + Duration::from_seconds((i as f64) * SLOW_STEP_SECS);
                         qitrf2gcrf_slow_parts(&t)
                     })
                     .collect();
-                // Cap the up-front reservation so an absurd (but
-                // ephemeris-covered) span grows the Vec instead of attempting
-                // one giant allocation.
-                let mut data = Vec::with_capacity(nsteps.min(1 << 22));
+                let mut data = Vec::with_capacity(nsteps);
                 for idx in 0..nsteps {
                     let dt = (idx as f64) * step;
                     let t = pbegin + Duration::from_seconds(dt);
@@ -248,6 +287,43 @@ mod tests {
                 "{label}: table vs full transform: {worst:.3e} rad"
             );
         }
+    }
+
+    #[test]
+    fn test_size_cap_and_bad_inputs() {
+        let t0 = Instant::from_datetime(2023, 5, 16, 20, 0, 0.0).unwrap();
+        let t1 = t0 + Duration::from_seconds(3600.0);
+
+        // A tiny step would need ~3.8e9 entries: must error, and must do so
+        // before allocating (previously this consumed >6 GB and was killed).
+        let start = std::time::Instant::now();
+        assert!(matches!(
+            Precomputed::new_with_step(&t0, &t1, 1e-6),
+            Err(Error::PrecomputeTooLarge { .. })
+        ));
+        assert!(start.elapsed().as_secs() < 2, "size check must be cheap");
+
+        // A denormal step used to overflow the entry count and wrap to a
+        // silent one-entry table.
+        assert!(matches!(
+            Precomputed::new_with_step(&t0, &t1, 1e-300),
+            Err(Error::PrecomputeTooLarge { .. })
+        ));
+
+        // Non-finite padding is rejected rather than treated as zero / huge.
+        assert!(matches!(
+            Precomputed::new_padded(&t0, &t1, 60.0, f64::NAN),
+            Err(Error::InvalidPrecomputePadding { .. })
+        ));
+        assert!(matches!(
+            Precomputed::new_padded(&t0, &t1, 60.0, f64::INFINITY),
+            Err(Error::InvalidPrecomputePadding { .. })
+        ));
+
+        // Ordinary tables are unaffected.
+        let week = Precomputed::new(&t0, &(t0 + Duration::from_days(7.0))).unwrap();
+        assert!(week.interp(&(t0 + Duration::from_days(3.5))).is_ok());
+        assert_eq!(table_len(7.0 * 86400.0, 60.0).unwrap(), 2 + 7 * 1440);
     }
 
     #[test]

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -395,6 +395,9 @@ pub fn propagate<const C: usize, T: TimeLike>(
     settings: &PropSettings,
     satprops: Option<&dyn SatProperties>,
 ) -> Result<PropagationResult<C>> {
+    // Settings built by struct literal bypass `set_gravity`; check here so an
+    // unsupported degree errors instead of silently evaluating at the cap.
+    settings.validate_gravity()?;
     // Only plain state (C==1) and state + state-transition-matrix (C==7)
     // propagation are supported; reject other instantiations up front so
     // the force closure (which cannot error) never sees them.
@@ -805,6 +808,30 @@ mod tests {
         assert!(matches!(
             propagate::<3, _>(&state, &t0, &t1, &PropSettings::default(), None),
             Err(Error::InvalidStateColumns { c: 3 })
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn test_gravity_degree_above_max_errors() -> Result<()> {
+        // Struct-literal settings bypass `set_gravity`; propagate must still
+        // refuse a degree the evaluator would otherwise silently clamp to 40.
+        let t0 = Instant::from_datetime(2015, 3, 20, 0, 0, 0.0)?;
+        let t1 = t0 + Duration::from_seconds(60.0);
+        let mut state = SimpleState::zeros();
+        state[0] = 7000.0e3;
+        state[4] = 7.5e3;
+        let settings = PropSettings {
+            gravity_degree: 41,
+            gravity_order: 41,
+            ..Default::default()
+        };
+        assert!(matches!(
+            propagate(&state, &t0, &t1, &settings, None),
+            Err(Error::InvalidGravityDegree {
+                degree: 41,
+                max: 40
+            })
         ));
         Ok(())
     }

--- a/src/orbitprop/settings.rs
+++ b/src/orbitprop/settings.rs
@@ -31,8 +31,9 @@ pub enum Integrator {
     /// of comparable accuracy on smooth orbit propagation problems.
     ///
     /// Uses a fixed step size set via [`PropSettings::gj_step_seconds`].
-    /// Does not support state transition matrix propagation (C=7) or dense
-    /// output interpolation. Not recommended for highly eccentric orbits or
+    /// Supports dense output (quintic Hermite interpolation between steps
+    /// when `enable_interp` is set) but not state transition matrix
+    /// propagation (C=7). Not recommended for highly eccentric orbits or
     /// integration across discontinuities (eclipse boundaries, maneuvers).
     GaussJackson8,
 }

--- a/src/orbitprop/settings.rs
+++ b/src/orbitprop/settings.rs
@@ -139,13 +139,38 @@ impl PropSettings {
     /// * `order` - Maximum order (must be ≤ degree)
     ///
     /// # Errors
-    /// Returns error if order > degree
+    /// Returns error if order > degree, or if degree exceeds
+    /// [`MAX_GRAVITY_DEGREE`](crate::earthgravity::MAX_GRAVITY_DEGREE) (40).
     pub fn set_gravity(&mut self, degree: u16, order: u16) -> Result<()> {
+        Self::check_gravity(degree, order)?;
+        self.gravity_degree = degree;
+        self.gravity_order = order;
+        Ok(())
+    }
+
+    /// Validate the gravity degree / order currently held by these settings.
+    ///
+    /// [`propagate`](super::propagate) calls this on entry so that settings
+    /// built by struct literal (bypassing [`set_gravity`](Self::set_gravity))
+    /// are checked too: a degree above
+    /// [`MAX_GRAVITY_DEGREE`](crate::earthgravity::MAX_GRAVITY_DEGREE) used to
+    /// be silently evaluated at 40, and an order above the degree silently
+    /// clamped.
+    pub fn validate_gravity(&self) -> Result<()> {
+        Self::check_gravity(self.gravity_degree, self.gravity_order)
+    }
+
+    fn check_gravity(degree: u16, order: u16) -> Result<()> {
+        use crate::earthgravity::MAX_GRAVITY_DEGREE;
+        if degree > MAX_GRAVITY_DEGREE {
+            return Err(Error::InvalidGravityDegree {
+                degree,
+                max: MAX_GRAVITY_DEGREE,
+            });
+        }
         if order > degree {
             return Err(Error::InvalidGravityOrder { order, degree });
         }
-        self.gravity_degree = degree;
-        self.gravity_order = order;
         Ok(())
     }
 
@@ -276,5 +301,55 @@ mod test {
     fn testdisplay() {
         let props = PropSettings::default();
         println!("props = {}", props);
+    }
+
+    #[test]
+    fn set_gravity_rejects_degree_above_max() {
+        let mut s = PropSettings::default();
+        assert!(s.set_gravity(40, 40).is_ok());
+        assert_eq!((s.gravity_degree, s.gravity_order), (40, 40));
+        assert!(matches!(
+            s.set_gravity(41, 41),
+            Err(Error::InvalidGravityDegree {
+                degree: 41,
+                max: 40
+            })
+        ));
+        assert!(matches!(
+            s.set_gravity(360, 360),
+            Err(Error::InvalidGravityDegree { degree: 360, .. })
+        ));
+        assert!(matches!(
+            s.set_gravity(20, 21),
+            Err(Error::InvalidGravityOrder {
+                order: 21,
+                degree: 20
+            })
+        ));
+        // A rejected call leaves the settings untouched.
+        assert_eq!((s.gravity_degree, s.gravity_order), (40, 40));
+    }
+
+    #[test]
+    fn validate_gravity_catches_struct_literal() {
+        let s = PropSettings {
+            gravity_degree: 41,
+            gravity_order: 41,
+            ..Default::default()
+        };
+        assert!(matches!(
+            s.validate_gravity(),
+            Err(Error::InvalidGravityDegree { .. })
+        ));
+        let s = PropSettings {
+            gravity_degree: 8,
+            gravity_order: 9,
+            ..Default::default()
+        };
+        assert!(matches!(
+            s.validate_gravity(),
+            Err(Error::InvalidGravityOrder { .. })
+        ));
+        assert!(PropSettings::default().validate_gravity().is_ok());
     }
 }

--- a/src/solar_cycle_forecast.rs
+++ b/src/solar_cycle_forecast.rs
@@ -260,6 +260,7 @@ mod tests {
 
     #[cfg(feature = "download")]
     #[test]
+    #[ignore = "requires network access to services.swpc.noaa.gov; run with `cargo test -- --ignored`"]
     fn test_download_and_parse() {
         let url = "https://services.swpc.noaa.gov/json/solar-cycle/predicted-solar-cycle.json";
         let contents = crate::utils::download_to_string(url).unwrap();

--- a/src/spaceweather.rs
+++ b/src/spaceweather.rs
@@ -180,7 +180,7 @@ fn load_default_path() -> PathBuf {
 /// Lazy default load from `SW-All.csv` under [`datadir`], with auto-download.
 fn load_space_weather_csv() -> Result<Vec<SpaceWeatherRecord>> {
     let path = load_default_path();
-    download_if_not_exist(&path, Some("http://celestrak.org/SpaceData/"))?;
+    download_if_not_exist(&path, Some("https://celestrak.org/SpaceData/"))?;
     parse_csv(&std::fs::read_to_string(&path)?)
 }
 

--- a/src/utils/update_data.rs
+++ b/src/utils/update_data.rs
@@ -23,6 +23,16 @@ pub enum Error {
     #[error("Invalid JSON manifest entry")]
     InvalidManifestEntry,
 
+    /// A manifest directory key was not a single plain path component
+    /// (absolute, contained `..`, or contained a path separator). Such a key
+    /// would be joined onto the data directory and could escape it.
+    #[error("Manifest directory name {name:?} is not a plain path component")]
+    InvalidManifestPath { name: String },
+
+    /// A refresh-manifest URL did not use `https://`.
+    #[error("Manifest URL {url:?} must use https://")]
+    InsecureManifestUrl { url: String },
+
     /// One or more entries in the JSON manifest could not be parsed.
     #[error("Could not parse manifest entries")]
     ManifestParseFailed,
@@ -63,6 +73,11 @@ fn download_from_url_json(json_url: String, basedir: &std::path::Path) -> Result
         .iter()
         .map(|url| -> Result<JoinHandle<download::Result<bool>>> {
             let url_str = url.as_str().ok_or(Error::NotJsonString)?;
+            if !url_str.starts_with("https://") {
+                return Err(Error::InsecureManifestUrl {
+                    url: url_str.to_string(),
+                });
+            }
             Ok(download_file_async(url_str.to_string(), basedir, true))
         })
         .collect::<Result<Vec<_>>>()?;
@@ -71,6 +86,26 @@ fn download_from_url_json(json_url: String, basedir: &std::path::Path) -> Result
         jh.join().map_err(|_| Error::ThreadPanic)??;
     }
 
+    Ok(())
+}
+
+/// A manifest object key names a subdirectory of the data directory and is
+/// joined onto it. Only a single, plain path component is acceptable: an
+/// absolute key would *replace* the base directory in `Path::join`, and
+/// `..` or embedded separators would escape it.
+fn validate_manifest_component(name: &str) -> Result<()> {
+    let bad = name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+        || std::path::Path::new(name).is_absolute();
+    if bad {
+        return Err(Error::InvalidManifestPath {
+            name: name.to_string(),
+        });
+    }
     Ok(())
 }
 
@@ -86,6 +121,7 @@ fn download_from_json(
         let r1: Vec<Result<()>> = obj
             .iter()
             .map(|(key, val)| -> Result<()> {
+                validate_manifest_component(key)?;
                 let pbnew = basedir.join(key);
                 if !pbnew.is_dir() {
                     std::fs::create_dir_all(pbnew.clone())?;
@@ -210,4 +246,36 @@ pub fn update_datafiles(dir: Option<PathBuf>, overwrite_if_exists: bool) -> Resu
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn manifest_component_validation() {
+        for ok in ["EGM96.gfc", "jplephem", "sw-data_v2", "a.b.c"] {
+            assert!(validate_manifest_component(ok).is_ok(), "{ok:?}");
+        }
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../x",
+            "/etc/passwd",
+            "a/b",
+            "a\\b",
+            "x/../y",
+            "C:\\x",
+            "a\0b",
+        ] {
+            assert!(
+                matches!(
+                    validate_manifest_component(bad),
+                    Err(Error::InvalidManifestPath { .. })
+                ),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Follow-up to #127/#128 addressing the verified items from an external code review.

## Behaviour (commit 1)
- **Gravity degree/order > 40 is rejected** (`Error::InvalidGravityDegree`, Python `ValueError`) instead of being silently evaluated at 40 — degree 60 or 360 previously produced results bit-identical to 40. Validated in `set_gravity`, at `propagate()` entry for struct-literal settings, and in the Python setters/constructor. `docs/index.md` no longer advertises degree 360. New `earthgravity::MAX_GRAVITY_DEGREE`.
- **`Precomputed` tables are sized with checked math and capped** at `MAX_PRECOMPUTE_ENTRIES` (16.8 M ≈ 1.3 GB, ~30 yr at 60 s) *before* allocation; non-finite padding is rejected. Previously a 1 µs step consumed >6 GB and a denormal step wrapped to a silent one-entry table.
- **Download hygiene**: EOP/space-weather lazy fallbacks use `https://celestrak.org` (were plain http); static-manifest directory keys must be a single plain path component (rejects `..`, separators, absolute); refresh-manifest URLs must be https.
- The NOAA solar-cycle download test is `#[ignore]`d so offline `cargo test` passes; CI still runs it explicitly.
- cibuildwheel now import-tests every wheel it can run (`test-skip = "*"` → `"*-macosx_x86_64"`, the one cross-built target).

## Docs/config (commit 2)
`doc = false` on the extension crate (fixes `cargo doc --workspace` name collision), GJ8 dense-output comments, MIT OR Apache-2.0 in crate docs, CONTRIBUTING (3.10, `python/test/`, actual CI coverage, satkit.dev), leap-second docs (compiled table through 2017-01-01; `leap-seconds.list` is not read), missing `0.20.3` CHANGELOG heading.

## Compatibility
Anyone passing `gravity_degree > 40` now gets an error rather than a silently degraded result. No other numerical change: full Rust suite, 151 Python tests, and GMAT residuals unchanged.

## Test plan
- [x] fmt / clippy clean; `cargo test --features chrono` all pass (new: degree-cap, precompute-cap, manifest-validation tests)
- [x] `cargo doc --workspace --no-deps` builds
- [x] `pytest python/test/` 151 passed (2 new)
- [ ] CI (wheel smoke test only runs in the release workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE