### PR TITLE
Make EOP coverage visible and enforceable; IERS-table preload for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,30 @@
 
 ### Added
 
+- **EOP coverage is visible and enforceable.** Earth-orientation
+  parameters silently held the last table row constant for epochs past the
+  end of `EOP-All.csv`, and silently used zeros when no table was loaded at
+  all (only pre-1962 epochs warned) — and since the propagator now uses the
+  full EOP chain, a stale file shifted a 7-day LEO propagation by ~10 m with
+  no indication. New `earth_orientation_params::{coverage, status,
+  EopCoverage, EopStatus}` (Python: `satkit.frametransform.eop_coverage()`
+  and `eop_status(t)` → `"observed" | "predicted" | "extrapolated" |
+  "before_table" | "not_loaded"`); one-time stderr warnings the first time an
+  epoch past the table end or a missing table is used;
+  `PropSettings::require_eop_coverage` (Python
+  `propsettings(require_eop_coverage=...)`, default off) makes `propagate`
+  fail with `Error::EopCoverage` instead of extrapolating; and a propagation
+  with **no** EOP table loaded now fails with `Error::EopUnavailable`
+  instead of running with zero polar motion / UT1−UTC. `disable_eop_time_warning()`
+  suppresses all three warnings. Frame-transform doc comments that claimed
+  "set to zero and a warning is printed" are corrected.
+- **`frametransform::ierstable::preload()`** loads the three IERS
+  precession-nutation tables and returns an error if a file is missing or
+  unreadable. The Python frame-transform entry points and
+  `Precomputed`/`propagate` call it, so a missing `tab5.2*.txt` now raises a
+  normal `RuntimeError` in Python rather than a `PanicException`. The Rust
+  `q*2*` functions still panic on a missing table until the `Result`
+  threading planned for 0.21 ([#125](https://github.com/ssmichael1/satkit/issues/125)).
 - **GMAT regression corpus** (`tests/gmat/cases/*.json`,
   `tests/gmat_regression.rs`, `python/test/test_gmat.py`). Seventeen
   7-day reference trajectories generated with NASA GMAT R2026A (RK89 at

--- a/docs/getting-started/datafiles.md
+++ b/docs/getting-started/datafiles.md
@@ -14,7 +14,31 @@ The `satkit` package relies upon a number of data files for certain calculations
 
 - **predicted-solar-cycle.json** — NOAA/SWPC solar cycle forecast. Monthly predicted F10.7 solar flux values extending ~5 years into the future. Used as a fallback for atmospheric density calculations when propagating beyond the range of historical space weather data.
 
-- **EOP-All.csv** — Earth orientation parameters. This includes $\Delta UT1$, the difference between $UT1$ and $UTC$, as well as $x_p$ and $y_p$, the polar "wander" of the Earth rotation axis. This file is updated daily with most-recent values at [celestrak.org](https://www.celestrak.org). For dates beyond the file, the last entry's values are used (constant extrapolation).
+- **EOP-All.csv** — Earth orientation parameters. This includes $\Delta UT1$, the difference between $UT1$ and $UTC$, as well as $x_p$ and $y_p$, the polar "wander" of the Earth rotation axis. This file is updated daily with most-recent values at [celestrak.org](https://www.celestrak.org) and carries IERS predictions roughly six months ahead. For dates beyond the file, the last entry's values are used (constant extrapolation) — see [EOP coverage](#eop-coverage) below.
+
+## EOP coverage
+
+Every Earth-fixed frame transform, every UT1-based quantity (`gmst`, `gast`, Earth rotation angle), and the high-precision propagator depend on the EOP table, so it matters where an epoch falls relative to it:
+
+| `satkit.frametransform.eop_status(t)` | meaning | what satkit does |
+|---|---|---|
+| `"observed"` | on or before the last observed (`O`) row | interpolates measured values |
+| `"predicted"` | after the last observed row, inside the table | interpolates IERS predictions (~6 months ahead) |
+| `"extrapolated"` | after the last row | holds the last row constant and prints a **one-time warning**. Polar motion drifts ~0.1″ and $\Delta UT1$ ~10 ms over a few months — metres of position error at LEO |
+| `"before_table"` | before 1962 | zeros, one-time warning |
+| `"not_loaded"` | no table at all | zeros, one-time warning; **`propagate` refuses to run** (`RuntimeError`) |
+
+`satkit.frametransform.eop_coverage()` returns `(first, last_observed, last)` as `satkit.time` values, or `None` if nothing is loaded. For precision work, propagate with `satkit.propsettings(require_eop_coverage=True)`: the propagator then raises instead of extrapolating past the table, and the fix is simply to refresh the file:
+
+```python
+import satkit as sk
+
+first, last_observed, last = sk.frametransform.eop_coverage()
+if sk.frametransform.eop_status(t_end) == "extrapolated":
+    sk.utils.update_datafiles()   # re-downloads EOP-All.csv (and SW-All.csv)
+```
+
+The warnings can be silenced with `satkit.frametransform.disable_eop_time_warning()`.
 
 ## Acquiring the Data Files
 

--- a/docs/guide/forces.md
+++ b/docs/guide/forces.md
@@ -124,7 +124,7 @@ Constant acceleration in a chosen frame (used to model low-thrust maneuvers or â
 
 When propagating into the future beyond the date range of downloaded data files:
 
-- **Earth Orientation Parameters** ($\Delta UT1$, $x_p$, $y_p$): the last available values are held constant. This is much more accurate than defaulting to zero since EOPs change slowly.
+- **Earth Orientation Parameters** ($\Delta UT1$, $x_p$, $y_p$): the last available values are held constant, with a one-time warning. This is much more accurate than defaulting to zero, but still drifts by ~0.1â€³ / ~10 ms over a few months (metres at LEO); check `satkit.frametransform.eop_status(t)` or set `propsettings.require_eop_coverage = True` to make the propagator raise instead, and refresh with `satkit.utils.update_datafiles()`. A propagation with no EOP table loaded at all is refused.
 - **Space Weather** (F10.7 solar flux, Ap geomagnetic index): if historical data isn't available, the [NOAA/SWPC solar cycle forecast](https://www.swpc.noaa.gov/products/solar-cycle-progression) supplies predicted F10.7 (out ~5 years). Ap defaults to 4. If neither source is available, F10.7 = 150 and Ap = 4 are used. Run `satkit.utils.update_datafiles()` to refresh both.
 
 ## Forces vs Altitude

--- a/python/satkit/frametransform.pyi
+++ b/python/satkit/frametransform.pyi
@@ -557,9 +557,11 @@ def earth_orientation_params(
             5 : dY wrt IAU-2000A nutation, milli-arcsecs
 
     Notes:
-        - Returns None if the time is before the range of available EOP data
-        - For times after the last available EOP data, the last entry's values are returned (constant extrapolation)
-        - EOP data is available from 1962 to current, with predictions ~4 months ahead
+        - Returns None if the time is before the range of available EOP data, or if no EOP table is loaded
+        - For times after the last available EOP data, the last entry's values are returned (constant
+          extrapolation) and a one-time warning is printed; use :func:`eop_status` / :func:`eop_coverage` to check
+        - EOP data is available from 1962 to current, with predictions ~6 months ahead; refresh with
+          ``satkit.utils.update_datafiles()``
         - See: <https://www.iers.org/IERS/EN/DataProducts/EarthOrientationData/eop.html>
 
     Example:
@@ -804,11 +806,41 @@ def from_gcrf(
     ...
 
 def disable_eop_time_warning() -> None:
-    """Disable the warning printed to stderr when Earth Orientation Parameters (EOP) are not available for a given time.
+    """Disable the warnings printed to stderr about Earth Orientation Parameters (EOP) availability.
 
     Notes:
-        - This function is used to disable the warning printed when EOP are not available for a given time.
-        - If not disabled, warning will be shown only once per library load,
+        - Three one-time warnings exist: epoch before the EOP table, epoch after the table end
+          (last values held constant), and no EOP table loaded at all (zeros used).
+        - Each is shown at most once per process; this call suppresses all of them.
+    """
+    ...
+
+def eop_coverage() -> tuple[time, time, time] | None:
+    """Time bounds of the loaded Earth Orientation Parameters (EOP) table.
+
+    Returns:
+        (satkit.time, satkit.time, satkit.time) | None: ``(first, last_observed, last)`` — the first
+        row, the last *observed* row (rows after it are IERS predictions), and the last row of the
+        table; ``None`` if no EOP table is loaded. Epochs after ``last`` use that row's values held
+        constant (see :func:`eop_status`); refresh with ``satkit.utils.update_datafiles()``.
+
+    Example:
+        >>> first, last_observed, last = satkit.frametransform.eop_coverage()
+    """
+    ...
+
+def eop_status(tm: time) -> str:
+    """Classify an epoch against the loaded Earth Orientation Parameters (EOP) table.
+
+    Args:
+        tm (satkit.time): Epoch to classify
+
+    Returns:
+        str: one of ``"observed"`` (inside the table, on or before the last observed row),
+        ``"predicted"`` (inside the table, IERS prediction), ``"extrapolated"`` (after the table
+        end — the last row is held constant; accuracy degrades by ~0.1 arcsec / ~10 ms per few
+        months, refresh the data files), ``"before_table"`` (before 1962; zeros used), or
+        ``"not_loaded"`` (no EOP table loaded; zeros used).
     """
     ...
 

--- a/python/satkit/satkit.pyi
+++ b/python/satkit/satkit.pyi
@@ -3615,6 +3615,7 @@ class propsettings:
         integrator: integrator = ...,
         gj_step_seconds: float = 60.0,
         max_steps: int = 1_000_000,
+        require_eop_coverage: bool = False,
     ) -> None:
         """Create propagation settings object used to configure high-precision orbit propagator
 
@@ -3646,6 +3647,10 @@ class propsettings:
                 a max-steps error. Applies to all integrators (adaptive Runge-Kutta, Rosenbrock,
                 and Gauss-Jackson 8). Default is 1_000_000, which covers very long propagation
                 arcs with plenty of headroom. Lower for a tighter runaway-propagation safeguard.
+            require_eop_coverage: Raise ``RuntimeError`` if the propagation span extends past
+                the end of the loaded Earth-orientation-parameter (EOP) table, instead of
+                holding the last EOP row constant with a one-time warning. Default is False.
+                See ``satkit.frametransform.eop_coverage`` / ``eop_status``.
 
         Returns:
             propsettings: New propsettings object with default settings
@@ -3781,6 +3786,21 @@ class propsettings:
 
     @use_relativistic_correction.setter
     def use_relativistic_correction(self, value: bool) -> None: ...
+    @property
+    def require_eop_coverage(self) -> bool:
+        """Raise ``RuntimeError`` from ``propagate`` if the span extends past the end
+        of the loaded Earth-orientation-parameter (EOP) table, instead of holding the
+        last EOP row constant with a one-time warning. Default False.
+
+        Polar motion and UT1−UTC drift by ~0.1 arcsec / ~10 ms over a few months —
+        metres at LEO — so set this for precision work and refresh the data files
+        with ``satkit.utils.update_datafiles()`` when it trips. See
+        ``satkit.frametransform.eop_coverage`` and ``eop_status``.
+        """
+        ...
+
+    @require_eop_coverage.setter
+    def require_eop_coverage(self, value: bool) -> None: ...
     @property
     def enable_interp(self) -> bool:
         """Store intermediate data that allows for fast high-precision interpolation of state between begin and end times

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -140,6 +140,10 @@ fn frametransform(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pyft::pyeop, m)?).unwrap();
     m.add_function(wrap_pyfunction!(pyft::disable_eop_time_warning, m)?)
         .unwrap();
+    m.add_function(wrap_pyfunction!(pyft::eop_coverage, m)?)
+        .unwrap();
+    m.add_function(wrap_pyfunction!(pyft::eop_status, m)?)
+        .unwrap();
     m.add_function(wrap_pyfunction!(pyft::to_gcrf, m)?).unwrap();
     m.add_function(wrap_pyfunction!(pyft::from_gcrf, m)?)
         .unwrap();

--- a/python/src/pyframetransform.rs
+++ b/python/src/pyframetransform.rs
@@ -103,6 +103,7 @@ pub fn qtirs2cirs(tm: &Bound<'_, PyAny>) -> Result<Py<PyAny>> {
 
 #[pyfunction]
 pub fn qcirs2gcrf(tm: &Bound<'_, PyAny>) -> Result<Py<PyAny>> {
+    satkit::frametransform::ierstable::preload()?;
     py_quat_from_time_arr(ft::qcirs2gcrs, tm)
 }
 
@@ -120,6 +121,7 @@ pub fn qcirs2gcrf(tm: &Bound<'_, PyAny>) -> Result<Py<PyAny>> {
 
 #[pyfunction]
 pub fn qitrf2gcrf(tm: &Bound<'_, PyAny>) -> Result<Py<PyAny>> {
+    satkit::frametransform::ierstable::preload()?;
     py_quat_from_time_arr(ft::qitrf2gcrf, tm)
 }
 
@@ -136,6 +138,7 @@ pub fn qitrf2gcrf(tm: &Bound<'_, PyAny>) -> Result<Py<PyAny>> {
 ///     satkit.quaternion|list: Quaternion or list of quaternions representing rotation from GCRF to ITRF at input time[s]
 #[pyfunction]
 pub fn qgcrf2itrf(tm: &Bound<'_, PyAny>) -> Result<Py<PyAny>> {
+    satkit::frametransform::ierstable::preload()?;
     py_quat_from_time_arr(ft::qgcrf2itrf, tm)
 }
 
@@ -379,6 +382,7 @@ pub fn itrf_to_gcrf_state(
     vel_itrf: &Bound<'_, PyAny>,
     time: &Bound<'_, PyAny>,
 ) -> Result<(Py<PyAny>, Py<PyAny>)> {
+    satkit::frametransform::ierstable::preload()?;
     state_transform_batch(pos_itrf, vel_itrf, time, ft::itrf_to_gcrf_state)
 }
 
@@ -405,6 +409,7 @@ pub fn gcrf_to_itrf_state(
     vel_gcrf: &Bound<'_, PyAny>,
     time: &Bound<'_, PyAny>,
 ) -> Result<(Py<PyAny>, Py<PyAny>)> {
+    satkit::frametransform::ierstable::preload()?;
     state_transform_batch(pos_gcrf, vel_gcrf, time, ft::gcrf_to_itrf_state)
 }
 
@@ -546,6 +551,7 @@ pub fn rotation(
     to_frame: crate::pyframes::PyFrame,
     tm: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
+    satkit::frametransform::ierstable::preload()?;
     rotation_dispatch_batch(from_frame, to_frame, tm, /* approx = */ false)
 }
 
@@ -636,6 +642,7 @@ pub fn transform_state(
     pos: &Bound<'_, PyAny>,
     vel: &Bound<'_, PyAny>,
 ) -> Result<(Py<PyAny>, Py<PyAny>)> {
+    satkit::frametransform::ierstable::preload()?;
     let t = instant_from_pyany(tm)?;
     let p: Vector3 = py_to_smatrix(pos)?;
     let v: Vector3 = py_to_smatrix(vel)?;
@@ -700,6 +707,7 @@ pub fn rotation_with_state(
     pos: &Bound<'_, PyAny>,
     vel: &Bound<'_, PyAny>,
 ) -> Result<Py<PyAny>> {
+    satkit::frametransform::ierstable::preload()?;
     let t = instant_from_pyany(tm)?;
     let p: Vector3 = py_to_smatrix(pos)?;
     let v: Vector3 = py_to_smatrix(vel)?;
@@ -720,4 +728,53 @@ pub fn rotation_with_state(
 #[pyfunction(name = "disable_eop_time_warning")]
 pub fn disable_eop_time_warning() {
     satkit::earth_orientation_params::disable_eop_time_warning();
+}
+
+/// Time bounds of the loaded Earth Orientation Parameters (EOP) table.
+///
+/// Returns:
+///     (satkit.time, satkit.time, satkit.time) | None: ``(first, last_observed, last)`` —
+///     the first row, the last *observed* row (rows after it are IERS
+///     predictions) and the last row of the table; ``None`` if no table is
+///     loaded. Epochs after ``last`` use that row's values held constant
+///     (see :func:`eop_status`); refresh with ``satkit.utils.update_datafiles()``.
+///
+/// Example:
+///     >>> first, last_obs, last = satkit.frametransform.eop_coverage()
+#[pyfunction(name = "eop_coverage")]
+pub fn eop_coverage() -> Option<(PyInstant, PyInstant, PyInstant)> {
+    satkit::earth_orientation_params::coverage().map(|c| {
+        (
+            PyInstant(c.first),
+            PyInstant(c.last_observed),
+            PyInstant(c.last),
+        )
+    })
+}
+
+/// Classify an epoch against the loaded Earth Orientation Parameters (EOP) table.
+///
+/// Args:
+///     tm (satkit.time): Epoch to classify
+///
+/// Returns:
+///     str: one of
+///
+///     * ``"observed"`` — inside the table, on or before the last observed row
+///     * ``"predicted"`` — inside the table, IERS prediction
+///     * ``"extrapolated"`` — after the table end: the last row is held constant
+///       (accuracy degrades by ~0.1 arcsec / ~10 ms per few months — refresh the
+///       data files)
+///     * ``"before_table"`` — before 1962: no EOP, zeros are used
+///     * ``"not_loaded"`` — no EOP table loaded at all: zeros are used
+#[pyfunction(name = "eop_status")]
+pub fn eop_status(tm: &PyInstant) -> &'static str {
+    use satkit::earth_orientation_params::EopStatus::*;
+    match satkit::earth_orientation_params::status(&tm.0) {
+        Observed => "observed",
+        Predicted => "predicted",
+        Extrapolated => "extrapolated",
+        BeforeTable => "before_table",
+        NotLoaded => "not_loaded",
+    }
 }

--- a/python/src/pypropsettings.rs
+++ b/python/src/pypropsettings.rs
@@ -188,6 +188,10 @@ impl PyPropSettings {
                 ps.use_relativistic_correction = gr.extract::<bool>()?;
                 kw.del_item("use_relativistic_correction")?;
             }
+            if let Some(req) = kw.get_item("require_eop_coverage")? {
+                ps.require_eop_coverage = req.extract::<bool>()?;
+                kw.del_item("require_eop_coverage")?;
+            }
             crate::pyutils::reject_unused_kwargs(kw)?;
             if order_explicitly_set {
                 // Clamp order to degree
@@ -363,6 +367,21 @@ impl PyPropSettings {
     #[setter(use_relativistic_correction)]
     fn set_use_relativistic_correction(&mut self, val: bool) -> PyResult<()> {
         self.0.use_relativistic_correction = val;
+        Ok(())
+    }
+
+    /// Fail a propagation whose span extends past the end of the loaded
+    /// Earth-orientation-parameter (EOP) table instead of holding the last
+    /// EOP row constant with a one-time warning. Default False. See
+    /// ``satkit.frametransform.eop_coverage``.
+    #[getter]
+    fn get_require_eop_coverage(&self) -> bool {
+        self.0.require_eop_coverage
+    }
+
+    #[setter(require_eop_coverage)]
+    fn set_require_eop_coverage(&mut self, val: bool) -> PyResult<()> {
+        self.0.require_eop_coverage = val;
         Ok(())
     }
 

--- a/python/test/test_eop.py
+++ b/python/test/test_eop.py
@@ -1,0 +1,64 @@
+"""
+Earth Orientation Parameter (EOP) coverage: the table bounds, the status of
+an epoch relative to them, and the propagator's behaviour past the table end.
+"""
+
+import pickle
+
+import numpy as np
+import pytest
+
+import satkit as sk
+
+
+def test_eop_coverage_bounds():
+    cov = sk.frametransform.eop_coverage()
+    assert cov is not None, "EOP-All.csv must be available for the test suite"
+    first, last_observed, last = cov
+    assert isinstance(first, sk.time)
+    assert first < last_observed <= last
+    # The table starts in 1962 and must cover a well-observed historical epoch.
+    assert first < sk.time(1963, 1, 1)
+    assert last_observed > sk.time(2020, 1, 1)
+
+
+def test_eop_status_values():
+    first, last_observed, last = sk.frametransform.eop_coverage()
+    assert sk.frametransform.eop_status(sk.time(2006, 4, 16, 17, 52, 50)) == "observed"
+    assert sk.frametransform.eop_status(first) == "observed"
+    assert sk.frametransform.eop_status(last_observed) == "observed"
+    assert sk.frametransform.eop_status(sk.time(1950, 1, 1)) == "before_table"
+    assert sk.frametransform.eop_status(last + sk.duration.from_days(10)) == "extrapolated"
+    if last_observed < last:
+        assert sk.frametransform.eop_status(last_observed + sk.duration.from_days(1)) == "predicted"
+    # earth_orientation_params still answers (constant extrapolation) past the end.
+    assert sk.frametransform.earth_orientation_params(last + sk.duration.from_days(10)) is not None
+
+
+def _leo_state():
+    return np.array([6878e3, 0.0, 0.0, 0.0, 7612.0, 0.0])
+
+
+def test_require_eop_coverage_raises_past_table_end():
+    _, _, last = sk.frametransform.eop_coverage()
+    t0 = last + sk.duration.from_days(30)
+    t1 = t0 + sk.duration.from_seconds(600)
+    strict = sk.propsettings(require_eop_coverage=True)
+    assert strict.require_eop_coverage is True
+    with pytest.raises(RuntimeError, match="EOP data ends"):
+        sk.propagate(_leo_state(), t0, end=t1, propsettings=strict)
+    # Default: extrapolates and succeeds.
+    res = sk.propagate(_leo_state(), t0, end=t1, propsettings=sk.propsettings())
+    assert np.all(np.isfinite(res.state))
+    # Inside coverage the flag is inert.
+    t0 = last - sk.duration.from_days(30)
+    sk.propagate(_leo_state(), t0, end=t0 + sk.duration.from_seconds(600), propsettings=strict)
+
+
+def test_require_eop_coverage_property_and_pickle():
+    ps = sk.propsettings()
+    assert ps.require_eop_coverage is False
+    ps.require_eop_coverage = True
+    restored = pickle.loads(pickle.dumps(ps))
+    assert restored.require_eop_coverage is True
+    assert "Require EOP Coverage: true" in str(restored)

--- a/src/earth_orientation_params.rs
+++ b/src/earth_orientation_params.rs
@@ -23,6 +23,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::utils::datadir;
 use crate::utils::{download_file, download_if_not_exist};
+use crate::{Instant, TimeLike, TimeScale};
 
 use thiserror::Error;
 
@@ -74,6 +75,46 @@ struct EOPEntry {
     lod: f64,
     dX: f64,
     dY: f64,
+    /// `true` for an observed (`O`) row, `false` for a predicted (`P`) row
+    /// (CelesTrak `DATA_TYPE` column).
+    observed: bool,
+}
+
+/// Where a given epoch falls relative to the loaded EOP table.
+///
+/// Returned by [`status`]; see [`coverage`] for the table bounds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EopStatus {
+    /// Inside the table, on or before the last observed (`O`) row.
+    Observed,
+    /// Inside the table, after the last observed row: IERS predictions.
+    Predicted,
+    /// After the last row of the table: the last row's values are held
+    /// constant. Accuracy degrades with distance from the table end
+    /// (polar motion drifts ~0.1″ and UT1−UTC by ~10 ms over a few
+    /// months) — refresh the data with
+    /// [`update`] / `satkit::utils::update_datafiles()`.
+    Extrapolated,
+    /// Before the first row of the table (before 1962): no EOP available,
+    /// [`get`] returns `None` and the frame transforms use zeros.
+    BeforeTable,
+    /// No EOP table is loaded at all (file missing and download failed,
+    /// or an empty table was installed): [`get`] returns `None` and the
+    /// frame transforms use zeros.
+    NotLoaded,
+}
+
+/// Time bounds of the loaded EOP table (UTC).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EopCoverage {
+    /// Epoch of the first row.
+    pub first: Instant,
+    /// Epoch of the last observed (`O`) row; rows after it are IERS
+    /// predictions.
+    pub last_observed: Instant,
+    /// Epoch of the last row (observed or predicted). Queries after it
+    /// return this row's values unchanged.
+    pub last: Instant,
 }
 
 /// Parse an `EOP-All.csv` text buffer into EOP entries.
@@ -93,6 +134,7 @@ fn parse_csv(text: &str) -> Result<Vec<EOPEntry>> {
                 lod: lvals[5].parse()?,
                 dX: lvals[8].parse()?,
                 dY: lvals[9].parse()?,
+                observed: lvals[11].trim() != "P",
             })
         })
         .collect()
@@ -108,6 +150,8 @@ fn load_eop_file_csv() -> Result<Vec<EOPEntry>> {
 }
 
 static WARNING_SHOWN: AtomicBool = AtomicBool::new(false);
+static EXTRAP_WARNING_SHOWN: AtomicBool = AtomicBool::new(false);
+static NOT_LOADED_WARNING_SHOWN: AtomicBool = AtomicBool::new(false);
 
 /// Module-scope refreshable singleton. The lazy default load (best-effort,
 /// silent on failure) runs at most once; [`init_from_bytes`] /
@@ -140,10 +184,12 @@ pub fn init_from_path(path: &std::path::Path) -> Result<()> {
 }
 
 ///
-/// Disable warning about out-of-range EOP data.
+/// Disable the warnings about out-of-range or missing EOP data.
 ///
-/// Warning is shown only once, but to prevent it from being shown,
-/// run this function.
+/// Three one-time warnings exist: epoch before the table, epoch after the
+/// table (values held constant), and no table loaded at all (zeros used).
+/// Each is shown at most once per process; call this to suppress all of
+/// them.
 ///
 /// # Example
 ///
@@ -153,6 +199,63 @@ pub fn init_from_path(path: &std::path::Path) -> Result<()> {
 ///
 pub fn disable_eop_time_warning() {
     WARNING_SHOWN.store(true, Ordering::Relaxed);
+    EXTRAP_WARNING_SHOWN.store(true, Ordering::Relaxed);
+    NOT_LOADED_WARNING_SHOWN.store(true, Ordering::Relaxed);
+}
+
+/// Time bounds of the loaded EOP table, or `None` if no table is loaded
+/// (file missing and download failed, or an empty table was installed).
+///
+/// # Example
+///
+/// ```rust
+/// if let Some(c) = satkit::earth_orientation_params::coverage() {
+///     println!("EOP observed through {}, predicted through {}", c.last_observed, c.last);
+/// }
+/// ```
+pub fn coverage() -> Option<EopCoverage> {
+    ensure_default_loaded();
+    let guard = EOP.read();
+    let eop = guard.as_ref()?;
+    let first = eop.first()?;
+    let last = eop.last()?;
+    let last_observed = eop.iter().rev().find(|e| e.observed).unwrap_or(first);
+    Some(EopCoverage {
+        first: Instant::from_mjd_utc(first.mjd_utc),
+        last_observed: Instant::from_mjd_utc(last_observed.mjd_utc),
+        last: Instant::from_mjd_utc(last.mjd_utc),
+    })
+}
+
+/// Classify an epoch against the loaded EOP table — see [`EopStatus`].
+///
+/// Useful before a long propagation or a precision frame transform: a
+/// result of [`EopStatus::Extrapolated`] means the data file should be
+/// refreshed, and [`EopStatus::NotLoaded`] means every EOP-dependent
+/// transform is using zeros.
+pub fn status<T: TimeLike>(tm: &T) -> EopStatus {
+    let mjd_utc = tm.as_mjd_with_scale(TimeScale::UTC);
+    ensure_default_loaded();
+    let guard = EOP.read();
+    let Some(eop) = guard.as_ref().filter(|e| !e.is_empty()) else {
+        return EopStatus::NotLoaded;
+    };
+    if mjd_utc < eop[0].mjd_utc {
+        return EopStatus::BeforeTable;
+    }
+    if mjd_utc > eop[eop.len() - 1].mjd_utc {
+        return EopStatus::Extrapolated;
+    }
+    let last_observed = eop
+        .iter()
+        .rev()
+        .find(|e| e.observed)
+        .map_or(-1.0, |e| e.mjd_utc);
+    if mjd_utc <= last_observed {
+        EopStatus::Observed
+    } else {
+        EopStatus::Predicted
+    }
 }
 
 /// Download new Earth Orientation Parameters file, and load it.
@@ -189,12 +292,30 @@ pub fn update() -> Result<()> {
 ///
 /// * If time is before range of file, returns None and prints warning to stderr
 ///   (but only once per library load)
-/// * If time is after range of file, returns the last entry's values (constant extrapolation)
+/// * If time is after range of file, returns the last entry's values (constant
+///   extrapolation) and prints a warning to stderr the first time this happens
+/// * If no table is loaded at all, returns None and prints a warning to stderr
+///   the first time this happens
+///
+/// Use [`status`] / [`coverage`] to check which regime an epoch is in without
+/// relying on the warnings; [`disable_eop_time_warning`] suppresses them.
 ///
 pub fn eop_from_mjd_utc(mjd_utc: f64) -> Option<[f64; 6]> {
     ensure_default_loaded();
     let guard = EOP.read();
-    let eop = guard.as_ref()?;
+    let Some(eop) = guard.as_ref().filter(|e| !e.is_empty()) else {
+        if !NOT_LOADED_WARNING_SHOWN.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "Warning: no Earth Orientation Parameters (EOP) table is loaded; polar motion, \
+                 UT1-UTC and nutation corrections are being treated as zero, which biases \
+                 Earth-fixed frame transforms and orbit propagation by metres.\n\
+                 Run `satkit::utils::update_datafiles()` (Python: `satkit.utils.update_datafiles()`) \
+                 to download EOP-All.csv, or set SATKIT_DATA to a directory containing it.\n\
+                 To disable: `satkit::earth_orientation_params::disable_eop_time_warning()`"
+            );
+        }
+        return None;
+    };
 
     // Binary search: find first entry with mjd_utc > query (O(log n) vs O(n) linear scan)
     let idx = eop.partition_point(|x| x.mjd_utc <= mjd_utc);
@@ -213,6 +334,18 @@ pub fn eop_from_mjd_utc(mjd_utc: f64) -> Option<[f64; 6]> {
     // For dates beyond the file, use the last entry's values
     if idx >= eop.len() {
         let last = &eop[eop.len() - 1];
+        if !EXTRAP_WARNING_SHOWN.swap(true, Ordering::Relaxed) {
+            eprintln!(
+                "Warning: EOP data ends at {} (MJD {}); the request for MJD UTC = {mjd_utc} and \
+                 all later epochs use the last entry's values held constant. Polar motion and \
+                 UT1-UTC drift by ~0.1 arcsec / ~10 ms over a few months, i.e. metres at LEO.\n\
+                 Run `satkit::utils::update_datafiles()` (Python: `satkit.utils.update_datafiles()`) \
+                 to download the most recent EOP-All.csv.\n\
+                 To disable: `satkit::earth_orientation_params::disable_eop_time_warning()`",
+                Instant::from_mjd_utc(last.mjd_utc),
+                last.mjd_utc
+            );
+        }
         return Some([last.dut1, last.xp, last.yp, last.lod, last.dX, last.dY]);
     }
 
@@ -302,6 +435,41 @@ mod tests {
         let tm = crate::Instant::from_rfc3339("1950-04-16T17:52:50.805408Z").unwrap();
         let eop = eop_from_mjd_utc(tm.as_mjd_with_scale(crate::TimeScale::UTC));
         assert!(eop.is_none());
+    }
+
+    #[test]
+    fn coverage_and_status() {
+        let c = coverage().expect("EOP table loaded in tests");
+        assert!(c.first < c.last_observed);
+        assert!(c.last_observed <= c.last);
+
+        // A well-observed historical epoch.
+        let t = crate::Instant::from_rfc3339("2006-04-16T17:52:50.805408Z").unwrap();
+        assert_eq!(status(&t), EopStatus::Observed);
+        assert_eq!(status(&c.first), EopStatus::Observed);
+        assert_eq!(status(&c.last_observed), EopStatus::Observed);
+        // Past the end of the table: held constant.
+        let late = c.last + crate::Duration::from_days(10.0);
+        assert_eq!(status(&late), EopStatus::Extrapolated);
+        assert!(eop_from_mjd_utc(late.as_mjd_utc()).is_some());
+        // Predictions, when the file carries any.
+        if c.last_observed < c.last {
+            let mid = c.last_observed + crate::Duration::from_days(1.0);
+            assert_eq!(status(&mid), EopStatus::Predicted);
+        }
+        // Before 1962.
+        let early = crate::Instant::from_rfc3339("1950-04-16T00:00:00Z").unwrap();
+        assert_eq!(status(&early), EopStatus::BeforeTable);
+    }
+
+    #[test]
+    fn parse_retains_data_type() {
+        let text = "DATE,MJD,X,Y,UT1-UTC,LOD,DPSI,DEPS,DX,DY,DAT,DATA_TYPE\n\
+                    2024-01-10,60319,0.119289,0.206294,0.0074355,-0.0004170,-0.112002,-0.006175,0.000248,-0.000168,37,O\n\
+                    2024-01-11,60320,0.118000,0.207000,0.0075000,-0.0004000,-0.112000,-0.006100,0.000240,-0.000160,37,P\n";
+        let rows = parse_csv(text).unwrap();
+        assert!(rows[0].observed);
+        assert!(!rows[1].observed);
     }
 
     /// Check value against manual value from file

--- a/src/frametransform/ierstable.rs
+++ b/src/frametransform/ierstable.rs
@@ -70,6 +70,25 @@ pub fn table(id: IersTableId) -> &'static IERSTable {
     })
 }
 
+/// Load all three IERS precession-nutation tables now, returning an error
+/// (instead of the panic the lazy [`table`] accessor raises) if a file is
+/// missing or unreadable. Idempotent: tables that are already initialized
+/// are left untouched. The Python bindings and
+/// [`Precomputed`](crate::orbitprop::Precomputed) call this so a missing
+/// data file surfaces as a normal error before any transform runs.
+pub fn preload() -> Result<()> {
+    for id in [IersTableId::Tab5A, IersTableId::Tab5B, IersTableId::Tab5D] {
+        let cell = instance_for(id);
+        if cell.get().is_none() {
+            let parsed = IERSTable::from_file(id.default_filename())?;
+            // A concurrent lazy init may have won the race; either way the
+            // table is now loaded, so an `Err` from `set` is not a failure.
+            let _ = cell.set(parsed);
+        }
+    }
+    Ok(())
+}
+
 /// Initialize the IERS table singleton for `id` from an in-memory byte
 /// buffer.
 ///

--- a/src/frametransform/mod.rs
+++ b/src/frametransform/mod.rs
@@ -142,10 +142,12 @@ pub fn earth_rotation_angle<T: TimeLike>(tm: &T) -> f64 {
 ///
 /// # Notes:
 ///
-/// This function requires use of the Earth orentation parameters
-/// (EOP) to compute the rotation. If the EOP are not outside of the
-/// valid range of EOP data (1962 to current, predicts to current + ~ 4 months)
-/// they will be set to zero, and a warning will be printed to stderr.
+/// This function uses the Earth orientation parameters (EOP). For epochs
+/// after the end of the loaded EOP table the last row's values are held
+/// constant; before 1962, or when no table is loaded at all, zeros are
+/// used. Each case prints a one-time warning to stderr; use
+/// [`earth_orientation_params::status`] / [`earth_orientation_params::coverage`]
+/// to check explicitly.
 ///
 pub fn qitrf2tirs<T: TimeLike>(tm: &T) -> Quaternion {
     // Get earth orientation parameters or set them all to zero if not available
@@ -416,10 +418,12 @@ pub fn qtod2mod_approx<T: TimeLike>(tm: &T) -> Quaternion {
 ///   Earth solid tides, but it does include polar motion,
 ///   precession, and nutation
 ///
-/// * This function requires use of the Earth orientation parameters
-///   (EOP) to compute the rotation. If the EOP are not outside of the
-///   valid range of EOP data (1962 to current, predicts to current + ~ 4 months)
-///   they will be set to zero, and a warning will be printed to stderr.
+/// * This function uses the Earth orientation parameters (EOP). For epochs
+///   after the end of the loaded EOP table the last row's values are held
+///   constant; before 1962, or when no table is loaded at all, zeros are
+///   used. Each case prints a one-time warning to stderr; use
+///   [`earth_orientation_params::status`] /
+///   [`earth_orientation_params::coverage`] to check explicitly.
 ///
 /// # Note — velocity transforms
 ///

--- a/src/orbitprop/error.rs
+++ b/src/orbitprop/error.rs
@@ -4,6 +4,7 @@ use numeris::ode;
 use thiserror::Error;
 
 use crate::Frame;
+use crate::Instant;
 
 /// Errors that can occur while configuring or executing orbit propagation.
 #[derive(Debug, Error)]
@@ -118,6 +119,42 @@ pub enum Error {
          gj_step_seconds or use an adaptive integrator."
     )]
     GJIntervalTooShort { span: f64, min: f64 },
+
+    // -- EOP coverage (precomputed.rs / propagator.rs) ---------------------
+    /// No Earth Orientation Parameters table is loaded (file missing and
+    /// download failed, or an empty table installed). A propagation would
+    /// then run with zero polar motion / UT1−UTC / nutation corrections and
+    /// be silently wrong by metres, so it is refused. Run
+    /// `satkit::utils::update_datafiles()` or point `SATKIT_DATA` at a
+    /// directory containing `EOP-All.csv`.
+    #[error(
+        "no Earth Orientation Parameters (EOP) table is loaded; run \
+         satkit::utils::update_datafiles() or set SATKIT_DATA to a directory \
+         containing EOP-All.csv"
+    )]
+    EopUnavailable,
+
+    /// Returned by [`propagate`](crate::orbitprop::propagate) when
+    /// [`PropSettings::require_eop_coverage`](crate::orbitprop::PropSettings::require_eop_coverage)
+    /// is set and the propagation span (plus integrator padding) extends
+    /// past the end of the loaded EOP table. Without the flag the last EOP
+    /// row is held constant and a one-time warning is printed instead.
+    #[error(
+        "propagation span extends to {span_end} but EOP data ends at {table_end} \
+         (PropSettings::require_eop_coverage is set); refresh the data files with \
+         satkit::utils::update_datafiles() or clear the flag to extrapolate"
+    )]
+    EopCoverage {
+        span_end: Instant,
+        table_end: Instant,
+    },
+
+    /// Wraps a frame-transform error — in practice a missing or unreadable
+    /// IERS precession-nutation table detected by
+    /// [`ierstable::preload`](crate::frametransform::ierstable::preload)
+    /// while building a [`Precomputed`](crate::orbitprop::Precomputed) table.
+    #[error(transparent)]
+    FrameTransform(#[from] crate::frametransform::Error),
 }
 
 impl From<ode::OdeError> for Error {

--- a/src/orbitprop/precomputed.rs
+++ b/src/orbitprop/precomputed.rs
@@ -159,6 +159,20 @@ impl Precomputed {
                 jplephem::geocentric_pos(SolarSystem::Sun, &pbegin)?;
                 jplephem::geocentric_pos(SolarSystem::Sun, &pend)?;
 
+                // The frame chain below needs the IERS nutation tables and an
+                // EOP table. Load the former now so a missing data file is an
+                // error here rather than a panic inside the force model, and
+                // refuse to build a table with no EOP at all — zero polar
+                // motion / UT1-UTC would silently bias the propagation by
+                // metres. A span past the *end* of the EOP table is allowed
+                // (the last row is held constant; `earth_orientation_params`
+                // warns once), and `PropSettings::require_eop_coverage`
+                // turns that into an error at `propagate()`.
+                crate::frametransform::ierstable::preload()?;
+                if crate::earth_orientation_params::coverage().is_none() {
+                    return Err(Error::EopUnavailable);
+                }
+
                 // The GCRF→ITRF rotation is the full IAU 2006/2000A chain
                 // (precession-nutation with EOP dX/dY, Earth rotation angle,
                 // polar motion) — the same as `frametransform::qgcrf2itrf`.
@@ -361,6 +375,19 @@ mod tests {
         let week = Precomputed::new(&t0, &(t0 + Duration::from_days(7.0))).unwrap();
         assert!(week.interp(&(t0 + Duration::from_days(3.5))).is_ok());
         assert_eq!(table_len(7.0 * 86400.0, 60.0).unwrap(), 2 + 7 * 1440);
+    }
+
+    /// A span past the end of the EOP table still builds (the last EOP row
+    /// is held constant, with a one-time warning); the IERS tables preload.
+    #[test]
+    fn test_past_eop_coverage_builds() {
+        crate::frametransform::ierstable::preload().expect("IERS tables present in tests");
+        let cov = crate::earth_orientation_params::coverage().expect("EOP loaded in tests");
+        let t0 = cov.last + Duration::from_days(30.0);
+        let t1 = t0 + Duration::from_days(1.0);
+        let pc = Precomputed::new(&t0, &t1).unwrap();
+        let s = pc.interp(&(t0 + Duration::from_seconds(3600.0))).unwrap();
+        assert!(s.qgcrf2itrf.to_axis_angle().1.is_finite());
     }
 
     #[test]

--- a/src/orbitprop/propagator.rs
+++ b/src/orbitprop/propagator.rs
@@ -476,6 +476,16 @@ pub fn propagate<const C: usize, T: TimeLike>(
     let padding = Duration::from_seconds(padding_secs);
     let required_min = tmin - padding;
     let required_max = tmax + padding;
+    if settings.require_eop_coverage {
+        let cov = crate::earth_orientation_params::coverage()
+            .ok_or(crate::orbitprop::Error::EopUnavailable)?;
+        if required_max > cov.last {
+            return Err(crate::orbitprop::Error::EopCoverage {
+                span_end: required_max,
+                table_end: cov.last,
+            });
+        }
+    }
     let interp: &Precomputed = match &settings.precomputed {
         Some(p) if required_min >= p.begin && required_max <= p.end => p,
         _ => &Precomputed::new_padded(&begin, &end, 60.0, padding_secs)?,
@@ -823,6 +833,44 @@ mod tests {
             propagate::<3, _>(&state, &t0, &t1, &PropSettings::default(), None),
             Err(Error::InvalidStateColumns { c: 3 })
         ));
+        Ok(())
+    }
+
+    /// `require_eop_coverage` turns a span past the EOP table end into an
+    /// error; the default keeps the (warned) constant extrapolation.
+    #[test]
+    fn test_require_eop_coverage() -> Result<()> {
+        let cov = crate::earth_orientation_params::coverage().expect("EOP loaded in tests");
+        let begin = cov.last + Duration::from_days(30.0);
+        let end = begin + Duration::from_seconds(600.0);
+        let mut state = SimpleState::zeros();
+        state[0] = 6_878e3;
+        state[4] = 7_612.0;
+        let strict = PropSettings {
+            require_eop_coverage: true,
+            ..Default::default()
+        };
+        match propagate(&state, &begin, &end, &strict, None) {
+            Err(Error::EopCoverage {
+                span_end,
+                table_end,
+            }) => {
+                assert_eq!(table_end, cov.last);
+                assert!(span_end >= end);
+            }
+            other => panic!("expected EopCoverage, got {other:?}"),
+        }
+        // Inside coverage the flag is inert.
+        let inside = cov.last - Duration::from_days(30.0);
+        propagate(
+            &state,
+            &inside,
+            &(inside + Duration::from_seconds(600.0)),
+            &strict,
+            None,
+        )?;
+        // Default: extrapolates.
+        propagate(&state, &begin, &end, &PropSettings::default(), None)?;
         Ok(())
     }
 

--- a/src/orbitprop/settings.rs
+++ b/src/orbitprop/settings.rs
@@ -104,6 +104,18 @@ pub struct PropSettings {
     /// Runge-Kutta / Rosenbrock via [`numeris::ode::AdaptiveSettings`] and
     /// Gauss-Jackson 8 via its own settings). Default: 1_000_000.
     pub max_steps: usize,
+    /// Fail a propagation whose span (plus integrator padding) extends past
+    /// the end of the loaded Earth-orientation-parameter (EOP) table with
+    /// [`Error::EopCoverage`](super::Error::EopCoverage), instead of holding
+    /// the last EOP row constant with a one-time warning. Off by default —
+    /// propagating into next year is a legitimate use and constant
+    /// extrapolation is a reasonable best effort (polar motion and UT1−UTC
+    /// drift by ~0.1″ / ~10 ms over a few months, i.e. metres at LEO) —
+    /// but set it for precision work and refresh the data files
+    /// (`satkit::utils::update_datafiles()`) when it trips. See
+    /// [`crate::earth_orientation_params::coverage`]. Default: `false`.
+    #[serde(default)]
+    pub require_eop_coverage: bool,
     /// Regenerable ephemeris/EOP cache; excluded from serialization (a
     /// deserialized `PropSettings` recomputes it lazily as needed).
     #[serde(skip)]
@@ -127,6 +139,7 @@ impl Default for PropSettings {
             integrator: Integrator::default(),
             gj_step_seconds: 60.0,
             max_steps: 1_000_000,
+            require_eop_coverage: false,
             precomputed: None,
         }
     }
@@ -272,6 +285,7 @@ impl std::fmt::Display for PropSettings {
             Interpolation: {},
             Integrator: {},
             Max Steps: {},
+            Require EOP Coverage: {},
             {}"#,
             self.gravity_degree,
             self.gravity_order,
@@ -286,6 +300,7 @@ impl std::fmt::Display for PropSettings {
             self.enable_interp,
             self.integrator,
             self.max_steps,
+            self.require_eop_coverage,
             self.precomputed.as_ref().map_or_else(
                 || "No Precomputed".to_string(),
                 |p| format!("Precomputed: {} to {}", p.begin, p.end)

--- a/tests/earth_orientation_params_init.rs
+++ b/tests/earth_orientation_params_init.rs
@@ -40,4 +40,32 @@ fn init_from_bytes_replaces_and_query_works() {
         .expect("second init_from_bytes should succeed (refreshable subsystem)");
     let v2 = eop::eop_from_mjd_utc(59464.00).expect("EOP for MJD 59464 after reload");
     assert_eq!(v, v2);
+
+    // 4. Coverage / status on the real table.
+    let cov = eop::coverage().expect("coverage after init");
+    assert!(cov.first < cov.last_observed && cov.last_observed <= cov.last);
+    assert_eq!(eop::status(&cov.first), eop::EopStatus::Observed);
+    assert_eq!(
+        eop::status(&(cov.last + satkit::Duration::from_days(1.0))),
+        eop::EopStatus::Extrapolated
+    );
+
+    // 5. An empty table (header only) counts as *not loaded*: no coverage,
+    //    queries return None, and the propagator refuses to build its
+    //    ephemeris table rather than run with zero EOP.
+    let header = bytes.split(|&b| b == b'\n').next().unwrap().to_vec();
+    eop::init_from_bytes(&header).expect("header-only init parses");
+    assert!(eop::coverage().is_none());
+    assert_eq!(eop::status(&cov.first), eop::EopStatus::NotLoaded);
+    assert!(eop::eop_from_mjd_utc(59464.00).is_none());
+    let t0 = satkit::Instant::from_datetime(2024, 1, 1, 0, 0, 0.0).unwrap();
+    let t1 = t0 + satkit::Duration::from_hours(1.0);
+    match satkit::orbitprop::Precomputed::new(&t0, &t1) {
+        Err(satkit::orbitprop::Error::EopUnavailable) => {}
+        other => panic!("expected EopUnavailable with an empty EOP table, got {other:?}"),
+    }
+
+    // 6. Restore the real table so nothing else in this process is affected.
+    eop::init_from_bytes(&bytes).expect("restore");
+    assert!(eop::coverage().is_some());
 }


### PR DESCRIPTION
Non-breaking mitigation from the #125 review. Since #127 the propagator uses the full EOP chain, and `eop_from_mjd_utc` silently (a) held the last row constant past the table end and (b) returned zeros when no table was loaded — only pre-1962 epochs warned. A 4-month-stale `EOP-All.csv` shifts a 7-day LEO propagation by ~10 m with no indication; this machine's file had been stale since 2026-08-23.

## Added
- `earth_orientation_params::{coverage() -> Option<EopCoverage>, status(t) -> EopStatus}` (`Observed | Predicted | Extrapolated | BeforeTable | NotLoaded`); the parser now keeps the `DATA_TYPE` flag.
- One-time stderr warnings when an epoch is past the table end (values held constant, with the table end date) and when no table is loaded (zeros); `disable_eop_time_warning()` silences all three.
- `PropSettings::require_eop_coverage` (default `false`; serde default, Display, Python kwarg/property/pickle): when set, `propagate()` returns `Error::EopCoverage { span_end, table_end }` if the span exceeds the predictions. Forward propagation past the predictions is still allowed by default — it is legitimate — just visible now.
- `Error::EopUnavailable`: `Precomputed::new_padded` fails when no EOP table is loaded at all (a zero-EOP propagation is silently wrong by metres; there is no legitimate use).
- `frametransform::ierstable::preload() -> Result<()>`: loads the three nutation tables, error instead of panic; called from `Precomputed` and from the Python frame-transform entry points, so a missing `tab5.2*.txt` now raises `RuntimeError` rather than `PanicException`. Rust `q*2*` functions still panic until the 0.21 `Result` threading (#125).
- Python: `satkit.frametransform.eop_coverage()`, `eop_status(t)`, `propsettings(require_eop_coverage=...)`.
- Docs: `datafiles.md` "EOP coverage" section; corrected the two `frametransform` doc comments that claimed zeros + a warning.

## Tests
Rust: coverage/status over observed/predicted/past-end/pre-1962 (via `coverage()`, no hard-coded dates), `DATA_TYPE` retained, past-end table builds with warning, `require_eop_coverage` errors past end / inert inside / default extrapolates, header-only table → `NotLoaded` → `EopUnavailable`. Python `test_eop.py`: coverage bounds, status values, `require_eop_coverage` raises `RuntimeError`, property + pickle round-trip.

## Verification
- [x] fmt / clippy clean; `cargo test --features chrono` 237 lib + 42 integration; GMAT residuals unchanged
- [x] `pytest python/test/` 155 passed; stubtest clean; `cargo doc` warning count = main
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE