### PR TITLE
ci: bump GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,7 +14,7 @@ jobs:
     name: cargo audit (scheduled)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-audit
         uses: taiki-e/install-action@cargo-audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -42,12 +42,12 @@ jobs:
     name: clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - name: Cargo Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index/
@@ -63,7 +63,7 @@ jobs:
     name: cargo audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-audit
         uses: taiki-e/install-action@cargo-audit
@@ -79,14 +79,14 @@ jobs:
     name: sdist installs from source
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Cargo Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry/index/
@@ -119,12 +119,12 @@ jobs:
       SATKIT_TESTVEC_ROOT: satkit-testvecs
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Satkit Data
         id: cache-satkit-data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: astro-data
           enableCrossOsArchive: true
@@ -138,7 +138,7 @@ jobs:
 
       - name: Cache Satkit Test Vectors
         id: cache-satkit-testvecs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: satkit-testvecs
           enableCrossOsArchive: true
@@ -151,7 +151,7 @@ jobs:
           python python/test/download_testvecs.py satkit-testvecs
 
       - name: Cargo Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/bin/
@@ -204,17 +204,17 @@ jobs:
       SATKIT_TESTVEC_ROOT: satkit-testvecs
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
       - name: Cache Satkit Data
         id: cache-satkit-data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: astro-data
           enableCrossOsArchive: true
@@ -228,7 +228,7 @@ jobs:
 
       - name: Cache Satkit Test Vectors
         id: cache-satkit-testvecs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: satkit-testvecs
           enableCrossOsArchive: true
@@ -241,7 +241,7 @@ jobs:
           python python/test/download_testvecs.py satkit-testvecs
 
       - name: Cargo Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -35,13 +35,13 @@ jobs:
             ${{ runner.os }}-cargo-docs-
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Cache astro-data
         id: cache-astro-data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: astro-data
           key: satkit-data-${{ hashFiles('data/manifest.json') }}
@@ -72,7 +72,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -85,4 +85,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Verify tag matches Cargo.toml, pyproject.toml, and python/Cargo.toml
         run: |
@@ -57,17 +57,17 @@ jobs:
       SATKIT_TESTVEC_ROOT: satkit-testvecs
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.13"
 
       - name: Cache Satkit Data
         id: cache-satkit-data
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: astro-data
           enableCrossOsArchive: true
@@ -81,7 +81,7 @@ jobs:
 
       - name: Cache Satkit Test Vectors
         id: cache-satkit-testvecs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: satkit-testvecs
           enableCrossOsArchive: true
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Publish to crates.io
@@ -179,10 +179,10 @@ jobs:
         install -m 755 /tmp/sccache-v0.15.0-$(uname -m)-unknown-linux-musl/sccache /usr/local/bin/sccache
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
 
       - name: Set up Rust
         if: matrix.platform != 'linux'
@@ -192,10 +192,10 @@ jobs:
       # ACTIONS_RESULTS_URL / ACTIONS_RUNTIME_TOKEN into the step env so the
       # CIBW_ENVIRONMENT_PASS_LINUX forwarding above has values to pass through.
       - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.0
+        uses: pypa/cibuildwheel@v4.2.0
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -212,7 +212,7 @@ jobs:
           python -m build --sdist . -o wheelhouse
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.python }}
           path: ./wheelhouse/*
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist
           pattern: cibw-wheels-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+### CI
+
+- GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+
 ## 0.21.0 - 2026-08-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### CI
 
-- GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 
 ## 0.21.0 - 2026-08-30
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,10 @@ before-build = [
 [tool.cibuildwheel.windows]
 archs = ["AMD64"]
 environment = { PATH = '$UserProfile\.cargo\bin;$PATH' }
+# cibuildwheel 4.0 made delvewheel the default Windows repair step. The
+# extension is pure Rust and links only the Python DLL and the VC runtime
+# (which delvewheel skips anyway), so keep the pre-4.0 behaviour: no repair.
+repair-wheel-command = ""
 before-build = [
     "pip install -U setuptools-rust",
     "rustup toolchain install stable-x86_64-pc-windows-msvc",


### PR DESCRIPTION
## What

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v5 | v7 |
| `actions/setup-python` | v6 | v7 |
| `actions/cache` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `mozilla-actions/sccache-action` | v0.0.9 | v0.0.11 |
| `pypa/cibuildwheel` | v3.2.0 | v4.2.0 |

Pinning style kept (floating majors for `actions/*`, full versions elsewhere). `dtolnay/rust-toolchain@stable`, `taiki-e/install-action@cargo-audit`, `pypa/gh-action-pypi-publish@release/v1` are already floating refs.

## Breaking changes reviewed

All Node 24 / ESM housekeeping; nothing in these workflows needed an input change: no `pull_request_target`/`workflow_run` (checkout v7), no `pip-install` input (setup-python v7), artifact download uses `pattern` + `merge-multiple` (download-artifact v5–v8; v8 now fails on digest mismatch, which is what we want on the publish path), no dotfiles in `site/` (upload-pages-artifact v4+).

cibuildwheel v4 makes `delvewheel` the default Windows repair command. To keep wheels byte-identical to 0.21.0, `pyproject.toml` `[tool.cibuildwheel.windows]` now sets `repair-wheel-command = ""` explicitly (commented). Delete those lines to adopt delvewheel; for a pure-Rust `.pyd` it should be a no-op.

## Verification

Workflow YAML and `pyproject.toml` parse; `actionlint` not available locally. The build/docs workflows exercise most of the bumps on this PR; `release.yml` (cibuildwheel, artifacts, sccache) runs only on tag — will be exercised at 0.21.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE