### PR TITLE
Correct frame-bias docs; pin EME2000 bias in Python; drop Frame catch-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 ### Fixed
 
 - **Frame-bias documentation.** `EME2000` docs said "≈ 17 mas"; the IERS 2010
-  constant bias is 23.0 mas total (≈ 18 mas pole, ≈ 15 mas equinox). The GMAT
+  constant bias is 23.1 mas total (≈ 18 mas pole, ≈ 15 mas equinox). The GMAT
   corpus docs claimed GMAT's `EarthMJ2000Eq` differs from `EarthICRF` by that
   bias; it does not — GMAT realizes `MJ2000Eq` through the IAU-76/FK5
   precession model, so its offset from ICRF is time-varying (≈ 44 mas in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@
   `leo_iss_gr` 2 → 1.5 m (residuals 2.08 → 1.01 m, 1.85 → 0.63 m,
   0.66 → 0.50 m, i.e. down to the non-relativistic floors).
 
+### Fixed
+
+- **Frame-bias documentation.** `EME2000` docs said "≈ 17 mas"; the IERS 2010
+  constant bias is 23.0 mas total (≈ 18 mas pole, ≈ 15 mas equinox). The GMAT
+  corpus docs claimed GMAT's `EarthMJ2000Eq` differs from `EarthICRF` by that
+  bias; it does not — GMAT realizes `MJ2000Eq` through the IAU-76/FK5
+  precession model, so its offset from ICRF is time-varying (≈ 44 mas in
+  2023). The corpus already used `EarthICRF`. A Python test now pins the
+  EME2000 bias magnitude and components against the IERS values, and the
+  approx-mode frame dispatcher lists every `Frame` variant explicitly instead
+  of a catch-all.
+
 ### CI
 
 - **Published wheels are smoke-tested.** cibuildwheel's `test-skip = "*"`

--- a/docs/guide/gmat_validation.md
+++ b/docs/guide/gmat_validation.md
@@ -12,7 +12,7 @@ GMAT is a large GUI-oriented application that cannot run inside a CI job. The co
 |---|---|---|
 | GMAT | R2026A, `GmatConsole` headless | |
 | integrator | `RungeKutta89`, `Accuracy = 1e-14`, `ErrorControl = RSSStep` | tight enough that GMAT's own error is well below the gates for most cases (see [floors](#known-differences-and-the-gates)) |
-| frame | `EarthICRF` | matches satkit's GCRF; `EarthMJ2000Eq` differs by the ~23 mas frame bias |
+| frame | `EarthICRF` | matches satkit's GCRF exactly; GMAT's `EarthMJ2000Eq` is an IAU-76/FK5 realization whose offset from ICRF is time-varying (≈ 44 mas ≈ 1.5 m at 7000 km in 2023), not the IERS constant 23 mas bias of satkit's `EME2000` |
 | ephemeris | SPICE `de440.bsp` | GMAT bundles only DE405/421/424; satkit uses DE440 |
 | body GMs | pinned to the DE440 values satkit uses and recorded in the JSON | a wrong constant in satkit shows up as a residual against a reviewable reference value |
 | gravity file | `EGM96.cof` | coefficients identical to satkit's `EGM96.gfc`; the field's $GM$ comes from the file on both sides |

--- a/python/test/test_frames.py
+++ b/python/test/test_frames.py
@@ -442,7 +442,7 @@ class TestGravity:
 
 
 def test_eme2000_frame_bias_matches_iers_2010():
-    """GCRF→EME2000 is the constant IERS 2010 frame bias: 23.0 mas total,
+    """GCRF→EME2000 is the constant IERS 2010 frame bias: 23.15 mas total,
     rotation vector (−η0, −ξ0, −dα0) = (−6.819, +16.617, +14.600) mas,
     identical at any epoch; GCRF↔ICRF is the identity.
 
@@ -459,7 +459,7 @@ def test_eme2000_frame_bias_matches_iers_2010():
 
     for t in (sk.time(2000, 1, 1, 12, 0, 0), sk.time(2026, 8, 28, 0, 0, 0)):
         v = rotvec(sk.frametransform.rotation(sk.frame.GCRF, sk.frame.EME2000, t))
-        assert np.linalg.norm(v) == pytest.approx(23.0006 * mas, abs=0.001 * mas)
+        assert np.linalg.norm(v) == pytest.approx(23.147 * mas, abs=0.001 * mas)
         assert v == pytest.approx(expected, abs=0.001 * mas)
         vi = rotvec(sk.frametransform.rotation(sk.frame.GCRF, sk.frame.ICRF, t))
         assert np.linalg.norm(vi) == pytest.approx(0.0, abs=1e-15)

--- a/python/test/test_frames.py
+++ b/python/test/test_frames.py
@@ -439,3 +439,27 @@ class TestGravity:
         diff_moon = np.linalg.norm(res_all.state[0:3] - res_no_moon.state[0:3])
         assert diff_sun > 1.0, f"Disabling sun gravity should matter, diff = {diff_sun} m"
         assert diff_moon > 1.0, f"Disabling moon gravity should matter, diff = {diff_moon} m"
+
+
+def test_eme2000_frame_bias_matches_iers_2010():
+    """GCRF→EME2000 is the constant IERS 2010 frame bias: 23.0 mas total,
+    rotation vector (−η0, −ξ0, −dα0) = (−6.819, +16.617, +14.600) mas,
+    identical at any epoch; GCRF↔ICRF is the identity.
+
+    The rotation vector is taken from the antisymmetric part of the rotation
+    matrix (exact to O(θ³)); ``quaternion.angle`` goes through ``acos`` near
+    1 and loses ~1% at 1e-7 rad.
+    """
+    mas = np.pi / 180.0 / 3600.0 / 1000.0
+    expected = np.array([-6.819, 16.617, 14.600]) * mas
+
+    def rotvec(q):
+        R = np.asarray(q.as_rotation_matrix())
+        return 0.5 * np.array([R[2, 1] - R[1, 2], R[0, 2] - R[2, 0], R[1, 0] - R[0, 1]])
+
+    for t in (sk.time(2000, 1, 1, 12, 0, 0), sk.time(2026, 8, 28, 0, 0, 0)):
+        v = rotvec(sk.frametransform.rotation(sk.frame.GCRF, sk.frame.EME2000, t))
+        assert np.linalg.norm(v) == pytest.approx(23.0006 * mas, abs=0.001 * mas)
+        assert v == pytest.approx(expected, abs=0.001 * mas)
+        vi = rotvec(sk.frametransform.rotation(sk.frame.GCRF, sk.frame.ICRF, t))
+        assert np.linalg.norm(vi) == pytest.approx(0.0, abs=1e-15)

--- a/src/frametransform/dispatch.rs
+++ b/src/frametransform/dispatch.rs
@@ -70,7 +70,17 @@ const FRAME_BIAS_DALPHA0_AS: f64 = -0.014600;
 const FRAME_BIAS_XI0_AS: f64 = -0.016617;
 const FRAME_BIAS_ETA0_AS: f64 = -0.006819;
 
-/// Constant quaternion: EME2000 → GCRF (≈ 17 milliarcsec frame bias).
+/// Constant quaternion: EME2000 → GCRF (≈ 23 milliarcsec total frame bias:
+/// ≈ 18 mas pole offset plus ≈ 15 mas equinox offset).
+///
+/// This is the IERS 2010 *constant* bias between the ICRS/GCRS axes and the
+/// J2000.0 mean dynamical equator and equinox — the same definition used by
+/// SOFA (`iauBp00`/`iauBp06`) and Orekit's `EME2000`. It is **not** the
+/// frame that GMAT calls `EarthMJ2000Eq` (or STK's FK5 "J2000"): GMAT
+/// realizes that frame through the IAU-76/FK5 precession model and its
+/// offset from ICRF is time-varying (≈ 20 mas at J2000, ≈ 44 mas in 2023,
+/// growing ≈ 2.5 mas/yr from the IAU-76 precession-rate error). Use
+/// [`Frame::GCRF`] to compare against GMAT's `EarthICRF`.
 ///
 /// Implements `B^T = R3(-dα0) · R2(-ξ0) · R1(η0)` in IERS notation. In
 /// numeris' active-rotation convention this is `rotz(dα0) · roty(ξ0) ·
@@ -318,7 +328,14 @@ pub fn transform_state_approx<T: TimeLike>(
 fn reject_for_approx(frame: Frame) -> Result<()> {
     match frame {
         Frame::TIRS | Frame::CIRS => Err(Error::ApproxNotSupportedForFrame { frame }),
-        _ => Ok(()),
+        Frame::ITRF
+        | Frame::GCRF
+        | Frame::TEME
+        | Frame::EME2000
+        | Frame::ICRF
+        | Frame::LVLH
+        | Frame::RTN
+        | Frame::NTW => Ok(()),
     }
 }
 
@@ -382,6 +399,12 @@ fn canonical_rotation<T: TimeLike>(from: Frame, to: Frame, t: &T) -> Result<Quat
 
 /// Canonical-direction rotation for the FK5 approximate reduction.
 /// Only inertial-cluster + ITRF + TEME pairs are valid.
+///
+/// Note on `EME2000` in approx mode: the IAU-76/FK5 chain behind
+/// [`qitrf2gcrf_approx`] has no frame bias, so its "GCRF" is already an
+/// FK5-flavoured J2000; applying the constant 23 mas bias on top is
+/// formally inconsistent, but the difference is far inside the ~1 arcsec
+/// accuracy of the approximate reduction.
 fn canonical_rotation_approx<T: TimeLike>(from: Frame, to: Frame, t: &T) -> Result<Quaternion> {
     use Frame::*;
     let q = match (from, to) {
@@ -795,7 +818,7 @@ mod tests {
         assert!((c0[0] - 1.0).abs() < 1e-14);
         assert!((c0[1] - (-7.07827974e-8)).abs() < 1e-15);
         assert!((c0[2] - 8.05614894e-8).abs() < 1e-15);
-        // Second column: (-dα0_rad, 1, η0_rad).
+        // Second column: (-dα0_rad, 1, -η0_rad).
         assert!((c1[0] - 7.07827948e-8).abs() < 1e-15);
         assert!((c1[1] - 1.0).abs() < 1e-14);
         assert!((c1[2] - 3.30594449e-8).abs() < 1e-15);

--- a/tests/gmat/README.md
+++ b/tests/gmat/README.md
@@ -66,8 +66,12 @@ Cases: every orbit × `j2` and `full`, plus `gr` for `leo_iss`, `tess` and
 
 * GMAT R2026A, `GmatConsole` headless, `RungeKutta89`, `Accuracy = 1e-14`,
   `ErrorControl = RSSStep`, `MaxStep = 2700`.
-* **Frame**: `EarthICRF`, not `EarthMJ2000Eq` — matches satkit's GCRF without
-  the ~23 mas frame bias.
+* **Frame**: `EarthICRF`, not `EarthMJ2000Eq` — matches satkit's GCRF
+  exactly. GMAT's `EarthMJ2000Eq` is *not* the IERS constant-bias EME2000
+  (satkit's `Frame::EME2000`, 23 mas from GCRF): GMAT realizes it through the
+  IAU-76/FK5 precession model via `data/icrf/ICRF_Table.txt`, and its offset
+  from ICRF is time-varying — ≈ 44 mas (1.5 m at 7000 km) at the corpus epoch,
+  growing ≈ 2.5 mas/yr.
 * **Ephemeris**: SPICE `de440.bsp` (GMAT bundles only DE405/421/424; satkit uses
   DE440).
 * **Body GMs** pinned to the DE440 values satkit uses (`Luna.Mu = 4902.800118`,


### PR DESCRIPTION
Docs-only corrections found while assessing whether to add a J2000 frame (answer: `Frame::EME2000` already implements the IERS 2010 constant bias correctly — verified against SOFA `erfa.bp00` to 1e-12).

- `dispatch.rs`: EME2000 doc said ≈17 mas; the total constant bias is **23.1 mas** (≈18 pole + ≈15 equinox). Added the distinction from GMAT's `EarthMJ2000Eq` / STK's FK5 J2000, which are IAU-76 realizations with a *time-varying* offset from ICRF (≈20 mas at J2000, ≈44 mas in 2023, +2.5 mas/yr). Fixed a mislabeled test comment; noted the (harmless) bias-on-FK5 inconsistency in approx mode.
- `tests/gmat/README.md`, `docs/guide/gmat_validation.md`: the corpus docs wrongly said GMAT's `EarthMJ2000Eq` differs from `EarthICRF` by the 23 mas bias; it's ≈44 mas (1.5 m at 7000 km) at the corpus epoch for the reason above. `EarthICRF` was already the corpus frame.
- `reject_for_approx`: `_ =>` replaced by explicit `Frame` variants (CLAUDE.md rule).
- Python test pinning `rotation(GCRF, EME2000)` = 23.147 mas (norm of the three IERS angles) with components (−6.819, +16.617, +14.600) mas at two epochs, and GCRF↔ICRF identity. Uses the rotation-matrix antisymmetric part because `quaternion.angle` loses ~1% at 1e-7 rad (`acos` near 1) — worth a separate `atan2`-based fix.

No numerical change to any transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE