### PR TITLE
Bump numeris to 0.5.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
 - **numeris 0.5.14 → 0.5.17.** Picks up the ODE fix that clamps the
   initial step to the propagation span; no measurable change to any test
   baseline or GMAT residual.
+- **numeris 0.5.17 → 0.5.18.** Adaptive Runge–Kutta integrators no longer
+  abort with "too many consecutive step rejections" when the force model has
+  a kink inside a step — e.g. an Earth-shadow boundary switching solar
+  radiation pressure on a GNSS satellite (previously failed for eclipsing
+  arcs longer than ~2 days at tight tolerances). No change to any test
+  baseline or GMAT residual.
 - **Relativistic correction now includes geodesic precession and
   Lense–Thirring.** `PropSettings::use_relativistic_correction` (default on)
   previously applied only the Schwarzschild term of IERS 2010 Eq. 10.12; it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ name = "satkit"
 
 
 [dependencies]
-numeris = { version = "0.5.17", features = ["serde", "ode"] }
+numeris = { version = "0.5.18", features = ["serde", "ode"] }
 thiserror = "2.0"
 ureq = { version = "3.1.2", optional = true }
 process_path = "0.1.4"

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Seamless conversion between UTC, TAI, TT, TDB, UT1, and GPS time scales with ful
 SatKit uses [numeris](https://crates.io/crates/numeris) for all linear algebra (vectors, matrices, quaternions, ODE integration). If you also use nalgebra in your project, enable the `nalgebra` feature on numeris for zero-cost `From`/`Into` conversions between types:
 
 ```toml
-numeris = { version = "0.5.17", features = ["nalgebra"] }
+numeris = { version = "0.5.18", features = ["nalgebra"] }
 ```
 
 ### Cargo Features

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,7 +16,7 @@ doc = false
 satkit = { path = "..", features = ["download"] }
 pyo3 = { version = "0.29", features = ["extension-module", "anyhow"] }
 numpy = "0.29"
-numeris = { version = "0.5.17", features = ["serde", "ode"] }
+numeris = { version = "0.5.18", features = ["serde", "ode"] }
 anyhow = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde-pickle = "1.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //! feature on `numeris` for zero-cost `From`/`Into` conversions:
 //!
 //! ```toml
-//! numeris = { version = "0.5.17", features = ["nalgebra"] }
+//! numeris = { version = "0.5.18", features = ["nalgebra"] }
 //! ```
 //!
 //! ## Optional Features


### PR DESCRIPTION
Bumps `numeris` 0.5.17 → 0.5.18 in both crates and the doc/README examples.

Upstream: `fix(ode): force 2x step shrink on repeated rejections; raise limit to 50` — the issue found during the ECOM validation (#131): adaptive RK integrators aborted with "too many consecutive step rejections" at Earth-shadow boundaries because the rejection shrink assumed h^(p+1) error scaling.

Verified in satkit: an eclipsing GPS arc (G08, ~8% umbra, cannonball SRP, RKV98 at 1e-10) now completes at 24/48/60/72 h; it previously failed for every end time ≥ 47.6 h. Full Rust suite (317 tests) and Python suite pass; all GMAT residuals unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE