### PR TITLE
Data manifest with SHA-256 verification and GitHub-release-first sources (Phase 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           path: astro-data
           enableCrossOsArchive: true
-          key: satkit-data-cache
+          key: satkit-data-${{ hashFiles('data/manifest.json') }}
 
       - name: Download Satkit Data
         if: steps.cache-satkit-data.outputs.cache-hit != 'true'
@@ -204,7 +204,7 @@ jobs:
         with:
           path: astro-data
           enableCrossOsArchive: true
-          key: satkit-data-cache
+          key: satkit-data-${{ hashFiles('data/manifest.json') }}
 
       - name: Download Satkit Data
         if: steps.cache-satkit-data.outputs.cache-hit != 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: astro-data
-          key: astro-data-v1
+          key: satkit-data-${{ hashFiles('data/manifest.json') }}
+
+      - name: Download satkit data (manifest-verified)
+        if: steps.cache-astro-data.outputs.cache-hit != 'true'
+        run: |
+          pip install requests
+          python python/test/download_data.py astro-data
 
       - name: Install system dependencies for cartopy
         run: sudo apt-get update && sudo apt-get install -y libgeos-dev libproj-dev proj-data

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           path: astro-data
           enableCrossOsArchive: true
-          key: satkit-data-cache
+          key: satkit-data-${{ hashFiles('data/manifest.json') }}
 
       - name: Download Satkit Data
         if: steps.cache-satkit-data.outputs.cache-hit != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Added
 
+- Static data files are downloaded from a manifest pinned to the release (`data/manifest.json`, SHA-256 verified), trying GitHub release assets, then the origin servers (JPL, IERS), then the GCS bucket; `SATKIT_DATA_URL` overrides the source for mirrors ([#137](https://github.com/ssmichael1/satkit/pull/137))
 - GMAT regression corpus: 17 seven-day reference trajectories (LEO to cislunar; `j2`/`full`/`gr` force models) replayed and gated under `cargo test` and `pytest`; regenerate with `tests/gmat/generate.py` ([#127](https://github.com/ssmichael1/satkit/pull/127))
 - EOP coverage is visible and enforceable: `earth_orientation_params::{coverage, status}` (Python `frametransform.eop_coverage()` / `eop_status()`), one-time warnings past the table end or with no table, and `PropSettings::require_eop_coverage` ([#133](https://github.com/ssmichael1/satkit/pull/133))
 - `frametransform::ierstable::preload()`; a missing `tab5.2*.txt` now raises `RuntimeError` in Python instead of `PanicException` ([#133](https://github.com/ssmichael1/satkit/pull/133))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ ureq = { version = "3.1.2", optional = true }
 process_path = "0.1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 quick-xml = { version = "0.41", features = ["serialize"], optional = true }
 chrono = { version = "0.4", optional = true }
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include LICENSE-APACHE
 include README.md
 include pyproject.toml
 include build.rs
+include data/manifest.json
 recursive-include src *.rs
 recursive-include benches *.rs
 recursive-include python/src *.rs

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,150 @@
+# satkit data manifest
+
+`manifest.json` is the single source of truth for the static data files
+satkit downloads at runtime. It is compiled into the library
+(`include_str!` in `src/utils/manifest.rs`), read by `python/test/download_data.py`
+for CI, and keys the CI data cache. This note explains the design so it can be
+maintained without re-deriving it.
+
+## Why a manifest
+
+Before this, the files lived on a Google Cloud Storage bucket and were
+fetched by name with no integrity check: a satkit release did not determine
+which data bytes a user got, a file could change under a fixed URL (it did —
+`msis21.parm`, Feb 2026), and four hand-maintained copies (bucket, PyPI
+`satkit-data` wheel, conda recipe, CI cache) drifted independently.
+
+With the manifest:
+
+- **A satkit build pins its data.** Every file has an exact size and SHA-256.
+  A given release always resolves to the same bytes, from whichever source
+  happens to work.
+- **Downloads are verified before they are trusted.** The fetch streams into
+  `<name>.part`, hashes as it goes, and only renames into place on a match.
+  A corrupt, truncated or substituted download is discarded and the next
+  source is tried; if all fail, the error lists every URL and why.
+- **One artefact drives everything.** The CI cache key is
+  `hashFiles('data/manifest.json')`, so changing the data invalidates the
+  cache automatically (the old static keys never did). The conda recipe's
+  `source:` URLs + sha256 can be generated from the same file.
+
+## URL order and why
+
+For each file, `urls` are tried in order; `SATKIT_DATA_URL` (environment) is
+tried before all of them.
+
+| order | source | rationale |
+|---|---|---|
+| 0 | `$SATKIT_DATA_URL/<name>` | corporate mirror, air-gapped share, or a local test server. Plain `http://` is allowed *here only*; every download is still hash-verified |
+| 1 | `https://github.com/ssmichael1/satkit-data/releases/download/data-v1/<name>` | GitHub release asset: CDN-backed, stable per-tag URL, no bandwidth cost to the maintainer, no API rate limit on downloads. **Returns 404 until the release is published** (below) — the client falls through cleanly |
+| 2 | origin server | only where the origin serves *byte-identical* data, verified by hash when the manifest was built: JPL for the DE files, IERS for `tab5.2*`. Zero hosting; the hash protects against silent upstream changes |
+| 3 | `https://storage.googleapis.com/astrokit-astro-data/<name>` | the legacy bucket, kept as a transitional fallback for a release or two |
+
+All manifest URLs must be `https://` (validated on load).
+
+## What is in the manifest
+
+| file | size | source | licence / attribution | tier |
+|---|---|---|---|---|
+| `linux_p1550p2650.440` | 102.3 MB | JPL | DE440 (Park et al. 2021). US Government work, public domain. Origin URL verified byte-identical | ephemeris (default) |
+| `lnxp1900p2053.421` | 14.0 MB | JPL | DE421 (Folkner et al. 2009). US Government work, public domain. `default: false` — fetched only by name (e.g. the conda package ships this one) | ephemeris |
+| `tab5.2a.txt`, `tab5.2b.txt`, `tab5.2d.txt` | 171 / 137 / 9 KB | IERS | IERS Conventions (2010), TN 36, Tables 5.2a/b/d. Freely redistributable. Origin URLs verified byte-identical | core |
+| `EGM96.gfc` | 5.6 MB | ICGEM (GFZ) | EGM96, Lemoine et al. 1998, NASA GSFC/NIMA — US Government work | core |
+| `JGM2.gfc`, `JGM3.gfc` | 118 / 215 KB | ICGEM (GFZ) | JGM-2 (Nerem et al. 1994), JGM-3 (Tapley et al. 1996), NASA GSFC / UT CSR — US Government work | core |
+| `ITU_GRACE16.gfc` | 1.8 MB | ICGEM (GFZ) | Akyilmaz et al. 2016, GFZ Data Services, **CC BY 4.0** — keep the file's header block, it carries the attribution | core |
+| `leap-seconds.list` | 11 KB | IERS / IETF | Public data. Reference only: the runtime leap-second table is compiled in | reference |
+
+`tier` is informational today: `core` = small files needed for frames and
+gravity, `ephemeris` = the large JPL files, `reference` = not read at runtime.
+Phase 2 (below) would embed the `core` tier in the binary.
+
+## Files deliberately excluded
+
+- **`msis21.parm`** — the NRLMSIS 2.1 parameter file. NRL's licence is
+  academic / non-commercial and covers derived data products, which is
+  incompatible with satkit's MIT / Apache-2.0 distribution. Nothing on `main`
+  reads it (the NRLMSIS 2 port is on an unmerged branch); if that feature
+  ships it must be an opt-in download with its own notice, not part of the
+  default bundle.
+- **`EOP-All.csv`, `SW-All.csv`** — Earth orientation and space weather.
+  CelesTrak asks that its compiled files not be mirrored, and they change
+  daily, so they are never pinned: `update_datafiles()` fetches them from
+  CelesTrak every run via the manifest's `refresh` list.
+- **`sw19571001.txt`** — an orphan on the old bucket; nothing reads it.
+- **`predicted-solar-cycle.json`** — fetched directly from NOAA/SWPC by
+  `solar_cycle_forecast::update()`; not a bundle file.
+
+## Publishing the release assets (maintainer)
+
+The manifest already points at `data-v1` on the `ssmichael1/satkit-data`
+repository (chosen over the main repo so satkit's Releases page stays for
+software, and so that repo can purge the 100 MB ephemeris from its git
+history). Until the release exists, every download falls through to the
+origin / GCS URLs, so nothing breaks — but publishing makes the first URL win:
+
+```bash
+D="$HOME/Library/Application Support/satkit-data"   # or any dir holding verified copies
+gh release create data-v1 --repo ssmichael1/satkit-data --latest=false \
+  --title "satkit static data v1" \
+  --notes "Static data files pinned by satkit's data/manifest.json (sizes and SHA-256 there). Sources and licences: see data/README.md in ssmichael1/satkit." \
+  "$D/linux_p1550p2650.440" "$D/lnxp1900p2053.421" \
+  "$D/tab5.2a.txt" "$D/tab5.2b.txt" "$D/tab5.2d.txt" \
+  "$D/EGM96.gfc" "$D/ITU_GRACE16.gfc" "$D/JGM2.gfc" "$D/JGM3.gfc" \
+  "$D/leap-seconds.list"
+```
+
+(`lnxp1900p2053.421` can be fetched first with
+`curl -O https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de421/lnxp1900p2053.421`;
+its sha256 is in the manifest.) Then verify end-to-end:
+
+```bash
+SATKIT_DATA=/tmp/satkit-data-check cargo test --lib real_network -- --ignored --nocapture
+```
+
+## Regenerating / changing the manifest
+
+```bash
+# after replacing or adding files in a data directory:
+python tools/make_manifest.py --data-dir "$D"            # recompute size + sha256
+python tools/make_manifest.py --data-dir "$D" --check    # CI-style drift check (exit 1 on change)
+python tools/make_manifest.py --data-dir "$D" --data-version data-v2   # new release tag
+```
+
+- **Adding a file**: add a stub entry (`name`, `urls`, `source`, `license`,
+  `tier`, `default`) to `manifest.json`, put the file in the data dir, run the
+  tool. The Rust unit test `embedded_manifest_is_valid` enforces the schema.
+  Upload the file to the release (`gh release upload data-vN --repo
+  ssmichael1/satkit-data <file>`).
+- **Changing bytes of an existing file** (e.g. a corrected table): that is a
+  new data version — bump `--data-version`, publish a new release tag, and
+  ship the manifest change in a satkit release. Never overwrite an asset under
+  an existing tag; the old satkit releases pin the old hashes.
+- **Retiring GCS**: once a release or two have shipped with the release-asset
+  URLs first, drop the `storage.googleapis.com` entries from `urls` and
+  delete the bucket. No client change is needed.
+- **conda recipe** (`recipes/conda/satkit-data/recipe.yaml`): its `source:`
+  list should become the manifest's release-asset (or origin) URLs with the
+  manifest's sha256 values — no GCS. Not done in this branch because the
+  recipe is being reworked separately.
+
+## Client behaviour
+
+- `satkit.utils.update_datafiles()` / `utils::update_datafiles` — fetches all
+  `default: true` files (in parallel, verified), then the `refresh` files,
+  then the NOAA solar-cycle forecast. `overwrite=True` re-downloads even
+  verified files.
+- First-use lazy loads (`jplephem`, `earthgravity`, `ierstable`) go through
+  the same verified fetch by name. A file name that is not in the manifest
+  (a user's alternative ephemeris, say) falls back to the old unverified
+  bucket fetch with a warning.
+- `utils::manifest::embedded()` exposes the parsed manifest;
+  `fetch_static_file(entry, dir, force)` is the verified fetch;
+  `ManifestEntry::verify(path)` checks a file on disk.
+
+## Phase 2 (not in this branch)
+
+Embed the `core` tier (~2.6 MB gzipped) in the library with `include_bytes!`
+so frames, gravity and time work offline out of the box; download only the
+ephemeris on first use (already lazy), with DE440 default and DE421
+selectable; then slim or retire the `satkit-data` PyPI package, which is
+currently a 105 MB hard dependency 133 KB under PyPI's file-size cap.

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,152 @@
+{
+  "manifest_version": 2,
+  "data_version": "data-v1",
+  "release_base": "https://github.com/ssmichael1/satkit-data/releases/download/data-v1",
+  "notes": [
+    "Static data files used by satkit, pinned by size and SHA-256.",
+    "URL order per file: GitHub release asset, then the origin server when it serves byte-identical bytes, then the legacy GCS bucket (transitional).",
+    "SATKIT_DATA_URL, if set, is a base URL tried before all of these.",
+    "Regenerate with tools/make_manifest.py; see data/README.md.",
+    "Deliberately excluded: msis21.parm (NRLMSIS 2.1 licence is academic/non-commercial), EOP-All.csv / SW-All.csv (CelesTrak asks that its compiled files not be mirrored; fetched at runtime via `refresh`), sw19571001.txt (orphan). See data/README.md."
+  ],
+  "files": [
+    {
+      "name": "linux_p1550p2650.440",
+      "size": 102272352,
+      "sha256": "29915576d0a6555766b99485ac3056ee415e86df4fce282611c31afb329ad062",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/linux_p1550p2650.440",
+        "https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de440/linux_p1550p2650.440",
+        "https://storage.googleapis.com/astrokit-astro-data/linux_p1550p2650.440"
+      ],
+      "source": "JPL",
+      "license": "JPL Planetary and Lunar Ephemerides DE440 (Park et al. 2021); US Government work, freely redistributable",
+      "tier": "ephemeris",
+      "default": true
+    },
+    {
+      "name": "lnxp1900p2053.421",
+      "size": 13966960,
+      "sha256": "5b3f81dd0c505925055a389431fd2bc5e0ae2fd02d85db37fa4d4fe54dfb4096",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/lnxp1900p2053.421",
+        "https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de421/lnxp1900p2053.421"
+      ],
+      "source": "JPL",
+      "license": "JPL Planetary and Lunar Ephemerides DE421 (Folkner et al. 2009); US Government work, freely redistributable",
+      "tier": "ephemeris",
+      "default": false
+    },
+    {
+      "name": "tab5.2a.txt",
+      "size": 171237,
+      "sha256": "19549252df9eb77c8237dbf5b749de82b7fd7713a8b60b35371538cd36b6aa1d",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/tab5.2a.txt",
+        "https://iers-conventions.obspm.fr/content/chapter5/additional_info/tab5.2a.txt",
+        "https://storage.googleapis.com/astrokit-astro-data/tab5.2a.txt"
+      ],
+      "source": "IERS",
+      "license": "IERS Conventions (2010), Technical Note 36, Table 5.2a (X series); freely redistributable",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "tab5.2b.txt",
+      "size": 136770,
+      "sha256": "1f17a3a6ad0b468705b3323bfe72d0320ce996798ec7cba0cdde4405d88f14d9",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/tab5.2b.txt",
+        "https://iers-conventions.obspm.fr/content/chapter5/additional_info/tab5.2b.txt",
+        "https://storage.googleapis.com/astrokit-astro-data/tab5.2b.txt"
+      ],
+      "source": "IERS",
+      "license": "IERS Conventions (2010), Technical Note 36, Table 5.2b (Y series); freely redistributable",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "tab5.2d.txt",
+      "size": 8656,
+      "sha256": "fe94c83e1ef6f92b15b3f007779ae70c0984c06ee45d5511b4c821ee9a0ecded",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/tab5.2d.txt",
+        "https://iers-conventions.obspm.fr/content/chapter5/additional_info/tab5.2d.txt",
+        "https://storage.googleapis.com/astrokit-astro-data/tab5.2d.txt"
+      ],
+      "source": "IERS",
+      "license": "IERS Conventions (2010), Technical Note 36, Table 5.2d (s + XY/2 series); freely redistributable",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "EGM96.gfc",
+      "size": 5620000,
+      "sha256": "5247a9e9c316dd2c8f8fd491d53be0e163cb5cb3676b021754240cc9e44cb43b",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/EGM96.gfc",
+        "https://storage.googleapis.com/astrokit-astro-data/EGM96.gfc"
+      ],
+      "source": "ICGEM-GFZ",
+      "license": "EGM96 (Lemoine et al. 1998, NASA GSFC/NIMA) as distributed by ICGEM; US Government work",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "ITU_GRACE16.gfc",
+      "size": 1782369,
+      "sha256": "b6bea9c78ad168f1e206fc7211f90b64fba54325c832f4473f6c05a07adbc718",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/ITU_GRACE16.gfc",
+        "https://storage.googleapis.com/astrokit-astro-data/ITU_GRACE16.gfc"
+      ],
+      "source": "ICGEM-GFZ",
+      "license": "ITU_GRACE16 (Akyilmaz et al. 2016, GFZ Data Services doi:10.5880/icgem.2016.006), CC BY 4.0",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "JGM2.gfc",
+      "size": 118296,
+      "sha256": "0779cf74f216d5b38c7a4c4a1a25d596b659605deb7731f00874c17e9ed3f5af",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/JGM2.gfc",
+        "https://storage.googleapis.com/astrokit-astro-data/JGM2.gfc"
+      ],
+      "source": "ICGEM-GFZ",
+      "license": "JGM-2 (Nerem et al. 1994, NASA GSFC / UT CSR) as distributed by ICGEM; US Government work",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "JGM3.gfc",
+      "size": 215405,
+      "sha256": "2ec791eec795689291974dd3602b304029da93d3fea30096daa3b368fb231d03",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/JGM3.gfc",
+        "https://storage.googleapis.com/astrokit-astro-data/JGM3.gfc"
+      ],
+      "source": "ICGEM-GFZ",
+      "license": "JGM-3 (Tapley et al. 1996, NASA GSFC / UT CSR) as distributed by ICGEM; US Government work",
+      "tier": "core",
+      "default": true
+    },
+    {
+      "name": "leap-seconds.list",
+      "size": 10665,
+      "sha256": "14b4faab51b1885680a704744863bda8b5728a0f0a5e07a15c8469532318b305",
+      "urls": [
+        "https://github.com/ssmichael1/satkit-data/releases/download/data-v1/leap-seconds.list",
+        "https://storage.googleapis.com/astrokit-astro-data/leap-seconds.list"
+      ],
+      "source": "IERS",
+      "license": "IERS/USNO leap-second list; public data. Reference only: satkit's runtime leap-second table is compiled in",
+      "tier": "reference",
+      "default": true
+    }
+  ],
+  "refresh": [
+    "https://celestrak.org/SpaceData/EOP-All.csv",
+    "https://celestrak.org/SpaceData/SW-All.csv"
+  ]
+}

--- a/docs/getting-started/datafiles.md
+++ b/docs/getting-started/datafiles.md
@@ -40,6 +40,35 @@ if sk.frametransform.eop_status(t_end) == "extrapolated":
 
 The warnings can be silenced with `satkit.frametransform.disable_eop_time_warning()`.
 
+## Where the files come from, and how downloads are verified
+
+The static files above are described by a manifest compiled into the library
+(`data/manifest.json` in the repository) that pins each file's exact size and
+SHA-256 and lists where it may be downloaded from, in order of preference:
+
+1. `SATKIT_DATA_URL` — if this environment variable is set, `"$SATKIT_DATA_URL/<name>"`
+   is tried first for every file. Use it for an internal mirror or an air-gapped
+   file share (plain `http://` is accepted here; downloads are still verified).
+2. The GitHub release asset (`github.com/ssmichael1/satkit-data/releases/download/data-v1/…`).
+3. The originating server where it serves identical bytes: JPL for the DE
+   ephemerides, IERS for the `tab5.2*` tables.
+4. The legacy `storage.googleapis.com/astrokit-astro-data` bucket (transitional).
+
+A download is streamed to `<name>.part`, hashed as it goes, and only renamed
+into place when both size and SHA-256 match the manifest; otherwise it is
+discarded and the next source is tried. A file already present with the right
+hash is never re-downloaded. The manifest is therefore what makes a given
+satkit release reproducible: the same version always resolves to the same
+data bytes.
+
+Sources and attribution: DE440 / DE421 — JPL (Park et al. 2021; Folkner et al.
+2009), US Government work; `tab5.2a/b/d.txt` — IERS Conventions (2010), TN 36;
+EGM96, JGM-2, JGM-3 — NASA GSFC (public), via ICGEM; ITU_GRACE16 — Akyilmaz et
+al. 2016, GFZ Data Services, CC BY 4.0; `leap-seconds.list` — IERS/IETF. The
+Earth-orientation and space-weather files are fetched from CelesTrak on every
+update and are not pinned (they change daily). The full table, with licences,
+is in `data/README.md`.
+
 ## Acquiring the Data Files
 
 The data files are included with the `satkit-data` package, a dependency of `satkit`.

--- a/python/satkit/utils.pyi
+++ b/python/satkit/utils.pyi
@@ -10,8 +10,14 @@ def update_datafiles(**kwargs) -> None:
 
     Keyword Args:
 
-      overwrite (bool):  Download and overwrite files if they already exist
+      overwrite (bool):  Re-download static files even when a verified copy is already present
       dir(string): Target directory for files.  Uses existing data directory if not specified. (see "datadir" function)
+
+    Static files are fetched according to the data manifest compiled into
+    satkit (``data/manifest.json``): each is tried from ``SATKIT_DATA_URL``
+    (if set), then the GitHub release asset, the origin server, and the
+    legacy bucket, and is only kept when its size and SHA-256 match the
+    manifest. Files already present with the right hash are skipped.
 
     Notes:
         - Files include:

--- a/python/src/mod_utils.rs
+++ b/python/src/mod_utils.rs
@@ -29,8 +29,14 @@ use anyhow::Result;
 /// * EOP_All.csv :: Earth orientation parameters,  updated daily
 /// * linux_p1550p2650.440 :: JPL Ephemeris version 440 (~ 100 MB)
 ///
-/// Note: Files update daily will always be downloaded independet of
-/// overwrite flag
+/// Static files are fetched per the compiled-in data manifest
+/// (`data/manifest.json`): `SATKIT_DATA_URL` mirror first if set, then the
+/// GitHub release asset, the origin server, and the legacy bucket, and are
+/// only kept when size and SHA-256 match. Files already present and verified
+/// are skipped unless `overwrite=True`.
+///
+/// Note: Files updated daily (EOP, space weather) are always downloaded
+/// regardless of the overwrite flag.
 ///
 #[pyfunction]
 #[pyo3(signature=(**kwds))]

--- a/python/test/download_data.py
+++ b/python/test/download_data.py
@@ -1,26 +1,103 @@
+#!/usr/bin/env python3
 """
-Download SatKit test vectors
-to a local directory
+Download satkit's static data files into a directory, verified against
+``data/manifest.json`` (the same manifest the Rust library embeds).
+
+Standalone — needs only ``requests`` — so CI can populate the data cache
+before the Rust build. Mirrors ``satkit.utils.update_datafiles()``:
+
+* every static file is tried from ``SATKIT_DATA_URL`` (if set) first, then
+  from the manifest's URLs in order (GitHub release asset, origin server,
+  legacy bucket), and is only kept when its size and SHA-256 match;
+* a file already present with the right hash is skipped;
+* the regularly refreshed files (EOP, space weather) are fetched from the
+  manifest's ``refresh`` URLs on every run, unverified.
+
+Usage: ``python python/test/download_data.py [dest_dir]`` (default ``astro-data``).
 """
 
-from pathlib import Path
-import requests
-from download_from_json import download_from_json
+import hashlib
+import json
+import os
 import sys
+from pathlib import Path
+
+import requests
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST = REPO / "data" / "manifest.json"
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def candidate_urls(entry: dict) -> list:
+    mirror = os.environ.get("SATKIT_DATA_URL", "").strip().rstrip("/")
+    urls = [f"{mirror}/{entry['name']}"] if mirror else []
+    return urls + list(entry["urls"])
+
+
+def fetch_verified(entry: dict, dest_dir: Path) -> str:
+    """Return the URL the file came from, or "present" if already verified."""
+    dest = dest_dir / entry["name"]
+    if dest.is_file() and dest.stat().st_size == entry["size"] and sha256_of(dest) == entry["sha256"]:
+        return "present"
+    part = dest.with_name(dest.name + ".part")
+    attempts = []
+    for url in candidate_urls(entry):
+        try:
+            with requests.get(url, stream=True, timeout=120) as r:
+                r.raise_for_status()
+                h = hashlib.sha256()
+                size = 0
+                with part.open("wb") as f:
+                    for chunk in r.iter_content(1 << 20):
+                        f.write(chunk)
+                        h.update(chunk)
+                        size += len(chunk)
+            if size != entry["size"]:
+                raise ValueError(f"size mismatch (expected {entry['size']}, got {size})")
+            if h.hexdigest() != entry["sha256"]:
+                raise ValueError("sha256 mismatch")
+            part.replace(dest)
+            return url
+        except Exception as e:  # noqa: BLE001 - report every source, then move on
+            part.unlink(missing_ok=True)
+            attempts.append(f"{url}: {e}")
+    raise SystemExit(f"could not download {entry['name']} from any source:\n  " + "\n  ".join(attempts))
+
+
+def fetch_refresh(url: str, dest_dir: Path) -> None:
+    name = url.rsplit("/", 1)[-1]
+    dest = dest_dir / name
+    part = dest.with_name(name + ".part")
+    with requests.get(url, stream=True, timeout=120) as r:
+        r.raise_for_status()
+        with part.open("wb") as f:
+            for chunk in r.iter_content(1 << 20):
+                f.write(chunk)
+    part.replace(dest)
+
+
+def main() -> None:
+    dest_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "astro-data")
+    dest_dir.mkdir(exist_ok=True, parents=True)
+    manifest = json.loads(MANIFEST.read_text())
+    print(f"satkit data {manifest['data_version']} -> {dest_dir}")
+    for entry in manifest["files"]:
+        if not entry.get("default", True):
+            continue
+        src = fetch_verified(entry, dest_dir)
+        print(f"  {entry['name']}: {src}")
+    for url in manifest.get("refresh", []):
+        fetch_refresh(url, dest_dir)
+        print(f"  {url.rsplit('/', 1)[-1]}: refreshed from {url}")
+
 
 if __name__ == "__main__":
-
-    baseurl = "https://storage.googleapis.com/astrokit-astro-data"
-
-    if len(sys.argv) > 1:
-        basedir = sys.argv[1]
-    else:
-        basedir = "astro-data"
-
-    fileurl = baseurl + "/files.json"
-    headers = {"Accept": "application/json"}
-
-    Path(basedir).mkdir(exist_ok=True, parents=True)
-
-    data = requests.get(fileurl, headers=headers).json()
-    download_from_json(data, basedir, baseurl)
+    main()

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 use thiserror::Error;
 
-/// Errors produced by the [`utils::download`](crate::utils::download) helpers.
+/// Errors produced by the [`utils::download`](crate::utils::download) and
+/// [`utils::manifest`](crate::utils::manifest) helpers.
 #[derive(Debug, Error)]
 pub enum Error {
     /// Returned by all download helpers when satkit was built without the
@@ -15,13 +16,39 @@ pub enum Error {
     #[error("File {path} not found and satkit was built without the `download` feature")]
     FileNotFoundNoDownload { path: String },
 
-    /// Returned when a download path or URL has no valid UTF-8 file-name
-    /// component (e.g. ends in `/` or `..`).
+    /// Returned when a download path, URL or manifest name has no valid
+    /// single-component file name (e.g. ends in `/`, is absolute, or contains
+    /// `..`).
     #[error("Path or URL has no valid file name: {path}")]
     InvalidFileName { path: String },
 
+    /// The embedded (or a supplied) data manifest failed validation.
+    #[error("Data manifest is invalid: {reason}")]
+    ManifestInvalid { reason: String },
+
+    /// A downloaded file's size or SHA-256 did not match the manifest.
+    #[error(
+        "{name} from {url}: {what} mismatch (expected {expected}, got {actual}); \
+         the partial download was discarded"
+    )]
+    HashMismatch {
+        name: String,
+        url: String,
+        what: &'static str,
+        expected: String,
+        actual: String,
+    },
+
+    /// Every candidate URL for a manifest file failed; `attempts` holds one
+    /// `"<url>: <error>"` line per URL tried.
+    #[error("Could not download {name} from any source:\n  {}", attempts.join("\n  "))]
+    AllSourcesFailed { name: String, attempts: Vec<String> },
+
     #[error(transparent)]
     Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
 
     #[cfg(feature = "download")]
     #[error(transparent)]
@@ -31,41 +58,113 @@ pub enum Error {
 /// Convenient type alias used throughout the `download` module.
 pub type Result<T> = std::result::Result<T, Error>;
 
+/// Path of the sibling `.part` file used for atomic writes.
+fn part_path(final_path: &Path) -> std::path::PathBuf {
+    let mut p = final_path.as_os_str().to_owned();
+    p.push(".part");
+    std::path::PathBuf::from(p)
+}
+
 /// Stream `reader` to `final_path` atomically: write to a sibling `.part` file
 /// and rename it into place on success. An interrupted transfer (network drop,
 /// Ctrl-C) then leaves only the discardable `.part` file rather than a truncated
 /// final file that later runs would trust as complete.
 #[cfg(feature = "download")]
 fn write_atomic(reader: &mut impl std::io::Read, final_path: &Path) -> Result<()> {
-    let part_path = {
-        let mut p = final_path.as_os_str().to_owned();
-        p.push(".part");
-        std::path::PathBuf::from(p)
-    };
+    let part = part_path(final_path);
     let mut write = || -> Result<()> {
-        let mut dest = std::fs::File::create(&part_path)?;
+        let mut dest = std::fs::File::create(&part)?;
         std::io::copy(reader, &mut dest)?;
         dest.sync_all()?;
         Ok(())
     };
     match write() {
         Ok(()) => {
-            std::fs::rename(&part_path, final_path)?;
+            std::fs::rename(&part, final_path)?;
             Ok(())
         }
         Err(e) => {
-            let _ = std::fs::remove_file(&part_path);
+            let _ = std::fs::remove_file(&part);
             Err(e)
         }
     }
 }
 
+/// Like [`write_atomic`], but the stream is hashed as it is written and the
+/// `.part` file is only renamed into place if its size and SHA-256 match
+/// `entry`. On mismatch the partial file is deleted and
+/// [`Error::HashMismatch`] is returned, so a corrupt or substituted download
+/// never becomes a trusted data file. Used by
+/// [`manifest::fetch_static_file`](crate::utils::manifest::fetch_static_file).
+pub(crate) fn write_atomic_verified(
+    reader: &mut impl std::io::Read,
+    final_path: &Path,
+    entry: &crate::utils::manifest::ManifestEntry,
+    url: &str,
+) -> Result<()> {
+    use sha2::{Digest, Sha256};
+    let part = part_path(final_path);
+    let mut write = || -> Result<(u64, String)> {
+        let mut dest = std::fs::File::create(&part)?;
+        let mut hasher = Sha256::new();
+        let mut buf = vec![0u8; 1 << 16];
+        let mut total: u64 = 0;
+        loop {
+            let n = reader.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+            std::io::Write::write_all(&mut dest, &buf[..n])?;
+            total += n as u64;
+        }
+        dest.sync_all()?;
+        let digest = hasher.finalize();
+        Ok((total, digest.iter().map(|b| format!("{b:02x}")).collect()))
+    };
+    let outcome = write();
+    let (size, sha) = match outcome {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = std::fs::remove_file(&part);
+            return Err(e);
+        }
+    };
+    let mismatch = |what: &'static str, expected: String, actual: String| {
+        let _ = std::fs::remove_file(&part);
+        Error::HashMismatch {
+            name: entry.name.clone(),
+            url: url.to_string(),
+            what,
+            expected,
+            actual,
+        }
+    };
+    if size != entry.size {
+        return Err(mismatch("size", entry.size.to_string(), size.to_string()));
+    }
+    if sha != entry.sha256 {
+        return Err(mismatch("sha256", entry.sha256.clone(), sha));
+    }
+    std::fs::rename(&part, final_path)?;
+    Ok(())
+}
+
+/// Ensure `fname` exists, downloading it if necessary.
+///
+/// * With `seturl == None` the file's base name is looked up in the embedded
+///   [data manifest](crate::utils::manifest): a known static file is fetched
+///   through [`fetch_static_file`](crate::utils::manifest::fetch_static_file)
+///   (release asset → origin → legacy bucket, SHA-256 verified). A name that
+///   is not in the manifest falls back to an *unverified* fetch from the
+///   legacy bucket, so user-supplied alternative files keep working.
+/// * With `seturl == Some(base)` (the celestrak refresh files) the file is
+///   fetched unverified from `base + name`, as before.
 #[cfg(feature = "download")]
 pub fn download_if_not_exist(fname: &Path, seturl: Option<&str>) -> Result<()> {
     if fname.is_file() {
         return Ok(());
     }
-    let baseurl = seturl.unwrap_or("https://storage.googleapis.com/astrokit-astro-data/");
     let basename =
         fname
             .file_name()
@@ -73,6 +172,17 @@ pub fn download_if_not_exist(fname: &Path, seturl: Option<&str>) -> Result<()> {
             .ok_or_else(|| Error::InvalidFileName {
                 path: fname.display().to_string(),
             })?;
+    if seturl.is_none() {
+        if let Some(entry) = crate::utils::manifest::embedded().entry(basename) {
+            let dir = fname.parent().unwrap_or_else(|| Path::new("."));
+            crate::utils::manifest::fetch_static_file(entry, dir, false)?;
+            return Ok(());
+        }
+        eprintln!(
+            "Warning: {basename} is not in satkit's data manifest; downloading it unverified"
+        );
+    }
+    let baseurl = seturl.unwrap_or("https://storage.googleapis.com/astrokit-astro-data/");
     let url = format!("{}{}", baseurl, basename);
     // Try to set proxy, if any, from environment variables
     let agent = ureq::Agent::new_with_defaults();
@@ -94,6 +204,9 @@ pub fn download_if_not_exist(fname: &Path, _seturl: Option<&str>) -> Result<()> 
     }
 }
 
+/// Download `url` into `downloaddir` (unverified; used for the regularly
+/// refreshed EOP / space-weather files). Returns `Ok(false)` if the file
+/// already exists and `overwrite_if_exists` is false.
 #[cfg(feature = "download")]
 pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -> Result<bool> {
     let fname = std::path::Path::new(url)
@@ -178,5 +291,50 @@ mod tests {
         assert!(!part_path.exists(), "the .part file must be renamed away");
         assert_eq!(std::fs::read(&final_path).unwrap(), data);
         let _ = std::fs::remove_file(&final_path);
+    }
+
+    #[test]
+    fn write_atomic_verified_rejects_bad_bytes() {
+        use crate::utils::manifest::{sha256_hex, ManifestEntry};
+        let dir = std::env::temp_dir().join(format!("satkit_wav_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let final_path = dir.join("f.bin");
+        let entry = ManifestEntry {
+            name: "f.bin".into(),
+            size: 5,
+            sha256: sha256_hex(b"hello"),
+            urls: vec!["https://example.invalid/f.bin".into()],
+            source: String::new(),
+            license: String::new(),
+            tier: String::new(),
+            default: true,
+        };
+        // Wrong bytes, right length -> sha mismatch, nothing left behind.
+        let err =
+            write_atomic_verified(&mut Cursor::new(&b"hellp"[..]), &final_path, &entry, "test")
+                .unwrap_err();
+        assert!(
+            matches!(err, Error::HashMismatch { what: "sha256", .. }),
+            "{err}"
+        );
+        assert!(!final_path.exists() && !part_path(&final_path).exists());
+        // Wrong length -> size mismatch.
+        let err = write_atomic_verified(
+            &mut Cursor::new(&b"hello!"[..]),
+            &final_path,
+            &entry,
+            "test",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, Error::HashMismatch { what: "size", .. }),
+            "{err}"
+        );
+        // Right bytes -> file in place.
+        write_atomic_verified(&mut Cursor::new(&b"hello"[..]), &final_path, &entry, "test")
+            .unwrap();
+        assert_eq!(std::fs::read(&final_path).unwrap(), b"hello");
+        assert!(!part_path(&final_path).exists());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/utils/manifest.rs
+++ b/src/utils/manifest.rs
@@ -1,0 +1,461 @@
+//! Embedded manifest of satkit's static data files, with verified download.
+//!
+//! # Why a manifest
+//!
+//! satkit needs a handful of third-party data files at runtime (JPL
+//! ephemeris, IERS nutation tables, gravity coefficients). Historically these were mirrored on a Google Cloud
+//! Storage bucket and fetched by name with no integrity check, so a
+//! satkit release did not determine which bytes a user actually got, and a
+//! file could change under a fixed URL without anyone noticing.
+//!
+//! `data/manifest.json` (compiled in via [`MANIFEST_JSON`]) pins every
+//! static file by size and SHA-256 and lists, in order of preference, the
+//! URLs it may be fetched from. A given satkit build therefore always
+//! resolves to the same data bytes, downloads are verified before they are
+//! trusted, and the same manifest drives the CI cache key, the Python
+//! bootstrap script and (by hand, for now) the conda recipe.
+//!
+//! # URL order
+//!
+//! 1. `SATKIT_DATA_URL` (environment) — an optional base URL tried first for
+//!    every file: a corporate mirror, an air-gapped file share exposed over
+//!    HTTP, or a local test server. `http://` is permitted here because such
+//!    mirrors are frequently plain HTTP on a private network; every download
+//!    is still hash-verified.
+//! 2. The GitHub release asset (`release_base/<name>`): CDN-backed, stable
+//!    per-tag URL, no bandwidth charge to the maintainer.
+//! 3. The origin server, where one exists *and serves byte-identical data*
+//!    (JPL for the DE files, IERS for the `tab5.2*` tables) — no mirror is
+//!    needed for these at all.
+//! 4. The legacy GCS bucket, kept as a transitional fallback until the
+//!    release assets have been published for a release or two.
+//!
+//! Every URL in the manifest itself must be `https://`; the mirror override
+//! is the only place plain HTTP is accepted.
+//!
+//! # Verification
+//!
+//! [`fetch_static_file`] streams each candidate into `<name>.part`, hashing
+//! as it goes, and only renames it into place when both the size and the
+//! SHA-256 match the manifest. On mismatch the partial file is deleted and
+//! the next URL is tried; if every URL fails the error lists each attempt.
+//! An existing file whose hash matches is never re-downloaded.
+//!
+//! The regularly refreshed files (`EOP-All.csv`, `SW-All.csv`) are *not*
+//! pinned — they change daily — and are listed under `refresh` as plain
+//! URLs (celestrak).
+
+use serde::Deserialize;
+use std::io::Read;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use super::download::{self, Error, Result};
+
+/// The manifest as compiled into the library (`data/manifest.json`).
+pub const MANIFEST_JSON: &str = include_str!("../../data/manifest.json");
+
+/// Environment variable naming a base URL to try before every manifest URL.
+pub const MIRROR_ENV: &str = "SATKIT_DATA_URL";
+
+/// Tests that set [`MIRROR_ENV`] take this lock so they cannot race each
+/// other (the test harness runs tests in parallel threads).
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Manifest of the static data files (see the [module docs](self)).
+#[derive(Debug, Clone, Deserialize)]
+pub struct Manifest {
+    /// Manifest schema version; this module understands `2`.
+    pub manifest_version: u32,
+    /// Data-bundle version; also the GitHub release tag the assets live under.
+    pub data_version: String,
+    /// Base URL of the GitHub release that hosts the assets.
+    pub release_base: String,
+    /// The pinned static files.
+    pub files: Vec<ManifestEntry>,
+    /// Regularly refreshed files (EOP, space weather): plain URLs, never pinned.
+    #[serde(default)]
+    pub refresh: Vec<String>,
+}
+
+/// One pinned static data file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManifestEntry {
+    /// File name (a single plain path component) under the data directory.
+    pub name: String,
+    /// Exact size in bytes.
+    pub size: u64,
+    /// Lower-case hex SHA-256 of the file contents.
+    pub sha256: String,
+    /// Download URLs in order of preference (all `https://`).
+    pub urls: Vec<String>,
+    /// Originating organisation (JPL, IERS, ICGEM-GFZ, NRL, ...).
+    #[serde(default)]
+    pub source: String,
+    /// Licence / attribution note.
+    #[serde(default)]
+    pub license: String,
+    /// `core` (small, required for frames/gravity), `ephemeris`, or
+    /// `reference` (downloaded for reference only, not read at runtime).
+    #[serde(default)]
+    pub tier: String,
+    /// Whether [`crate::utils::update_datafiles`] fetches this file. Optional
+    /// alternatives (e.g. the smaller DE421 ephemeris) are listed with
+    /// `default: false` so they are still pinned and fetchable by name.
+    #[serde(default = "default_true")]
+    pub default: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Outcome of [`fetch_static_file`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FetchOutcome {
+    /// The file was already present and its hash matched; nothing downloaded.
+    AlreadyPresent,
+    /// The file was downloaded (and verified) from this URL.
+    Downloaded { url: String },
+}
+
+impl Manifest {
+    /// Parse a manifest from JSON and validate it.
+    pub fn parse(json: &str) -> Result<Self> {
+        let m: Self = serde_json::from_str(json)?;
+        m.validate()?;
+        Ok(m)
+    }
+
+    /// Structural validation: known schema version, plain file names, unique
+    /// names, positive sizes, 64-hex SHA-256, at least one `https://` URL per
+    /// file, `https://` refresh URLs.
+    pub fn validate(&self) -> Result<()> {
+        let invalid = |msg: String| Error::ManifestInvalid { reason: msg };
+        if self.manifest_version != 2 {
+            return Err(invalid(format!(
+                "unsupported manifest_version {}",
+                self.manifest_version
+            )));
+        }
+        if !self.release_base.starts_with("https://") {
+            return Err(invalid("release_base must be https://".into()));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for e in &self.files {
+            validate_file_name(&e.name)?;
+            if !seen.insert(e.name.as_str()) {
+                return Err(invalid(format!("duplicate file name {:?}", e.name)));
+            }
+            if e.size == 0 {
+                return Err(invalid(format!("{}: size must be positive", e.name)));
+            }
+            if e.sha256.len() != 64 || !e.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(invalid(format!("{}: sha256 must be 64 hex chars", e.name)));
+            }
+            if e.sha256.chars().any(|c| c.is_ascii_uppercase()) {
+                return Err(invalid(format!("{}: sha256 must be lower-case", e.name)));
+            }
+            if e.urls.is_empty() {
+                return Err(invalid(format!("{}: needs at least one URL", e.name)));
+            }
+            for u in &e.urls {
+                if !u.starts_with("https://") {
+                    return Err(invalid(format!("{}: URL {u:?} must be https://", e.name)));
+                }
+            }
+        }
+        for u in &self.refresh {
+            if !u.starts_with("https://") {
+                return Err(invalid(format!("refresh URL {u:?} must be https://")));
+            }
+        }
+        Ok(())
+    }
+
+    /// Look up a file by name.
+    pub fn entry(&self, name: &str) -> Option<&ManifestEntry> {
+        self.files.iter().find(|e| e.name == name)
+    }
+
+    /// The files [`crate::utils::update_datafiles`] downloads by default.
+    pub fn default_files(&self) -> impl Iterator<Item = &ManifestEntry> {
+        self.files.iter().filter(|e| e.default)
+    }
+}
+
+/// A manifest file name is joined onto the data directory, so it must be a
+/// single plain path component: an absolute name would *replace* the base
+/// directory in `Path::join`, and `..` or embedded separators would escape it.
+pub fn validate_file_name(name: &str) -> Result<()> {
+    let bad = name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+        || Path::new(name).is_absolute();
+    if bad {
+        return Err(Error::InvalidFileName {
+            path: name.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// The compiled-in manifest, parsed once. The embedded JSON is validated by
+/// a unit test, so a failure here means a build with a corrupt
+/// `data/manifest.json` — not a runtime condition worth propagating.
+pub fn embedded() -> &'static Manifest {
+    static M: OnceLock<Manifest> = OnceLock::new();
+    M.get_or_init(|| {
+        Manifest::parse(MANIFEST_JSON).expect("embedded data/manifest.json is invalid")
+    })
+}
+
+/// Lower-case hex SHA-256 of a byte slice.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex(&h.finalize())
+}
+
+/// Lower-case hex SHA-256 of a file, streamed.
+pub fn sha256_file(path: &Path) -> std::io::Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut f = std::fs::File::open(path)?;
+    let mut h = Sha256::new();
+    let mut buf = vec![0u8; 1 << 16];
+    loop {
+        let n = f.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        h.update(&buf[..n]);
+    }
+    Ok(hex(&h.finalize()))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// The mirror base URL from [`MIRROR_ENV`], if set and non-empty, without a
+/// trailing slash.
+pub fn mirror_base() -> Option<String> {
+    std::env::var(MIRROR_ENV)
+        .ok()
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+}
+
+impl ManifestEntry {
+    /// URLs to try, in order: the [`MIRROR_ENV`] mirror (if set), then the
+    /// manifest's own list.
+    pub fn candidate_urls(&self) -> Vec<String> {
+        let mut v = Vec::with_capacity(self.urls.len() + 1);
+        if let Some(base) = mirror_base() {
+            v.push(format!("{base}/{}", self.name));
+        }
+        v.extend(self.urls.iter().cloned());
+        v
+    }
+
+    /// `true` if `path` exists with exactly the pinned size and SHA-256.
+    /// The size is compared first as a cheap pre-check; the hash of a 100 MB
+    /// ephemeris takes ~0.3 s and is only computed when the size matches.
+    pub fn verify(&self, path: &Path) -> std::io::Result<bool> {
+        let md = match std::fs::metadata(path) {
+            Ok(md) => md,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e),
+        };
+        if !md.is_file() || md.len() != self.size {
+            return Ok(false);
+        }
+        Ok(sha256_file(path)? == self.sha256)
+    }
+}
+
+/// Fetch one static file into `dest_dir`, verifying it against the manifest.
+///
+/// * If `<dest_dir>/<name>` already exists with the pinned size and hash and
+///   `force` is `false`, nothing is downloaded ([`FetchOutcome::AlreadyPresent`]).
+/// * Otherwise each candidate URL ([`ManifestEntry::candidate_urls`]) is tried
+///   in order. The response is streamed to `<name>.part` while being hashed;
+///   the file is renamed into place only if size and SHA-256 match, otherwise
+///   the partial file is removed and the next URL is tried.
+/// * If every URL fails, [`Error::AllSourcesFailed`] lists each URL and why.
+#[cfg(feature = "download")]
+pub fn fetch_static_file(
+    entry: &ManifestEntry,
+    dest_dir: &Path,
+    force: bool,
+) -> Result<FetchOutcome> {
+    validate_file_name(&entry.name)?;
+    let dest = dest_dir.join(&entry.name);
+    if !force && dest.is_file() {
+        if entry.verify(&dest)? {
+            return Ok(FetchOutcome::AlreadyPresent);
+        }
+        eprintln!(
+            "Warning: {} exists but does not match the manifest (size/sha256); re-downloading",
+            dest.display()
+        );
+    }
+    if !dest_dir.is_dir() {
+        std::fs::create_dir_all(dest_dir)?;
+    }
+
+    let mut attempts: Vec<String> = Vec::new();
+    for url in entry.candidate_urls() {
+        match download_verified(&url, entry, &dest) {
+            Ok(()) => return Ok(FetchOutcome::Downloaded { url }),
+            Err(e) => attempts.push(format!("{url}: {e}")),
+        }
+    }
+    Err(Error::AllSourcesFailed {
+        name: entry.name.clone(),
+        attempts,
+    })
+}
+
+/// GET `url` into `dest` atomically, verifying size and SHA-256 before the
+/// final rename.
+#[cfg(feature = "download")]
+fn download_verified(url: &str, entry: &ManifestEntry, dest: &Path) -> Result<()> {
+    let agent = ureq::Agent::new_with_defaults();
+    let mut resp = agent.get(url).call()?;
+    let mut reader = resp.body_mut().as_reader();
+    download::write_atomic_verified(&mut reader, dest, entry, url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_manifest_is_valid() {
+        let m = Manifest::parse(MANIFEST_JSON).expect("embedded manifest parses and validates");
+        assert_eq!(m.manifest_version, 2);
+        assert!(m.entry("linux_p1550p2650.440").is_some());
+        assert!(m.entry("tab5.2a.txt").is_some());
+        assert!(m.entry("EGM96.gfc").is_some());
+        assert!(
+            m.entry("msis21.parm").is_none(),
+            "NRLMSIS 2.1 licence forbids redistribution"
+        );
+        // Refresh files must not be pinned.
+        assert!(m.entry("EOP-All.csv").is_none());
+        assert!(m.entry("SW-All.csv").is_none());
+        assert!(m.refresh.iter().any(|u| u.ends_with("EOP-All.csv")));
+        // Every entry: GitHub release asset first.
+        for e in &m.files {
+            assert!(
+                e.urls[0].starts_with(&m.release_base),
+                "{}: first URL should be the release asset",
+                e.name
+            );
+        }
+        // The default set includes the DE440 ephemeris but not DE421.
+        assert!(m.entry("linux_p1550p2650.440").unwrap().default);
+        assert!(!m.entry("lnxp1900p2053.421").unwrap().default);
+        assert_eq!(embedded().data_version, m.data_version);
+    }
+
+    #[test]
+    fn validation_rejects_bad_entries() {
+        let base = r#"{"manifest_version":2,"data_version":"x","release_base":"https://h/r","files":[FILES],"refresh":[]}"#;
+        let ok = r#"{"name":"a.bin","size":1,"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","urls":["https://h/r/a.bin"]}"#;
+        assert!(Manifest::parse(&base.replace("FILES", ok)).is_ok());
+        for (bad, why) in [
+            (ok.replace("\"size\":1", "\"size\":0"), "zero size"),
+            (ok.replace("aaaa", "AAAA"), "upper-case hash"),
+            (ok.replace("aaaaaaaa", "aaaaaaa"), "short hash"),
+            (ok.replace("https://", "http://"), "http url"),
+            (ok.replace("\"a.bin\"", "\"../a.bin\""), "path escape"),
+            (ok.replace("\"a.bin\"", "\"/a.bin\""), "absolute"),
+            (ok.replace("[\"https://h/r/a.bin\"]", "[]"), "no urls"),
+            (format!("{ok},{ok}"), "duplicate"),
+        ] {
+            assert!(
+                Manifest::parse(&base.replace("FILES", &bad)).is_err(),
+                "{why}"
+            );
+        }
+        assert!(Manifest::parse(
+            &base
+                .replace("FILES", ok)
+                .replace("\"manifest_version\":2", "\"manifest_version\":1")
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn file_name_validation() {
+        for ok in ["EGM96.gfc", "sw-data_v2", "a.b.c"] {
+            assert!(validate_file_name(ok).is_ok(), "{ok:?}");
+        }
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../x",
+            "/etc/passwd",
+            "a/b",
+            "a\\b",
+            "x/../y",
+            "C:\\x",
+            "a\0b",
+        ] {
+            assert!(
+                matches!(validate_file_name(bad), Err(Error::InvalidFileName { .. })),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn sha256_matches_known_vector() {
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        let dir = std::env::temp_dir().join(format!("satkit_sha_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("abc.txt");
+        std::fs::write(&p, b"abc").unwrap();
+        assert_eq!(sha256_file(&p).unwrap(), sha256_hex(b"abc"));
+        let entry = ManifestEntry {
+            name: "abc.txt".into(),
+            size: 3,
+            sha256: sha256_hex(b"abc"),
+            urls: vec!["https://example.invalid/abc.txt".into()],
+            source: String::new(),
+            license: String::new(),
+            tier: String::new(),
+            default: true,
+        };
+        assert!(entry.verify(&p).unwrap());
+        std::fs::write(&p, b"abd").unwrap();
+        assert!(!entry.verify(&p).unwrap(), "same size, different bytes");
+        std::fs::write(&p, b"abcd").unwrap();
+        assert!(!entry.verify(&p).unwrap(), "different size");
+        assert!(!entry.verify(&dir.join("missing")).unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mirror_env_is_tried_first() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = embedded().entry("tab5.2d.txt").unwrap().clone();
+        std::env::set_var(MIRROR_ENV, "http://mirror.local/data/");
+        let urls = entry.candidate_urls();
+        std::env::remove_var(MIRROR_ENV);
+        assert_eq!(urls[0], "http://mirror.local/data/tab5.2d.txt");
+        assert_eq!(&urls[1..], &entry.urls[..]);
+        assert_eq!(entry.candidate_urls(), entry.urls);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,10 +15,12 @@ pub mod singleton;
 pub use singleton::RefreshableSingleton;
 
 pub mod download;
+pub mod manifest;
 pub use download::download_file;
 pub use download::download_file_async;
 pub use download::download_if_not_exist;
 pub use download::download_to_string;
+pub use manifest::{fetch_static_file, Manifest, ManifestEntry};
 
 ///
 /// Return git hash of compiled library

--- a/src/utils/update_data.rs
+++ b/src/utils/update_data.rs
@@ -1,41 +1,30 @@
-use super::download::{self, download_file_async, download_to_string};
+//! Download / refresh the data files satkit needs.
+//!
+//! Static files (ephemeris, IERS tables, gravity coefficients, leap-second
+//! list) come from the embedded [data manifest](crate::utils::manifest)
+//! and are SHA-256 verified; the regularly updated files (EOP, space weather)
+//! are listed in the manifest's `refresh` section and fetched unverified from
+//! celestrak on every run. See `data/README.md` for the design.
+
+use super::download::{self, download_file_async};
+use super::manifest::{self, FetchOutcome};
 use crate::utils::datadir;
-use serde_json::Value;
 use std::path::PathBuf;
 use std::thread::JoinHandle;
 use thiserror::Error;
 
-/// Errors produced by [`update_datafiles`] and the underlying download
-/// orchestration helpers.
+/// Errors produced by [`update_datafiles`].
 #[derive(Debug, Error)]
 pub enum Error {
-    /// The downloaded JSON file does not parse as the expected array of
-    /// file URLs.
-    #[error("Expected JSON array of file URLs")]
-    NotJsonArray,
-
-    /// An entry inside the JSON array is not a string URL.
-    #[error("Expected string URL")]
-    NotJsonString,
-
-    /// Encountered an unexpected JSON node while traversing the
-    /// recursive directory manifest.
-    #[error("Invalid JSON manifest entry")]
-    InvalidManifestEntry,
-
-    /// A manifest directory key was not a single plain path component
-    /// (absolute, contained `..`, or contained a path separator). Such a key
-    /// would be joined onto the data directory and could escape it.
-    #[error("Manifest directory name {name:?} is not a plain path component")]
-    InvalidManifestPath { name: String },
-
     /// A refresh-manifest URL did not use `https://`.
     #[error("Manifest URL {url:?} must use https://")]
     InsecureManifestUrl { url: String },
 
-    /// One or more entries in the JSON manifest could not be parsed.
-    #[error("Could not parse manifest entries")]
-    ManifestParseFailed,
+    /// A manifest file name was not a single plain path component
+    /// (absolute, contained `..`, or contained a path separator). Such a
+    /// name would be joined onto the data directory and could escape it.
+    #[error("Manifest file name {name:?} is not a plain path component")]
+    InvalidManifestPath { name: String },
 
     /// The configured data directory is read-only and cannot receive
     /// new or refreshed files.
@@ -45,7 +34,8 @@ pub enum Error {
     )]
     DataDirReadOnly,
 
-    /// A worker thread launched by [`download_file_async`] panicked.
+    /// A worker thread launched by [`download_file_async`] or the static
+    /// fetch panicked.
     #[error("Background download thread panicked")]
     ThreadPanic,
 
@@ -65,113 +55,51 @@ pub enum Error {
 /// Convenient type alias used throughout the `update_data` module.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Download a list of files from a JSON file
-fn download_from_url_json(json_url: String, basedir: &std::path::Path) -> Result<()> {
-    let json_base: Value = serde_json::from_str(download_to_string(json_url.as_str())?.as_str())?;
-    let arr = json_base.as_array().ok_or(Error::NotJsonArray)?;
-    let vresult: Vec<JoinHandle<download::Result<bool>>> = arr
+/// Fetch every default static file of the embedded manifest into `dir`,
+/// in parallel, verifying each against its pinned size and SHA-256.
+///
+/// Returns one `(name, outcome)` per file. `force` re-downloads even when a
+/// matching file is already present.
+pub fn download_static_files(
+    dir: &std::path::Path,
+    force: bool,
+) -> Result<Vec<(String, FetchOutcome)>> {
+    let m = manifest::embedded();
+    let handles: Vec<(String, JoinHandle<download::Result<FetchOutcome>>)> = m
+        .default_files()
+        .map(|entry| {
+            let entry = entry.clone();
+            let dir = dir.to_path_buf();
+            let name = entry.name.clone();
+            (
+                name,
+                std::thread::spawn(move || manifest::fetch_static_file(&entry, &dir, force)),
+            )
+        })
+        .collect();
+    let mut out = Vec::with_capacity(handles.len());
+    for (name, jh) in handles {
+        let outcome = jh.join().map_err(|_| Error::ThreadPanic)??;
+        out.push((name, outcome));
+    }
+    Ok(out)
+}
+
+/// Download the regularly refreshed files (EOP, space weather) listed in the
+/// manifest's `refresh` section, always overwriting.
+fn download_refresh_files(dir: &std::path::Path) -> Result<()> {
+    let m = manifest::embedded();
+    let handles: Vec<JoinHandle<download::Result<bool>>> = m
+        .refresh
         .iter()
-        .map(|url| -> Result<JoinHandle<download::Result<bool>>> {
-            let url_str = url.as_str().ok_or(Error::NotJsonString)?;
-            if !url_str.starts_with("https://") {
-                return Err(Error::InsecureManifestUrl {
-                    url: url_str.to_string(),
-                });
+        .map(|url| -> Result<_> {
+            if !url.starts_with("https://") {
+                return Err(Error::InsecureManifestUrl { url: url.clone() });
             }
-            Ok(download_file_async(url_str.to_string(), basedir, true))
+            Ok(download_file_async(url.clone(), dir, true))
         })
         .collect::<Result<Vec<_>>>()?;
-    // Wait for all the threads to finish
-    for jh in vresult {
-        jh.join().map_err(|_| Error::ThreadPanic)??;
-    }
-
-    Ok(())
-}
-
-/// A manifest object key names a subdirectory of the data directory and is
-/// joined onto it. Only a single, plain path component is acceptable: an
-/// absolute key would *replace* the base directory in `Path::join`, and
-/// `..` or embedded separators would escape it.
-fn validate_manifest_component(name: &str) -> Result<()> {
-    let bad = name.is_empty()
-        || name == "."
-        || name == ".."
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains('\0')
-        || std::path::Path::new(name).is_absolute();
-    if bad {
-        return Err(Error::InvalidManifestPath {
-            name: name.to_string(),
-        });
-    }
-    Ok(())
-}
-
-/// Download a list of files from a JSON file
-fn download_from_json(
-    v: &Value,
-    basedir: std::path::PathBuf,
-    baseurl: String,
-    overwrite: &bool,
-    thandles: &mut Vec<JoinHandle<download::Result<bool>>>,
-) -> Result<()> {
-    if let Some(obj) = v.as_object() {
-        let r1: Vec<Result<()>> = obj
-            .iter()
-            .map(|(key, val)| -> Result<()> {
-                validate_manifest_component(key)?;
-                let pbnew = basedir.join(key);
-                if !pbnew.is_dir() {
-                    std::fs::create_dir_all(pbnew.clone())?;
-                }
-                let mut newurl = baseurl.clone();
-                newurl.push_str(format!("/{key}").as_str());
-                download_from_json(val, pbnew, newurl, overwrite, thandles)?;
-                Ok(())
-            })
-            .filter(|res| res.is_err())
-            .collect();
-        if !r1.is_empty() {
-            return Err(Error::ManifestParseFailed);
-        }
-    } else if let Some(arr) = v.as_array() {
-        let r2: Vec<Result<()>> = arr
-            .iter()
-            .map(|val| -> Result<()> {
-                download_from_json(val, basedir.clone(), baseurl.clone(), overwrite, thandles)?;
-                Ok(())
-            })
-            .filter(|res| res.is_err())
-            .collect();
-        if !r2.is_empty() {
-            return Err(Error::ManifestParseFailed);
-        }
-    } else if let Some(s) = v.as_str() {
-        let mut newurl = baseurl;
-        newurl.push_str(format!("/{s}").as_str());
-        thandles.push(download_file_async(newurl, &basedir, *overwrite));
-    } else {
-        return Err(Error::InvalidManifestEntry);
-    }
-
-    Ok(())
-}
-
-fn download_datadir(basedir: PathBuf, baseurl: String, overwrite: &bool) -> Result<()> {
-    if !basedir.is_dir() {
-        std::fs::create_dir_all(basedir.clone())?;
-    }
-
-    let mut fileurl = baseurl.clone();
-    fileurl.push_str("/files.json");
-
-    let json_base: Value = serde_json::from_str(download_to_string(fileurl.as_str())?.as_str())?;
-    let mut thandles: Vec<JoinHandle<download::Result<bool>>> = Vec::new();
-    download_from_json(&json_base, basedir, baseurl, overwrite, &mut thandles)?;
-    // Wait for all the threads to finish
-    for jh in thandles {
+    for jh in handles {
         jh.join().map_err(|_| Error::ThreadPanic)??;
     }
     Ok(())
@@ -182,47 +110,56 @@ fn download_datadir(basedir: PathBuf, baseurl: String, overwrite: &bool) -> Resu
 ///
 /// # Arguments
 /// dir: The directory to download to, optional.  If not provided, the default data directory is used.
-/// overwrite_if_exists: If true, overwrite any existing files.  If false, skip files that already exist.
+/// overwrite_if_exists: If true, re-download static files even when a verified copy is present.
+///   If false, a static file whose size and SHA-256 already match the manifest is left alone.
 ///
 /// # Returns
 /// Result<()>
 ///
 /// # Notes
 ///
-/// This function downloads the data files necessary for "satkit" calculations.  These files include
-/// data necessary for calculating the JPL ephemerides, inertial-to-Earth-fixed rotations, high-order
-/// gravity field coefficients, and other data necessary for satellite calculations.
+/// Static files (JPL ephemeris, IERS nutation tables, gravity coefficients,
+/// leap-second list) are described by the embedded
+/// [data manifest](crate::utils::manifest): each is fetched from the first
+/// working source (`SATKIT_DATA_URL` mirror if set, then the GitHub release
+/// asset, the origin server, and the legacy bucket) and is only accepted
+/// when its size and SHA-256 match the manifest.
 ///
-/// The data files also include space weather and Earth orientation parameters.  These files are always
-/// downloaded, as they are updated at least daily.
+/// The space weather and Earth orientation files are refreshed from
+/// celestrak on every call, and the NOAA solar-cycle forecast is fetched;
+/// these change daily and are not pinned.
 ///
 pub fn update_datafiles(dir: Option<PathBuf>, overwrite_if_exists: bool) -> Result<()> {
     let downloaddir = match dir {
         Some(d) => d,
         None => datadir()?,
     };
+    if !downloaddir.is_dir() {
+        std::fs::create_dir_all(&downloaddir)?;
+    }
     if downloaddir.metadata()?.permissions().readonly() {
         return Err(Error::DataDirReadOnly);
     }
 
+    let m = manifest::embedded();
     println!(
-        "Downloading data files to {}",
+        "Downloading data files ({}) to {}",
+        m.data_version,
         downloaddir.to_string_lossy()
     );
-    // Download old files
-    download_datadir(
-        downloaddir.clone(),
-        String::from("https://storage.googleapis.com/astrokit-astro-data"),
-        &overwrite_if_exists,
-    )?;
+    if let Some(mirror) = manifest::mirror_base() {
+        println!("  {} = {mirror} (tried first)", manifest::MIRROR_ENV);
+    }
+    for (name, outcome) in download_static_files(&downloaddir, overwrite_if_exists)? {
+        match outcome {
+            FetchOutcome::AlreadyPresent => println!("  {name}: present and verified"),
+            FetchOutcome::Downloaded { url } => println!("  {name}: downloaded from {url}"),
+        }
+    }
 
     println!("Now downloading files that are regularly updated:");
     println!("  Space Weather & Earth Orientation Parameters");
-    // Get a list of files that are updated with new data, and download them
-    download_from_url_json(
-        String::from("https://storage.googleapis.com/astrokit-astro-data/files_refresh.json"),
-        &downloaddir,
-    )?;
+    download_refresh_files(&downloaddir)?;
 
     println!("  Solar Cycle Forecast");
     if let Err(e) = crate::solar_cycle_forecast::update() {
@@ -251,31 +188,296 @@ pub fn update_datafiles(dir: Option<PathBuf>, overwrite_if_exists: bool) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::manifest::{sha256_hex, ManifestEntry};
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    // All fetch tests hold `ENV_LOCK`: `candidate_urls()` reads SATKIT_DATA_URL,
+    // and the mirror test sets it, so they must not run concurrently.
+
+    /// A minimal in-process HTTP/1.1 server: `GET /<path>` returns the bytes
+    /// registered for that path or 404. Counts requests so tests can assert
+    /// what was (not) downloaded. Stops when `stop` is set.
+    struct TestServer {
+        base: String,
+        hits: Arc<AtomicUsize>,
+        stop: Arc<AtomicBool>,
+        thread: Option<std::thread::JoinHandle<()>>,
+    }
+
+    impl TestServer {
+        fn start(files: HashMap<String, Vec<u8>>) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let hits = Arc::new(AtomicUsize::new(0));
+            let stop = Arc::new(AtomicBool::new(false));
+            let files = Arc::new(Mutex::new(files));
+            let (h2, s2, f2) = (hits.clone(), stop.clone(), files.clone());
+            let thread = std::thread::spawn(move || {
+                while !s2.load(Ordering::Relaxed) {
+                    match listener.accept() {
+                        Ok((mut sock, _)) => {
+                            h2.fetch_add(1, Ordering::Relaxed);
+                            sock.set_nonblocking(false).unwrap();
+                            let mut buf = vec![0u8; 4096];
+                            let n = sock.read(&mut buf).unwrap_or(0);
+                            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                            let path = req
+                                .lines()
+                                .next()
+                                .and_then(|l| l.split_whitespace().nth(1))
+                                .unwrap_or("/")
+                                .trim_start_matches('/')
+                                .to_string();
+                            let body = f2.lock().unwrap().get(&path).cloned();
+                            let resp = match body {
+                                Some(b) => {
+                                    let mut r = format!(
+                                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                                        b.len()
+                                    )
+                                    .into_bytes();
+                                    r.extend_from_slice(&b);
+                                    r
+                                }
+                                None => b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec(),
+                            };
+                            let _ = sock.write_all(&resp);
+                            let _ = sock.flush();
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(std::time::Duration::from_millis(5));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+            Self {
+                base: format!("http://127.0.0.1:{port}"),
+                hits,
+                stop,
+                thread: Some(thread),
+            }
+        }
+        fn url(&self, path: &str) -> String {
+            format!("{}/{path}", self.base)
+        }
+        fn hits(&self) -> usize {
+            self.hits.load(Ordering::Relaxed)
+        }
+    }
+
+    impl Drop for TestServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Relaxed);
+            if let Some(t) = self.thread.take() {
+                let _ = t.join();
+            }
+        }
+    }
+
+    fn entry(name: &str, bytes: &[u8], urls: Vec<String>) -> ManifestEntry {
+        ManifestEntry {
+            name: name.into(),
+            size: bytes.len() as u64,
+            sha256: sha256_hex(bytes),
+            urls,
+            source: "test".into(),
+            license: String::new(),
+            tier: "core".into(),
+            default: true,
+        }
+    }
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("satkit_fetch_{tag}_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
 
     #[test]
-    fn manifest_component_validation() {
-        for ok in ["EGM96.gfc", "jplephem", "sw-data_v2", "a.b.c"] {
-            assert!(validate_manifest_component(ok).is_ok(), "{ok:?}");
+    fn fetch_success_is_verified_and_cached() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data = b"the quick brown fox".to_vec();
+        let srv = TestServer::start(HashMap::from([("good.bin".to_string(), data.clone())]));
+        let dir = tmpdir("ok");
+        let e = entry("good.bin", &data, vec![srv.url("good.bin")]);
+
+        let out = manifest::fetch_static_file(&e, &dir, false).unwrap();
+        assert_eq!(
+            out,
+            FetchOutcome::Downloaded {
+                url: srv.url("good.bin")
+            }
+        );
+        assert_eq!(std::fs::read(dir.join("good.bin")).unwrap(), data);
+        assert!(!dir.join("good.bin.part").exists());
+        assert_eq!(srv.hits(), 1);
+
+        // Second call: present + hash matches -> no request at all.
+        let out = manifest::fetch_static_file(&e, &dir, false).unwrap();
+        assert_eq!(out, FetchOutcome::AlreadyPresent);
+        assert_eq!(srv.hits(), 1, "verified file must not be re-downloaded");
+
+        // force = true re-downloads.
+        let out = manifest::fetch_static_file(&e, &dir, true).unwrap();
+        assert!(matches!(out, FetchOutcome::Downloaded { .. }));
+        assert_eq!(srv.hits(), 2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fetch_falls_through_404_to_next_url() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data = b"payload".to_vec();
+        let first = TestServer::start(HashMap::new()); // serves nothing -> 404
+        let second = TestServer::start(HashMap::from([("f.bin".to_string(), data.clone())]));
+        let dir = tmpdir("fallthrough");
+        let e = entry(
+            "f.bin",
+            &data,
+            vec![first.url("f.bin"), second.url("f.bin")],
+        );
+        let out = manifest::fetch_static_file(&e, &dir, false).unwrap();
+        assert_eq!(
+            out,
+            FetchOutcome::Downloaded {
+                url: second.url("f.bin")
+            }
+        );
+        assert_eq!(first.hits(), 1);
+        assert_eq!(second.hits(), 1);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fetch_rejects_hash_mismatch_and_tries_next_url() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let good = b"correct bytes".to_vec();
+        let bad = b"corrupt bytes".to_vec(); // same length: exercises the sha check, not the size check
+        let first = TestServer::start(HashMap::from([("f.bin".to_string(), bad)]));
+        let second = TestServer::start(HashMap::from([("f.bin".to_string(), good.clone())]));
+        let dir = tmpdir("mismatch");
+        let e = entry(
+            "f.bin",
+            &good,
+            vec![first.url("f.bin"), second.url("f.bin")],
+        );
+        let out = manifest::fetch_static_file(&e, &dir, false).unwrap();
+        assert_eq!(
+            out,
+            FetchOutcome::Downloaded {
+                url: second.url("f.bin")
+            }
+        );
+        assert_eq!(std::fs::read(dir.join("f.bin")).unwrap(), good);
+        assert!(
+            !dir.join("f.bin.part").exists(),
+            "corrupt partial must be removed"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn fetch_reports_every_failed_source() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let a = TestServer::start(HashMap::new());
+        let b = TestServer::start(HashMap::from([("f.bin".to_string(), b"wrong".to_vec())]));
+        let dir = tmpdir("allfail");
+        let e = entry("f.bin", b"right", vec![a.url("f.bin"), b.url("f.bin")]);
+        let err = manifest::fetch_static_file(&e, &dir, false).unwrap_err();
+        match &err {
+            download::Error::AllSourcesFailed { name, attempts } => {
+                assert_eq!(name, "f.bin");
+                assert_eq!(attempts.len(), 2);
+                assert!(attempts[0].starts_with(&a.url("f.bin")), "{}", attempts[0]);
+                assert!(attempts[1].starts_with(&b.url("f.bin")), "{}", attempts[1]);
+                assert!(attempts[1].contains("mismatch"), "{}", attempts[1]);
+            }
+            other => panic!("unexpected error {other}"),
         }
-        for bad in [
-            "",
-            ".",
-            "..",
-            "../x",
-            "/etc/passwd",
-            "a/b",
-            "a\\b",
-            "x/../y",
-            "C:\\x",
-            "a\0b",
-        ] {
+        assert!(!dir.join("f.bin").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn mirror_override_is_tried_before_manifest_urls() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data = b"mirror payload".to_vec();
+        let mirror = TestServer::start(HashMap::from([("f.bin".to_string(), data.clone())]));
+        let official = TestServer::start(HashMap::from([("f.bin".to_string(), data.clone())]));
+        let dir = tmpdir("mirror");
+        let e = entry("f.bin", &data, vec![official.url("f.bin")]);
+        std::env::set_var(manifest::MIRROR_ENV, &mirror.base);
+        let out = manifest::fetch_static_file(&e, &dir, false);
+        std::env::remove_var(manifest::MIRROR_ENV);
+        assert_eq!(
+            out.unwrap(),
+            FetchOutcome::Downloaded {
+                url: mirror.url("f.bin")
+            }
+        );
+        assert_eq!(mirror.hits(), 1);
+        assert_eq!(
+            official.hits(),
+            0,
+            "official URL must not be contacted when the mirror works"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn existing_corrupt_file_is_replaced() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data = b"fresh".to_vec();
+        let srv = TestServer::start(HashMap::from([("f.bin".to_string(), data.clone())]));
+        let dir = tmpdir("corrupt");
+        std::fs::write(dir.join("f.bin"), b"stale").unwrap(); // same size, wrong hash
+        let e = entry("f.bin", &data, vec![srv.url("f.bin")]);
+        let out = manifest::fetch_static_file(&e, &dir, false).unwrap();
+        assert!(matches!(out, FetchOutcome::Downloaded { .. }));
+        assert_eq!(std::fs::read(dir.join("f.bin")).unwrap(), data);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Real network, full run: `update_datafiles` into a temp dir; prints the
+    /// URL each file came from. `cargo test --lib real_network_update -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "requires network access; downloads ~110 MB"]
+    fn real_network_update_datafiles_into_tmp() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tmpdir("full");
+        let t0 = std::time::Instant::now();
+        update_datafiles(Some(dir.clone()), false).unwrap();
+        println!("update_datafiles took {:.1} s", t0.elapsed().as_secs_f64());
+        for e in manifest::embedded().default_files() {
             assert!(
-                matches!(
-                    validate_manifest_component(bad),
-                    Err(Error::InvalidManifestPath { .. })
-                ),
-                "{bad:?} should be rejected"
+                e.verify(&dir.join(&e.name)).unwrap(),
+                "{} not verified",
+                e.name
             );
         }
+        assert!(dir.join("EOP-All.csv").is_file() && dir.join("SW-All.csv").is_file());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Real network: exercises the GitHub-asset → origin/GCS fallthrough for
+    /// the smallest manifest file. `cargo test -- --ignored real_network`.
+    #[test]
+    #[ignore = "requires network access"]
+    fn real_network_fetch_smallest_file() {
+        let _guard = manifest::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let m = manifest::embedded();
+        let e = m.entry("tab5.2d.txt").unwrap();
+        let dir = tmpdir("net");
+        let out = manifest::fetch_static_file(e, &dir, false).unwrap();
+        println!("{out:?}");
+        assert!(e.verify(&dir.join("tab5.2d.txt")).unwrap());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/tools/make_manifest.py
+++ b/tools/make_manifest.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Regenerate ``data/manifest.json`` from a directory of data files.
+
+The manifest pins every static data file satkit downloads by size and
+SHA-256 and lists the URLs it may be fetched from (see ``data/README.md``).
+This tool recomputes ``size``/``sha256`` from the files on disk and keeps
+``urls``, ``source``, ``license``, ``tier`` and ``default`` from the existing
+manifest, so a data refresh is a reproducible two-step process::
+
+    python tools/make_manifest.py --data-dir ~/Library/Application\\ Support/satkit-data
+    git diff data/manifest.json          # review what changed
+
+Add a new file by first adding a stub entry (name + urls + source + license)
+to the manifest, then running this tool to fill in size and hash. Bump
+``data_version`` (and ``release_base``) with ``--data-version data-v2`` when
+the GitHub release tag changes.
+
+Only files already listed in the manifest are touched; unknown files in the
+data directory are ignored (the refresh files EOP-All.csv / SW-All.csv are
+never pinned).
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+MANIFEST = REPO / "data" / "manifest.json"
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--data-dir", type=Path, required=True, help="directory holding the data files")
+    ap.add_argument("--manifest", type=Path, default=MANIFEST, help="manifest to update (default: data/manifest.json)")
+    ap.add_argument("--data-version", help="new data_version / release tag (also rewrites release_base and the release URLs)")
+    ap.add_argument("--check", action="store_true", help="exit 1 if the manifest would change (CI drift check)")
+    args = ap.parse_args()
+
+    manifest = json.loads(args.manifest.read_text())
+    data_dir = args.data_dir.expanduser()
+    changed = []
+
+    if args.data_version and args.data_version != manifest["data_version"]:
+        old, new = manifest["data_version"], args.data_version
+        manifest["data_version"] = new
+        manifest["release_base"] = manifest["release_base"].replace(old, new)
+        for e in manifest["files"]:
+            e["urls"] = [u.replace(f"/{old}/", f"/{new}/") for u in e["urls"]]
+        changed.append(f"data_version {old} -> {new}")
+
+    for e in manifest["files"]:
+        path = data_dir / e["name"]
+        if not path.is_file():
+            print(f"warning: {e['name']} not in {data_dir}; keeping existing size/sha256", file=sys.stderr)
+            continue
+        size, sha = path.stat().st_size, sha256_of(path)
+        if size != e.get("size") or sha != e.get("sha256"):
+            changed.append(f"{e['name']}: size {e.get('size')} -> {size}, sha256 {str(e.get('sha256'))[:12]}… -> {sha[:12]}…")
+            e["size"], e["sha256"] = size, sha
+
+    if args.check:
+        for c in changed:
+            print("would change:", c)
+        return 1 if changed else 0
+
+    args.manifest.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+    for c in changed:
+        print("changed:", c)
+    if not changed:
+        print("manifest unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Phase 1 of the data-hosting plan. **Draft for review** — no release has been published yet, so the GitHub asset URLs 404 and the client falls through to the origin servers / GCS exactly as designed (verified end-to-end: full bundle in 6.1 s, every hash checked).

## Design (see `data/README.md`)
- **`data/manifest.json`**, embedded via `include_str!`: per static file — `name`, `size`, `sha256`, ordered `urls`, `source`, `license`, `tier`. A satkit release therefore pins the exact data bytes it was tested with; the same file generates the CI cache key and (later) the conda recipe sources. `tools/make_manifest.py` regenerates it from a data directory (`--check` mode for CI).
- **URL order**: GitHub release asset (`ssmichael1/satkit-data`, tag `data-v1`) → origin server where byte-identical (JPL for DE440/DE421, IERS for tab5.2*) → GCS (transitional). `SATKIT_DATA_URL` is tried first for mirrors / air-gapped sites.
- **Verified fetch** (`src/utils/manifest.rs`): pooch-style — skip if on-disk sha256 matches; stream to `.part` hashing as it goes; rename only on size+hash match; on 404/mismatch delete `.part` and try the next URL; error names every source tried. `download_if_not_exist` routes manifest-known names through it, so first-use downloads by `jplephem`/`earthgravity`/`ierstable` are verified too. `update_datafiles()` keeps its signature and no longer reads the bucket's `files.json`.
- **Excluded on purpose**: `msis21.parm` (NRL non-commercial licence; nothing on `main` reads it), `EOP-All.csv`/`SW-All.csv` (CelesTrak asks not to mirror; refreshed at runtime), orphan `sw19571001.txt`. Licence/attribution table in `data/README.md`.
- `lnxp1900p2053.421` (DE421, 14 MB) listed as a non-default alternative.

## Also
- CI cache keys are now `hashFiles('data/manifest.json')` (were static, never invalidated); `docs.yml` gains an explicit download step.
- `python/test/download_data.py` is a standalone verified downloader with the same URL order.
- New dependency: `sha2`.
- CHANGELOG **Added**/**Changed** (and the duplicated Unreleased headings on `main` consolidated).

## Tests
Manifest validation (bad sizes/hashes/http URLs/paths/duplicates), sha256 vector, in-process HTTP server cases (success+verified, 404 fall-through, hash-mismatch → next URL, all-fail error lists every URL, corrupt existing file replaced, `SATKIT_DATA_URL` first), plus `#[ignore]`d real-network tests. `cargo test --features chrono`: 248 lib + 42 integration + 18 GMAT; `pytest` 156; stubtest clean; fmt/clippy/doc clean.

## To publish (maintainer)
```bash
D="$HOME/Library/Application Support/satkit-data"
curl -o "$D/lnxp1900p2053.421" https://ssd.jpl.nasa.gov/ftp/eph/planets/Linux/de421/lnxp1900p2053.421
gh release create data-v1 --repo ssmichael1/satkit-data --latest=false --title "satkit static data v1" \
  --notes "Static data files pinned by satkit's data/manifest.json (sizes and SHA-256 there)." \
  "$D/linux_p1550p2650.440" "$D/lnxp1900p2053.421" "$D/tab5.2a.txt" "$D/tab5.2b.txt" "$D/tab5.2d.txt" \
  "$D/EGM96.gfc" "$D/ITU_GRACE16.gfc" "$D/JGM2.gfc" "$D/JGM3.gfc" "$D/leap-seconds.list"
```
Follow-ups: short DE440 (`linux_p1900p2053.440`, ~14 MB) with truncation script + test once the release exists; conda recipe sources from the manifest; retire GCS after one release; Phase 2 (embed core tier, slim `satkit-data`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE