### PR TITLE
Fix import crash when satkit_data is a namespace package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Fixed
 
+- `import satkit` no longer fails when the optional `satkit_data` bundle is installed as a namespace package (the conda layout, no `__init__.py`): its `data/` directory is discovered via `__path__` ([#140](https://github.com/ssmichael1/satkit/pull/140))
 - References page rebuilt as a full bibliography and every guide, API page and tutorial now cites its primary source; wrong SGP4 (AIAA 2006-6753), JGM-3 DOI and box-wing citations corrected; drag gate, Lambert multi-revolution, leap-second and GR descriptions brought in line with the code; RK stage counts corrected (RKV98 is 21 stages) ([#136](https://github.com/ssmichael1/satkit/pull/136))
 - Frame-bias docs: `EME2000` is 23.1 mas from GCRF (docs said 17); GMAT's `EarthMJ2000Eq` is an IAU-76 realization ~44 mas from ICRF, not the constant bias ([#132](https://github.com/ssmichael1/satkit/pull/132))
 - Doc fixes: Gauss–Jackson dense-output note, dual licence in crate docs, CONTRIBUTING versions/paths, gravity degree limit in `docs/index.md`, leap-second table described as compiled in ([#130](https://github.com/ssmichael1/satkit/pull/130))

--- a/python/satkit/__init__.py
+++ b/python/satkit/__init__.py
@@ -10,18 +10,41 @@ from .satkit import *  # type: ignore
 # `satkit.utils.datadir()`, and the Earth-orientation / space-weather files
 # are refreshed by `satkit.utils.update_datafiles()`.
 #
-# If the optional offline bundle (`pip install satkit[data]`, i.e. the
-# `satkit_data` package) is importable, register its data directory as a
-# read-only search location so its ephemeris and files are used wherever
-# the package happens to be installed. Downloads still go to `datadir()`.
+# If the optional offline bundle (the `satkit_data` package, from
+# `pip install satkit-data` or the conda `satkit-data` package) is importable,
+# register its `data/` directory as a read-only search location so its
+# ephemeris and files are used wherever the package happens to be installed.
+# Downloads still go to `datadir()`.
+
+
+def _optional_data_bundle_dirs(module) -> list:
+    """Candidate ``data`` directories of an installed ``satkit_data`` package.
+
+    The conda package (and any directory without ``__init__.py``) imports as
+    a *namespace* package, whose ``__file__`` is ``None`` — only ``__path__``
+    is meaningful. The PyPI wheel is a regular package with ``__file__``.
+    Both layouts put the files under ``<package>/data``.
+    """
+    import os
+
+    roots = []
+    file = getattr(module, "__file__", None)
+    if file:
+        roots.append(os.path.dirname(file))
+    for entry in getattr(module, "__path__", None) or []:
+        if entry not in roots:
+            roots.append(entry)
+    return [os.path.join(r, "data") for r in roots if os.path.isdir(os.path.join(r, "data"))]
+
+
 try:
-    import os as _os
-
     import satkit_data as _satkit_data
-
-    _data_path = _os.path.join(_os.path.dirname(_satkit_data.__file__), "data")
-    if _os.path.isdir(_data_path):
-        utils.add_search_dir(_data_path)  # type: ignore
-    del _data_path, _satkit_data, _os
 except ImportError:
     pass
+else:
+    try:
+        for _d in _optional_data_bundle_dirs(_satkit_data):
+            utils.add_search_dir(_d)  # type: ignore
+    except Exception:  # never let optional data discovery break `import satkit`
+        pass
+    del _satkit_data

--- a/python/test/test_optional_data_bundle.py
+++ b/python/test/test_optional_data_bundle.py
@@ -1,0 +1,31 @@
+"""``import satkit`` must not break on any layout of the optional ``satkit_data`` bundle."""
+
+import os
+import types
+
+import satkit
+
+
+def test_namespace_package_without___file__(tmp_path):
+    # conda's satkit-data (and any bare directory) imports as a namespace
+    # package: __file__ is None, only __path__ is set.
+    (tmp_path / "data").mkdir()
+    mod = types.ModuleType("satkit_data")
+    mod.__file__ = None
+    mod.__path__ = [str(tmp_path)]
+    assert satkit._optional_data_bundle_dirs(mod) == [str(tmp_path / "data")]
+
+
+def test_regular_package_with___file__(tmp_path):
+    (tmp_path / "data").mkdir()
+    mod = types.ModuleType("satkit_data")
+    mod.__file__ = str(tmp_path / "__init__.py")
+    mod.__path__ = [str(tmp_path)]
+    assert satkit._optional_data_bundle_dirs(mod) == [str(tmp_path / "data")]
+
+
+def test_package_without_data_dir_registers_nothing(tmp_path):
+    mod = types.ModuleType("satkit_data")
+    mod.__file__ = None
+    mod.__path__ = [str(tmp_path)]
+    assert satkit._optional_data_bundle_dirs(mod) == []


### PR DESCRIPTION
Regression from #139: `python/satkit/__init__.py` used `satkit_data.__file__`, which is `None` when `satkit_data` is a *namespace* package — the conda `satkit-data` layout (no `__init__.py`), or any bare directory named `satkit_data` on `sys.path`. `import satkit` then raised `TypeError`. CI didn't see it because `satkit_data` isn't installed there; it showed up immediately on a machine with the conda-style directory in site-packages.

Fix: `_optional_data_bundle_dirs(module)` collects `<root>/data` from `__file__` (regular package) and every `__path__` entry (namespace package), and the discovery is wrapped so it can never break `import satkit`. Three unit tests cover the namespace, regular, and no-`data`-dir cases; full Python suite passes with the namespace directory present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE