### PR TITLE
fix(kepler): hang-free anomaly setters, atan2 conditioning in from_pv, keyword constructor, guide page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Fixed
 
-- Python `kepler.mean_anomaly` setter no longer hangs on NaN or `eccen >= 1` (delegates to the core capped solver); `from_pv` extracts inclination and the anomalies with `atan2` (exact down to i = 1e-9 rad, e ≤ 0.999); constructor accepts keyword arguments matching the stub (`a, eccen, incl, raan, w, nu`), `propagate` accepts `int` seconds, and a new [Keplerian Elements guide](https://satkit.dev/guide/kepler/) ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- Python `kepler.mean_anomaly` setter no longer hangs on NaN or `eccen >= 1` (delegates to the core capped solver); `from_pv` extracts inclination and the anomalies with `atan2` (exact down to i = 1e-9 rad, e ≤ 0.999); constructor accepts keyword arguments matching the stub (`a, eccen, incl, raan, w, nu`), `propagate` accepts `int` seconds, and a new [Keplerian Elements guide](https://satkit.dev/guide/kepler/) ([#146](https://github.com/ssmichael1/satkit/pull/146))
 
 ## 0.21.0 - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 
+### Fixed
+
+- Python `kepler.mean_anomaly` setter no longer hangs on NaN or `eccen >= 1` (delegates to the core capped solver); `from_pv` extracts inclination and the anomalies with `atan2` (exact down to i = 1e-9 rad, e ≤ 0.999); constructor accepts keyword arguments matching the stub (`a, eccen, incl, raan, w, nu`), `propagate` accepts `int` seconds, and a new [Keplerian Elements guide](https://satkit.dev/guide/kepler/) ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+
 ## 0.21.0 - 2026-08-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Only recent releases are listed. Older entries are in this file's git history (`
 ## Unreleased
 
 ### CI
-- CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))
 
+- CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Fixed
 
+- HTTP requests send a descriptive `satkit/<version>` User-Agent; a CelesTrak 503/403 from `TLE.from_url` / `omm_from_url` now explains CelesTrak's throttling of repeated identical queries instead of a bare status code; the TLE, OMM and Optical Observations tutorials fall back to a pinned element set when the live fetch is unavailable, so the docs build no longer depends on CelesTrak ([#144](https://github.com/ssmichael1/satkit/pull/144))
 - Python `kepler.mean_anomaly` setter no longer hangs on NaN or `eccen >= 1` (delegates to the core capped solver); `from_pv` extracts inclination and the anomalies with `atan2` (exact down to i = 1e-9 rad, e ≤ 0.999); constructor accepts keyword arguments matching the stub (`a, eccen, incl, raan, w, nu`), `propagate` accepts `int` seconds, and a new [Keplerian Elements guide](https://satkit.dev/guide/kepler/) ([#146](https://github.com/ssmichael1/satkit/pull/146))
 
 ## 0.21.0 - 2026-08-30
@@ -41,7 +42,6 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Fixed
 
-- HTTP requests send a descriptive `satkit/<version>` User-Agent; a CelesTrak 503/403 from `TLE.from_url` / `omm_from_url` now explains CelesTrak's throttling of repeated identical queries instead of a bare status code; the TLE, OMM and Optical Observations tutorials fall back to a pinned element set when the live fetch is unavailable, so the docs build no longer depends on CelesTrak ([#144](https://github.com/ssmichael1/satkit/pull/144))
 - SP3 epochs are read as GPS time, not UTC (18 s error) in `test_gps`, `sp3file.py` and the validation script — `test_gps` residual 1.80 → 1.21 m; cannonball SRP now acts along the satellite→Sun line; `jgm3`/`itugrace16` documented as zero-tide models ([#131](https://github.com/ssmichael1/satkit/pull/131))
 - `import satkit` no longer fails when the optional `satkit_data` bundle is installed as a namespace package (the conda layout, no `__init__.py`): its `data/` directory is discovered via `__path__` ([#140](https://github.com/ssmichael1/satkit/pull/140))
 - References page rebuilt as a full bibliography and every guide, API page and tutorial now cites its primary source; wrong SGP4 (AIAA 2006-6753), JGM-3 DOI and box-wing citations corrected; drag gate, Lambert multi-revolution, leap-second and GR descriptions brought in line with the code; RK stage counts corrected (RKV98 is 21 stages) ([#136](https://github.com/ssmichael1/satkit/pull/136))

--- a/docs/guide/kepler.md
+++ b/docs/guide/kepler.md
@@ -1,0 +1,181 @@
+# Keplerian Elements
+
+This page describes the classical (Keplerian) orbital element set used by
+[`satkit.kepler`](../api/kepler.md) (Rust: `satkit::kepler::Kepler`), the
+conventions it follows, and what it does *not* do. For a worked notebook see
+the [Keplerian Elements tutorial](../tutorials/Keplerian%20Elements.ipynb).
+
+## The Element Set
+
+A bound two-body orbit is described by six numbers. `satkit` stores them under
+these names, in SI units and radians:
+
+| Field   | Symbol     | Meaning                                              |
+|---------|------------|------------------------------------------------------|
+| `a`     | $a$        | semi-major axis, **meters**                          |
+| `eccen` | $e$        | eccentricity, $0 \le e < 1$                          |
+| `incl`  | $i$        | inclination, radians, $0 \le i \le \pi$              |
+| `raan`  | $\Omega$   | right ascension of the ascending node, radians       |
+| `w`     | $\omega$   | argument of perigee, radians                         |
+| `nu`    | $\nu$      | true anomaly, radians                                |
+
+The size and shape of the ellipse are $a$ and $e$; the orientation of the
+orbital plane and of the ellipse within it are $i$, $\Omega$ and $\omega$; and
+$\nu$ locates the satellite along the ellipse at the epoch of the elements.
+The semiparameter (semi-latus rectum) $p = a(1 - e^2)$ is available as a
+derived property, but the class is constructed from $a$, not $p$.
+
+In Python the inclination property is spelled `inclination`; the constructor
+argument and the Rust field are `incl`. Angles returned by `from_pv` are
+reduced to $[0, 2\pi)$; angles you set are stored as given.
+
+### Anomalies
+
+Three angles can locate the satellite in its orbit
+([Vallado 2013](references.md#vallado2013), §2.2):
+
+- **True anomaly** $\nu$ — the angle at the focus (Earth's center) from
+  perigee to the satellite. This is what is stored (`nu`).
+- **Eccentric anomaly** $E$ — the angle at the *center* of the ellipse to the
+  point on the auxiliary circle above the satellite. Related to $\nu$ by
+  $\tan\frac{\nu}{2} = \sqrt{\frac{1+e}{1-e}}\tan\frac{E}{2}$.
+- **Mean anomaly** $M$ — the angle that advances uniformly in time,
+  $M = M_0 + n\,(t - t_0)$ with mean motion $n = \sqrt{\mu / a^3}$. Related to
+  $E$ by Kepler's equation $M = E - e\sin E$.
+
+Converting $M \to E$ requires solving Kepler's equation iteratively. `satkit`
+uses Newton's method with the [Danby (1987)](references.md#danby1987) starting
+value $E_0 = M + 0.85\,e\,\mathrm{sign}(\sin M)$ after reducing $M$ to
+$[0, 2\pi)$, which converges in a handful of iterations for every $e < 1$
+([Vallado 2013](references.md#vallado2013), Algorithm 2). The iteration is
+capped, so a non-finite $M$ yields NaN rather than looping.
+
+The class accepts any of the three anomalies when it is constructed, and
+exposes all three as properties; `mean_anomaly` and `eccentric_anomaly` can
+be assigned and are converted to `nu` on the spot.
+
+## What the Elements Mean (and Don't)
+
+**Osculating, not mean.** The elements are *osculating*: they describe the
+two-body orbit that is tangent to the actual trajectory at the epoch of the
+state. Under perturbations (oblateness, drag, third bodies, …) the osculating
+elements vary continuously along the orbit — for a LEO satellite $a$ oscillates
+by several kilometers within one revolution because of $J_2$ alone. They are
+not the *mean* elements of an analytical theory. In particular, the elements
+in a TLE are SGP4 mean elements and cannot be passed to `kepler` (or read
+back from `from_pv`) without a significant, model-dependent error; use
+[`satkit.TLE`](../api/tle.md) and the SGP4 propagator for those
+(see [TLEs, SGP4 & OMMs](tle.md)).
+
+**Frame.** `kepler` does no frame handling. `from_pv` interprets the position
+and velocity you pass in whatever frame they are in, and `to_pv` returns the
+state in that same frame. Elements are meaningful only in an inertial frame;
+the rest of `satkit` assumes **GCRF**, so convert ITRF or TEME states with
+[`frametransform`](../api/frametransform.md) first. Passing an Earth-fixed
+state produces elements that are numerically valid but physically
+meaningless.
+
+**Central body.** The Earth's gravitational parameter
+[`consts.MU_EARTH`](../api/consts.md) ($3.986004418 \times 10^{14}$
+m³ s⁻²) is used everywhere: in the `from_pv` energy equation, in `to_pv`, and
+in the mean motion, period and `propagate`. There is no way to use a
+different $\mu$; for heliocentric or lunar orbits compute the elements
+yourself.
+
+**Closed orbits only.** `from_pv` returns an error (Python: `RuntimeError`)
+for parabolic or hyperbolic states ($e \ge 1$) and for rectilinear states
+(zero angular momentum, where the orbital plane is undefined). The
+constructor itself does not validate $e$; supplying $e \ge 1$ produces
+meaningless anomaly conversions.
+
+**Singular cases.** $\Omega$ is undefined for an equatorial orbit and $\omega$
+for a circular one. `from_pv` follows the conventions of
+[Vallado (2013)](references.md#vallado2013), Algorithm 9: for a circular
+inclined orbit `w` is 0 and `nu` holds the argument of latitude; for an
+elliptical equatorial orbit `raan` is 0 and `w` holds the true longitude of
+perigee; for a circular equatorial orbit both are 0 and `nu` holds the true
+longitude. In each case `to_pv` reproduces the input state.
+
+## Conversions
+
+- **Elements → state** follows [Vallado (2013)](references.md#vallado2013),
+  Algorithm 10: the state is formed in the perifocal (PQW) frame and rotated
+  by $R_z(\Omega)\,R_x(i)\,R_z(\omega)$.
+- **State → elements** follows Algorithm 9, with every angle extracted by
+  `atan2` rather than `acos` so that near-zero inclinations (down to
+  $10^{-9}$ rad) and anomalies near perigee/apogee are recovered to full
+  precision; the round trip state → elements → state is accurate to better
+  than $10^{-6}$ relative for $e \le 0.999$.
+- **`propagate(dt)`** is pure two-body motion: only the mean anomaly advances,
+  by $n\,\Delta t$. No perturbation is applied. For anything beyond a quick
+  look, use the numerical propagator ([Force Model](forces.md)).
+
+## Examples
+
+=== "Python"
+
+    ```python
+    import math
+    import numpy as np
+    import satkit as sk
+
+    # Sun-synchronous-ish LEO, located by mean anomaly
+    k = sk.kepler(
+        a=7000.0e3,
+        eccen=0.001,
+        incl=math.radians(98.0),
+        raan=math.radians(45.0),
+        w=0.0,
+        mean_anomaly=math.radians(30.0),
+    )
+    print(f"period = {k.period / 60:.2f} min, nu = {math.degrees(k.nu):.3f} deg")
+
+    # Elements -> GCRF state -> elements
+    r, v = k.to_pv()
+    k2 = sk.kepler.from_pv(r, v)
+    assert abs(k2.a - k.a) < 1e-3
+
+    # Two-body propagation by a quarter period
+    k3 = k.propagate(k.period / 4)
+    print(f"mean anomaly after T/4 = {math.degrees(k3.mean_anomaly):.3f} deg")
+
+    # An osculating snapshot of a numerically propagated state
+    t0 = sk.time(2024, 1, 1)
+    state = sk.satstate(t0, r, v)
+    state1 = state.propagate(t0 + sk.duration.from_hours(1))
+    k_osc = sk.kepler.from_pv(state1.pos, state1.vel)
+    print(f"osculating a after 1 h: {k_osc.a / 1e3:.3f} km")
+    ```
+
+=== "Rust"
+
+    ```rust
+    use satkit::kepler::{Anomaly, Kepler};
+    use satkit::Duration;
+
+    let k = Kepler::new(
+        7000.0e3,                 // a, m
+        0.001,                    // eccen
+        98.0_f64.to_radians(),    // incl
+        45.0_f64.to_radians(),    // raan
+        0.0,                      // w
+        Anomaly::Mean(30.0_f64.to_radians()),
+    );
+    println!("period = {:.2} min, nu = {:.3} deg",
+             k.period() / 60.0, k.nu.to_degrees());
+
+    // Elements -> state -> elements
+    let (r, v) = k.to_pv();
+    let k2 = Kepler::from_pv(r, v)?;
+    assert!((k2.a - k.a).abs() < 1e-3);
+
+    // Two-body propagation by a quarter period
+    let k3 = k.propagate(&Duration::from_seconds(k.period() / 4.0));
+    println!("M after T/4 = {:.3} deg", k3.mean_anomaly().to_degrees());
+    # Ok::<(), satkit::kepler::Error>(())
+    ```
+
+## References
+
+- [Vallado, D. A. (2013)](references.md#vallado2013), *Fundamentals of Astrodynamics and Applications*, 4th ed., Microcosm Press. Algorithm 2 (Kepler's equation), Algorithm 9 (RV2COE), Algorithm 10 (COE2RV); §2.2–2.5.
+- [Danby, J. M. A. (1987)](references.md#danby1987), "The solution of Kepler's equation, III," *Celestial Mechanics*, 40, 303–312. <https://doi.org/10.1007/BF01235847>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
           - Quaternions: tutorials/Quaternions.ipynb
           - Coordinate Frames: tutorials/Coordinate Frames.ipynb
           - Geodetic Coordinates: tutorials/Geodetic Coordinates.ipynb
+          - "Theory: Keplerian Elements": guide/kepler.md
           - Keplerian Elements: tutorials/Keplerian Elements.ipynb
       - SGP4 Propagation:
           - "Theory: TLEs, SGP4 & OMMs": guide/tle.md

--- a/python/satkit/satkit.pyi
+++ b/python/satkit/satkit.pyi
@@ -2300,59 +2300,68 @@ class quaternion:
 class kepler:
     """Represent Keplerian element sets and convert between cartesian
 
-
     Notes:
         - This class is used to represent Keplerian elements and convert between Cartesian coordinates
         - The class uses the semi-major axis (a), not the semiparameter
+        - Elements are osculating and expressed in the frame of the input state
+          (normally GCRF); the class does no frame handling
+        - The Earth gravitational parameter (MU_EARTH) is used throughout
+        - Only closed orbits are supported (0 <= eccen < 1)
         - All angle units are radians
         - All length units are meters
         - All velocity units are meters / second
+
+    See the "Theory: Keplerian Elements" guide page for details.
     """
 
     def __init__(
         self,
         a: float,
-        e: float,
-        i: float,
+        eccen: float,
+        incl: float,
         raan: float,
-        argp: float,
-        nu: float = ...,
+        w: float,
+        nu: float | None = None,
         *,
-        true_anomaly: float = ...,
-        mean_anomaly: float = ...,
-        eccentric_anomaly: float = ...,
-    ):
+        true_anomaly: float | None = None,
+        eccentric_anomaly: float | None = None,
+        mean_anomaly: float | None = None,
+    ) -> None:
         """Create Keplerian element set object from input elements
 
         Args:
             a: Semi-major axis, meters
-            e: Eccentricity, unitless
-            i: Inclination, radians
+            eccen: Eccentricity, unitless (0 <= eccen < 1)
+            incl: Inclination, radians
             raan: Right ascension of ascending node, radians
-            argp: Argument of perigee, radians
-            nu: True anomaly, radians
+            w: Argument of perigee, radians
+            nu: True anomaly, radians (6th positional argument)
             true_anomaly: True anomaly, radians (keyword alternative to nu)
-            mean_anomaly: Mean anomaly, radians (keyword alternative to nu)
             eccentric_anomaly: Eccentric anomaly, radians (keyword alternative to nu)
+            mean_anomaly: Mean anomaly, radians (keyword alternative to nu)
 
         Notes:
-            If "nu" is provided (6th argument), it will be used as the true anomaly.
-            Anomaly may also be set via keyword arguments; if so, there should only be
-            5 positional input arguments.
+            Exactly one of ``nu``, ``true_anomaly``, ``eccentric_anomaly`` or
+            ``mean_anomaly`` must be given; anything else raises ValueError.
+            All six elements may be passed positionally or by keyword.
 
         Example:
             ```python
             import math
+            import satkit
 
             # Create a ~400 km circular LEO orbit
             k = satkit.kepler(
-                a=6.781e6,        # semi-major axis, meters
-                e=0.001,          # near-circular
-                i=math.radians(51.6),
+                a=6.781e6,  # semi-major axis, meters
+                eccen=0.001,  # near-circular
+                incl=math.radians(51.6),
                 raan=math.radians(0),
-                argp=math.radians(0),
+                w=math.radians(0),
                 nu=math.radians(0),
             )
+
+            # Same orbit, positional, located by mean anomaly instead
+            k2 = satkit.kepler(6.781e6, 0.001, math.radians(51.6), 0, 0, mean_anomaly=1.0)
             ```
         """
         ...
@@ -2374,12 +2383,14 @@ class kepler:
         """
         ...
 
-    def propagate(self, dt: duration | float) -> kepler:
+    def propagate(self, dt: duration | float | int) -> kepler:
         """Propagate Keplerian element set by input duration
 
+        Two-body (unperturbed) propagation: only the anomaly changes.
+
         Args:
-            dt (duration | float): Duration by which to propagate the Keplerian element set
-                                   If float, value is seconds
+            dt (duration | float | int): Duration by which to propagate the
+                Keplerian element set. A number is interpreted as seconds.
 
         Returns:
             Keplerian element set object after propagation
@@ -2388,6 +2399,8 @@ class kepler:
             ```python
             # Propagate orbit by one orbital period
             k2 = k.propagate(k.period)
+            # ... or by ten minutes
+            k3 = k.propagate(satkit.duration.from_minutes(10))
             ```
         """
         ...
@@ -2408,14 +2421,22 @@ class kepler:
         ...
 
     @eccentric_anomaly.setter
-    def eccentric_anomaly(self, value: float) -> None: ...
+    def eccentric_anomaly(self, value: float) -> None:
+        """Set the in-plane position by eccentric anomaly, radians"""
+        ...
     @property
     def mean_anomaly(self) -> float:
         """Mean anomaly, radians"""
         ...
 
     @mean_anomaly.setter
-    def mean_anomaly(self, value: float) -> None: ...
+    def mean_anomaly(self, value: float) -> None:
+        """Set the in-plane position by mean anomaly, radians
+
+        Kepler's equation is solved for the eccentric anomaly and the result
+        stored as true anomaly (``nu``). A non-finite value yields NaN.
+        """
+        ...
     @property
     def period(self) -> float:
         """Orbital period, seconds"""
@@ -2486,8 +2507,13 @@ class kepler:
             vel = np.array([0, 7.5e3, 0])    # m/s, GCRF
             k = satkit.kepler.from_pv(pos, vel)
             print(f"Semi-major axis: {k.a/1e3:.1f} km")
-            print(f"Eccentricity: {k.e:.6f}")
+            print(f"Eccentricity: {k.eccen:.6f}")
             ```
+
+        Raises:
+            RuntimeError: if the state is hyperbolic/parabolic (eccen >= 1) or
+                rectilinear (zero angular momentum), or if the inputs are not
+                3-element vectors.
         """
         ...
 

--- a/python/src/pykepler.rs
+++ b/python/src/pykepler.rs
@@ -7,16 +7,14 @@ use pyo3::IntoPyObjectExt;
 use satkit::kepler::{Anomaly, Kepler};
 
 use crate::pyduration::PyDuration;
-use crate::pyutils::kwargs_or_none;
 use crate::pyutils::py_to_smatrix;
 
 ///
 /// Representation of Keplerian orbital elements
 ///
-/// Note: True anomaly can be specified as a positional argument or
-/// anomalies of different types can be specified as keyword arguments
-///
-/// If keyword argument is used, the positional argument should be left out
+/// The anomaly can be given positionally as the true anomaly (6th argument)
+/// or by exactly one of the keyword arguments ``true_anomaly``,
+/// ``eccentric_anomaly`` or ``mean_anomaly``.
 ///
 /// Args:
 ///     a: semi-major axis, meters
@@ -28,8 +26,8 @@ use crate::pyutils::py_to_smatrix;
 ///
 /// Keyword Args:
 ///     true_anomaly: True Anomaly, radians
-///      eccentric_anomaly: Eccentric Anomaly, radians
-///      mean_anomaly: Mean Anomaly, radians
+///     eccentric_anomaly: Eccentric Anomaly, radians
+///     mean_anomaly: Mean Anomaly, radians
 ///
 /// Returns:
 ///     Kepler: Keplerian orbital elements
@@ -38,38 +36,41 @@ use crate::pyutils::py_to_smatrix;
 #[derive(Clone)]
 pub struct PyKepler(pub Kepler);
 
+impl PyKepler {
+    /// The same elements with the in-plane position replaced by `an`,
+    /// converted to true anomaly by the core solver.
+    fn with_anomaly(&self, an: Anomaly) -> Kepler {
+        let k = &self.0;
+        Kepler::new(k.a, k.eccen, k.incl, k.raan, k.w, an)
+    }
+}
+
 #[pymethods]
 impl PyKepler {
     #[new]
-    #[pyo3(signature=(*args, **kwargs))]
-    fn new(args: &Bound<PyTuple>, mut kwargs: Option<&Bound<PyDict>>) -> PyResult<Self> {
-        let a = args.get_item(0)?.extract::<f64>()?;
-        let e = args.get_item(1)?.extract::<f64>()?;
-        let i = args.get_item(2)?.extract::<f64>()?;
-        let raan = args.get_item(3)?.extract::<f64>()?;
-        let w = args.get_item(4)?.extract::<f64>()?;
-
-        let nu: Option<f64>;
-        let mut ea: Option<f64> = None;
-        let mut ma: Option<f64> = None;
-        if args.len() > 5 {
-            nu = Some(args.get_item(5)?.extract::<f64>()?);
-        } else {
-            nu = kwargs_or_none(&mut kwargs, "true_anomaly")?;
-            ea = kwargs_or_none(&mut kwargs, "eccentric_anomaly")?;
-            ma = kwargs_or_none(&mut kwargs, "mean_anomaly")?;
-        }
-        let an = match (nu, ea, ma) {
-            (Some(v), None, None) => Anomaly::True(v),
-            (None, Some(v), None) => Anomaly::Eccentric(v),
-            (None, None, Some(v)) => Anomaly::Mean(v),
-            _ => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Specify only one of true_anomaly, eccentric_anomaly, or mean_anomaly",
-                ))
-            }
-        };
-        Ok(Self(Kepler::new(a, e, i, raan, w, an)))
+    #[pyo3(signature = (a, eccen, incl, raan, w, nu=None, *, true_anomaly=None, eccentric_anomaly=None, mean_anomaly=None))]
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        a: f64,
+        eccen: f64,
+        incl: f64,
+        raan: f64,
+        w: f64,
+        nu: Option<f64>,
+        true_anomaly: Option<f64>,
+        eccentric_anomaly: Option<f64>,
+        mean_anomaly: Option<f64>,
+    ) -> PyResult<Self> {
+        let an =
+            match (nu, true_anomaly, eccentric_anomaly, mean_anomaly) {
+                (Some(v), None, None, None) | (None, Some(v), None, None) => Anomaly::True(v),
+                (None, None, Some(v), None) => Anomaly::Eccentric(v),
+                (None, None, None, Some(v)) => Anomaly::Mean(v),
+                _ => return Err(pyo3::exceptions::PyValueError::new_err(
+                    "Specify exactly one of nu, true_anomaly, eccentric_anomaly, or mean_anomaly",
+                )),
+            };
+        Ok(Self(Kepler::new(a, eccen, incl, raan, w, an)))
     }
 
     #[getter]
@@ -161,14 +162,26 @@ impl PyKepler {
         }
     }
 
+    /// Propagate the elements forward (or backward) in time
+    ///
+    /// Args:
+    ///     dt (duration | float | int): time to propagate; a number is
+    ///         interpreted as seconds
+    ///
+    /// Returns:
+    ///     kepler: new element set
     fn propagate(&self, dt: &Bound<'_, PyAny>) -> PyResult<Self> {
-        if dt.is_instance_of::<pyo3::types::PyFloat>() {
-            let dt = dt.extract::<f64>()?;
-            let dt = satkit::Duration::from_seconds(dt);
-            Ok(Self(self.0.propagate(&dt)))
-        } else {
-            let dt: PyDuration = dt.extract()?;
+        if let Ok(dt) = dt.extract::<PyDuration>() {
             Ok(Self(self.0.propagate(&dt.0)))
+        } else {
+            let secs = dt.extract::<f64>().map_err(|_| {
+                pyo3::exceptions::PyTypeError::new_err(
+                    "dt must be a satkit.duration or a number of seconds",
+                )
+            })?;
+            Ok(Self(
+                self.0.propagate(&satkit::Duration::from_seconds(secs)),
+            ))
         }
     }
 
@@ -183,11 +196,7 @@ impl PyKepler {
 
     #[setter(eccentric_anomaly)]
     fn set_eccentric_anomaly(&mut self, val: f64) {
-        // Convert eccentric anomaly to true anomaly
-        self.0.nu = f64::atan2(
-            val.sin() * self.0.eccen.mul_add(-self.0.eccen, 1.0).sqrt(),
-            val.cos() - self.0.eccen,
-        );
+        self.0 = self.with_anomaly(Anomaly::Eccentric(val));
     }
 
     /// Return the mean motion of the satellite in radians/second
@@ -228,26 +237,9 @@ impl PyKepler {
 
     #[setter(mean_anomaly)]
     fn set_mean_anomaly(&mut self, val: f64) {
-        // Convert mean anomaly to true anomaly via eccentric anomaly
-        // First convert mean to eccentric
-        use std::f64::consts::PI;
-        let mut ea = match (val > PI) || ((val < 0.0) && (val > -PI)) {
-            true => val - self.0.eccen,
-            false => val + self.0.eccen,
-        };
-        loop {
-            let de =
-                self.0.eccen.mul_add(ea.sin(), val - ea) / self.0.eccen.mul_add(-ea.cos(), 1.0);
-            ea += de;
-            if de.abs() < 1.0e-6 {
-                break;
-            }
-        }
-        // Then convert eccentric to true
-        self.0.nu = f64::atan2(
-            ea.sin() * self.0.eccen.mul_add(-self.0.eccen, 1.0).sqrt(),
-            ea.cos() - self.0.eccen,
-        );
+        // Kepler's equation is solved by the core crate (range-reduced,
+        // Danby start, iteration-capped), so NaN or e >= 1 cannot hang here.
+        self.0 = self.with_anomaly(Anomaly::Mean(val));
     }
 
     /// Return the true anomaly of the satellite in radians

--- a/python/test/test_coordinates.py
+++ b/python/test/test_coordinates.py
@@ -45,6 +45,113 @@ class TestKepler:
             np.array([4.902279, 5.533140, -1.975710]) * 1.0e3, 1.0e-3
         )
 
+    def test_kepler_kwargs_construction(self):
+        """All six elements can be passed by keyword, matching the stub."""
+        k_pos = sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, 0.7)
+        k_kw = sk.kepler(a=7000e3, eccen=0.1, incl=0.5, raan=1.0, w=0.3, nu=0.7)
+        assert k_kw == k_pos
+        # Mixed positional / keyword
+        k_mix = sk.kepler(7000e3, 0.1, 0.5, raan=1.0, w=0.3, nu=0.7)
+        assert k_mix == k_pos
+        # Anomaly by keyword
+        k_ta = sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, true_anomaly=0.7)
+        assert k_ta == k_pos
+        k_ma = sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, mean_anomaly=0.7)
+        assert k_ma.mean_anomaly == pytest.approx(0.7, abs=1e-12)
+        k_ea = sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, eccentric_anomaly=0.7)
+        assert k_ea.eccentric_anomaly == pytest.approx(0.7, abs=1e-12)
+        # Exactly one anomaly must be given
+        with pytest.raises(ValueError):
+            sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3)
+        with pytest.raises(ValueError):
+            sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, 0.7, mean_anomaly=0.7)
+        with pytest.raises(TypeError):
+            sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, 0.7, bogus=1.0)
+
+    def test_mean_anomaly_setter_nan_does_not_hang(self):
+        """Regression: the setter used to spin forever on NaN with the GIL held."""
+        import threading
+
+        results = {}
+
+        def worker():
+            k = sk.kepler(7000e3, 0.5, 0.5, 1.0, 0.3, 0.0)
+            k.mean_anomaly = float("nan")
+            results["nan"] = k.nu
+            k.mean_anomaly = float("inf")
+            results["inf"] = k.nu
+            # e >= 1 is outside the supported domain but must still return
+            k.eccen = 1.5
+            k.mean_anomaly = 1.0
+            results["hyper"] = k.nu
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        t.join(timeout=10.0)
+        assert not t.is_alive(), "mean_anomaly setter hung"
+        assert m.isnan(results["nan"])
+        assert m.isnan(results["inf"])
+        assert "hyper" in results
+
+    def test_mean_anomaly_setter_roundtrip(self):
+        """Set M, read it back: |dM| < 1e-12 at e = 0.9 over a full revolution."""
+        k = sk.kepler(7000e3, 0.9, 0.5, 1.0, 0.3, 0.0)
+        for i in range(64):
+            m0 = 2 * m.pi * i / 64
+            k.mean_anomaly = m0
+            dm = (k.mean_anomaly - m0 + m.pi) % (2 * m.pi) - m.pi
+            assert abs(dm) < 1e-12, f"M={m0}: dM={dm:e}"
+            # E must be consistent with M via Kepler's equation
+            ea = k.eccentric_anomaly
+            assert (ea - 0.9 * m.sin(ea) - m0 + m.pi) % (2 * m.pi) - m.pi == pytest.approx(
+                0.0, abs=1e-12
+            )
+        # Eccentric-anomaly setter round-trip
+        for i in range(64):
+            e0 = 2 * m.pi * i / 64
+            k.eccentric_anomaly = e0
+            de = (k.eccentric_anomaly - e0 + m.pi) % (2 * m.pi) - m.pi
+            assert abs(de) < 1e-12
+
+    def test_kepler_pickle_roundtrip(self):
+        import pickle
+
+        k = sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, 0.7)
+        k2 = pickle.loads(pickle.dumps(k))
+        assert k2 == k
+        assert (k2.a, k2.eccen, k2.inclination, k2.raan, k2.w, k2.nu) == (
+            k.a,
+            k.eccen,
+            k.inclination,
+            k.raan,
+            k.w,
+            k.nu,
+        )
+
+    def test_kepler_propagate_accepts_int_and_duration(self):
+        k = sk.kepler(7000e3, 0.1, 0.5, 1.0, 0.3, 0.7)
+        k_f = k.propagate(600.0)
+        k_i = k.propagate(600)
+        k_d = k.propagate(sk.duration.from_minutes(10))
+        assert k_i == k_f
+        assert k_d.nu == pytest.approx(k_f.nu, abs=1e-12)
+        with pytest.raises(TypeError):
+            k.propagate("600")
+
+    def test_kepler_from_pv_tiny_inclination(self):
+        """from_pv keeps precision for e up to 0.999 and i down to 1e-9 rad."""
+        for eccen in (0.0, 0.5, 0.99, 0.999):
+            for incl in (1e-9, 1e-6, 0.3):
+                for nu in (0.0, 1.0, m.pi, 4.0):
+                    k = sk.kepler(12000e3, eccen, incl, 1.1, 0.7, nu)
+                    r, v = k.to_pv()
+                    k2 = sk.kepler.from_pv(r, v)
+                    assert k2.inclination == pytest.approx(incl, rel=1e-6, abs=1e-15)
+                    assert k2.eccen == pytest.approx(eccen, abs=1e-9)
+                    r2, v2 = k2.to_pv()
+                    assert np.linalg.norm(r - r2) / np.linalg.norm(r) < 1e-6
+                    assert np.linalg.norm(v - v2) / np.linalg.norm(v) < 1e-6
+
 
 class TestITRFCoord:
     def test_geodetic(self):

--- a/src/kepler.rs
+++ b/src/kepler.rs
@@ -279,7 +279,7 @@ impl Kepler {
     /// * `Kepler` - A new Keplerian orbital element object
     ///
     pub fn from_pv(r: Vector3, v: Vector3) -> Result<Self> {
-        use std::f64::consts::PI;
+        use std::f64::consts::TAU;
         let mu = crate::consts::MU_EARTH;
         let rmag = r.norm();
 
@@ -298,62 +298,50 @@ impl Kepler {
         }
         let xi = v.norm_squared() / 2.0 - mu / rmag;
         let a = -mu / (2.0 * xi);
-        let incl = (h.z() / hmag).clamp(-1.0, 1.0).acos();
+        // atan2 form rather than acos(h_z / |h|): acos loses about half the
+        // available precision for inclinations below ~1e-6 rad (and the
+        // mirror case near π), where the argument sits at the edge of the
+        // domain. `nmag` is |ẑ × h| = |h| sin i, so this is atan2(sin i, cos i).
+        let incl = f64::atan2(nmag, h.z());
 
-        // `acos` with the argument clamped to [-1, 1] to absorb rounding error.
-        let safe_acos = |x: f64| x.clamp(-1.0, 1.0).acos();
+        // Every angle below is extracted with atan2(sin, cos) rather than the
+        // textbook acos-plus-quadrant-test, which loses ~half the available
+        // precision (≈1e-8 rad) whenever the angle is near 0 or π. The sine
+        // terms come from triple products with the unit angular-momentum
+        // vector: for any two vectors p, q in the orbital plane,
+        // ĥ·(p × q) = |p||q| sin∠(p,q). Quadrant conventions are the same as
+        // Vallado's Algorithm 9; results are reduced to [0, 2π).
+        let hhat = h / hmag;
+        let wrap = |x: f64| x.rem_euclid(TAU);
         // Below these tolerances the eccentricity / node vectors are
-        // numerically zero, and the usual acos expressions would divide by
-        // zero and yield NaN. Fall back to the standard Vallado special cases.
+        // numerically zero and their directions are meaningless. Fall back
+        // to the standard Vallado special cases. The node test uses
+        // |n| / |h| = sin i, which is dimensionless; |n| itself is ~1e10 m²/s
+        // for any bound Earth orbit, so an absolute tolerance never triggers.
         const TOL: f64 = 1.0e-11;
         let circular = eccen < TOL;
-        let equatorial = nmag < TOL;
+        let equatorial = nmag / hmag < TOL;
 
         let (raan, w, nu) = if circular && equatorial {
             // Circular equatorial: RAAN and argument of perigee undefined;
             // report the true longitude in `nu`.
-            let mut lambda = safe_acos(r.x() / rmag);
-            if r.y() < 0.0 {
-                lambda = 2.0 * PI - lambda;
-            }
-            (0.0, 0.0, lambda)
+            (0.0, 0.0, wrap(f64::atan2(r.y(), r.x())))
         } else if circular {
             // Circular inclined: argument of perigee undefined; report the
             // argument of latitude in `nu`.
-            let mut raan = safe_acos(n.x() / nmag);
-            if n.y() < 0.0 {
-                raan = 2.0 * PI - raan;
-            }
-            let mut u = safe_acos(n.dot(&r) / (nmag * rmag));
-            if r.z() < 0.0 {
-                u = 2.0 * PI - u;
-            }
+            let raan = wrap(f64::atan2(n.y(), n.x()));
+            let u = wrap(f64::atan2(hhat.dot(&n.cross(&r)), n.dot(&r)));
             (raan, 0.0, u)
         } else if equatorial {
             // Elliptical equatorial: RAAN undefined; report the true longitude
             // of periapsis in `w`.
-            let mut w_true = safe_acos(e.x() / eccen);
-            if e.y() < 0.0 {
-                w_true = 2.0 * PI - w_true;
-            }
-            let mut nu = safe_acos(r.dot(&e) / (rmag * eccen));
-            if r.dot(&v) < 0.0 {
-                nu = 2.0 * PI - nu;
-            }
+            let w_true = wrap(f64::atan2(e.y(), e.x()));
+            let nu = wrap(f64::atan2(hhat.dot(&e.cross(&r)), e.dot(&r)));
             (0.0, w_true, nu)
         } else {
-            let mut raan = safe_acos(n.x() / nmag);
-            if n.y() < 0.0 {
-                raan = 2.0 * PI - raan;
-            }
-            let mut w = safe_acos(n.dot(&e) / (nmag * eccen));
-            if e.z() < 0.0 {
-                w = 2.0 * PI - w;
-            }
-            let mut nu = safe_acos(r.dot(&e) / (rmag * eccen));
-            if r.dot(&v) < 0.0 {
-                nu = 2.0 * PI - nu;
-            }
+            let raan = wrap(f64::atan2(n.y(), n.x()));
+            let w = wrap(f64::atan2(hhat.dot(&n.cross(&e)), n.dot(&e)));
+            let nu = wrap(f64::atan2(hhat.dot(&e.cross(&r)), e.dot(&r)));
             (raan, w, nu)
         };
 
@@ -526,6 +514,129 @@ mod tests {
                     diff
                 );
             }
+        }
+    }
+
+    #[test]
+    fn test_mean2eccentric_nan_returns() {
+        // A NaN mean anomaly must fall out of the capped Newton loop as NaN
+        // rather than spinning forever (the Python setter used to hang here).
+        assert!(mean2eccentric(f64::NAN, 0.5).is_nan());
+        assert!(mean2eccentric(0.5, f64::NAN).is_nan());
+        // e >= 1 is outside the domain of the elliptical solver; the result is
+        // meaningless but the call must return.
+        let _ = mean2eccentric(1.0, 1.0);
+        let _ = mean2eccentric(1.0, 1.5);
+        let _ = mean2eccentric(f64::INFINITY, 0.1);
+    }
+
+    #[test]
+    fn test_mean_anomaly_setter_roundtrip_high_eccen() {
+        use std::f64::consts::TAU;
+        // Set M via the public constructor path, read it back.
+        for &e in &[0.0, 0.1, 0.5, 0.9, 0.99, 0.999] {
+            for i in 0..64 {
+                let m = (i as f64) * TAU / 64.0;
+                let k = Kepler::with_mean_anomaly(7000.0e3, e, 0.5, 1.0, 0.3, m);
+                let mut dm = (k.mean_anomaly() - m).rem_euclid(TAU);
+                if dm > TAU / 2.0 {
+                    dm -= TAU;
+                }
+                assert!(
+                    dm.abs() < 1.0e-12,
+                    "M round-trip failed for e={e}, M={m}: dM={dm:e}"
+                );
+            }
+        }
+    }
+
+    /// Round-trip r,v → elements → r,v over a grid of eccentricities up to
+    /// 0.999 and inclinations down to 1e-9 rad (and the retrograde mirror
+    /// near π), including the true-anomaly quadrants near periapsis and
+    /// apoapsis where the acos branches are least conditioned.
+    #[test]
+    fn test_from_pv_roundtrip_grid() {
+        use std::f64::consts::PI;
+        let eccens = [0.0, 1.0e-6, 0.01, 0.3, 0.7, 0.9, 0.99, 0.999];
+        let incls = [
+            0.0,
+            1.0e-9,
+            1.0e-7,
+            1.0e-5,
+            1.0e-3,
+            0.5,
+            PI / 2.0,
+            PI - 1.0e-3,
+            PI - 1.0e-9,
+        ];
+        let nus = [
+            0.0,
+            1.0e-7,
+            0.3,
+            PI / 2.0,
+            PI - 1.0e-6,
+            PI,
+            PI + 0.4,
+            2.0 * PI - 1.0e-7,
+        ];
+        let a = 12_000.0e3;
+        for &e in &eccens {
+            for &i in &incls {
+                for &nu in &nus {
+                    let k = Kepler::new(a, e, i, 1.1, 0.7, Anomaly::True(nu));
+                    let (r, v) = k.to_pv();
+                    let k2 = Kepler::from_pv(r, v)
+                        .unwrap_or_else(|err| panic!("from_pv failed e={e} i={i} nu={nu}: {err}"));
+                    assert!(
+                        k2.a.is_finite()
+                            && k2.eccen.is_finite()
+                            && k2.incl.is_finite()
+                            && k2.raan.is_finite()
+                            && k2.w.is_finite()
+                            && k2.nu.is_finite(),
+                        "non-finite element e={e} i={i} nu={nu}: {k2:?}"
+                    );
+                    assert!(
+                        (k2.a - a).abs() / a < 1.0e-9,
+                        "a mismatch e={e} i={i} nu={nu}: {}",
+                        (k2.a - a).abs() / a
+                    );
+                    assert!(
+                        (k2.eccen - e).abs() < 1.0e-9,
+                        "e mismatch e={e} i={i} nu={nu}: {}",
+                        k2.eccen - e
+                    );
+                    assert!(
+                        (k2.incl - i).abs() < 1.0e-9,
+                        "i mismatch e={e} i={i} nu={nu}: {:e}",
+                        k2.incl - i
+                    );
+                    let (r2, v2) = k2.to_pv();
+                    let dr = (r - r2).norm() / r.norm();
+                    let dv = (v - v2).norm() / v.norm();
+                    assert!(
+                        dr < 1.0e-6 && dv < 1.0e-6,
+                        "round-trip e={e} i={i} nu={nu}: dr={dr:e} dv={dv:e}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_from_pv_tiny_inclination_precision() {
+        // acos(h_z/|h|) would return exactly 0 (or ~1.5e-8) here; atan2 keeps
+        // the inclination to full relative precision.
+        for &i in &[1.0e-9, 1.0e-8, 1.0e-7] {
+            let k = Kepler::new(7000.0e3, 0.2, i, 0.4, 1.2, Anomaly::True(2.0));
+            let (r, v) = k.to_pv();
+            let k2 = Kepler::from_pv(r, v).unwrap();
+            assert!(
+                (k2.incl - i).abs() / i < 1.0e-6,
+                "i={i}: got {} (rel err {:e})",
+                k2.incl,
+                (k2.incl - i).abs() / i
+            );
         }
     }
 


### PR DESCRIPTION
Implements items 1–4 of the Keplerian-elements interface review. No breaking changes (no renames, no new struct fields, no exception-type changes).

## 1. Python `mean_anomaly` / `eccentric_anomaly` setter hang (bug)
`python/src/pykepler.rs` re-implemented Kepler's equation with an uncapped Newton loop, so `k.mean_anomaly = float('nan')` (or e ≥ 1) hung with the GIL held. Both setters now delegate to the core `Kepler::new(..., Anomaly::…)` (range-reduced, Danby starter, 50-iteration cap). New tests: NaN setter returns (thread with timeout), setter round-trip |ΔM| < 1e-12 up to e = 0.999, `kepler` pickle round-trip (was missing), Rust `test_mean2eccentric_nan_returns`.

## 2. `from_pv` conditioning
- `incl = atan2(|n|, h_z)` instead of `acos(h_z/|h|)` (precision loss below ~1e-6 rad).
- Equatorial test now dimensionless (`|n|/|h| < 1e-11`); it previously compared |n| (~5e10 in SI) to 1e-11.
- While extending the tests, ν failed the 1e-6 round-trip at e = 0.99, ν = π (acos loses ~1.5e-8 rad, amplified near apoapsis) — Ω, ω, ν, u, λ now use `atan2` of triple products (same Vallado Alg. 9 quadrant conventions, wrapped to [0, 2π)).
- New deterministic grid tests: e ∈ {0…0.999} × i ∈ {0, 1e-9 … π−1e-9} × 8 anomalies; r,v round-trip < 1e-6, elements < 1e-9.

## 3. Docs / stubs
`satkit.pyi` constructor example advertised keyword args the runtime rejected, and the `from_pv` example used `k.e` (field is `eccen`). Fixed; every snippet executed. New guide page `docs/guide/kepler.md` (elements/naming, anomalies, osculating vs mean, GCRF + `MU_EARTH` assumptions, e ≥ 1 and singular cases, Python/Rust examples, Vallado Alg. 2/9/10 + Danby refs), registered in `mkdocs.yml`; `mkdocs build --strict` passes.

## 4. Constructor hygiene
Real `#[pyo3(signature = (a, eccen, incl, raan, w, nu=None, *, true_anomaly, eccentric_anomaly, mean_anomaly))]`; stub and runtime agree (stubtest clean). `propagate` accepts `duration | float | int`. Side-effect: too few positionals now raise `TypeError` (was `IndexError`); unknown keywords now raise `TypeError` instead of being silently ignored.

## Verification
`cargo test --features chrono` (283 lib + integration/doc tests) green; `pytest python/test/` 181 passed, 2 skipped (incl. GMAT corpus); stubtest clean; fmt + clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE