### PR TITLE
ci: refresh EOP/space-weather files on every run (stale EOP in docs build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,11 @@ jobs:
           python -m pip install requests
           python python/test/download_data.py astro-data
 
+      - name: Refresh EOP and space weather (every run, cache hit or not)
+        run: |
+          python -m pip install requests
+          python python/test/download_data.py astro-data --refresh-only
+
       - name: Cache Satkit Test Vectors
         id: cache-satkit-testvecs
         uses: actions/cache@v6
@@ -225,6 +230,11 @@ jobs:
         run: |
           pip install requests
           python python/test/download_data.py astro-data
+
+      - name: Refresh EOP and space weather (every run, cache hit or not)
+        run: |
+          pip install requests
+          python python/test/download_data.py astro-data --refresh-only
 
       - name: Cache Satkit Test Vectors
         id: cache-satkit-testvecs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,6 +52,11 @@ jobs:
           pip install requests
           python python/test/download_data.py astro-data
 
+      - name: Refresh EOP and space weather (every run, cache hit or not)
+        run: |
+          pip install requests
+          python python/test/download_data.py astro-data --refresh-only
+
       - name: Install system dependencies for cartopy
         run: sudo apt-get update && sudo apt-get install -y libgeos-dev libproj-dev proj-data
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,11 @@ jobs:
           pip install requests
           python python/test/download_data.py astro-data
 
+      - name: Refresh EOP and space weather (every run, cache hit or not)
+        run: |
+          pip install requests
+          python python/test/download_data.py astro-data --refresh-only
+
       - name: Cache Satkit Test Vectors
         id: cache-satkit-testvecs
         uses: actions/cache@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 ## Unreleased
 
 ### CI
-- CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))
 
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 ## Unreleased
 
 ### CI
+- CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
 
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 

--- a/python/test/download_data.py
+++ b/python/test/download_data.py
@@ -11,9 +11,13 @@ before the Rust build. Mirrors ``satkit.utils.update_datafiles()``:
   legacy bucket), and is only kept when its size and SHA-256 match;
 * a file already present with the right hash is skipped;
 * the regularly refreshed files (EOP, space weather) are fetched from the
-  manifest's ``refresh`` URLs on every run, unverified.
+  manifest's ``refresh`` URLs on every run, unverified; a failed refresh keeps
+  the existing copy and prints a warning instead of failing the run.
 
-Usage: ``python python/test/download_data.py [dest_dir]`` (default ``astro-data``).
+Usage: ``python python/test/download_data.py [dest_dir] [--refresh-only]``
+(default ``astro-data``). ``--refresh-only`` skips the manifest files and only
+re-fetches EOP / space weather — run it on every CI job, including cache hits,
+so a cached data directory never carries a stale EOP table.
 """
 
 import hashlib
@@ -72,31 +76,41 @@ def fetch_verified(entry: dict, dest_dir: Path) -> str:
     raise SystemExit(f"could not download {entry['name']} from any source:\n  " + "\n  ".join(attempts))
 
 
-def fetch_refresh(url: str, dest_dir: Path) -> None:
+def fetch_refresh(url: str, dest_dir: Path) -> str:
+    """Re-fetch a daily-refreshed file; on failure keep the existing copy."""
     name = url.rsplit("/", 1)[-1]
     dest = dest_dir / name
     part = dest.with_name(name + ".part")
-    with requests.get(url, stream=True, timeout=120) as r:
-        r.raise_for_status()
-        with part.open("wb") as f:
-            for chunk in r.iter_content(1 << 20):
-                f.write(chunk)
-    part.replace(dest)
+    try:
+        with requests.get(url, stream=True, timeout=120) as r:
+            r.raise_for_status()
+            with part.open("wb") as f:
+                for chunk in r.iter_content(1 << 20):
+                    f.write(chunk)
+        part.replace(dest)
+        return f"refreshed from {url}"
+    except Exception as exc:  # noqa: BLE001 - any failure keeps the old file
+        part.unlink(missing_ok=True)
+        if dest.exists():
+            return f"WARNING: refresh failed ({exc}); keeping existing copy"
+        return f"WARNING: refresh failed ({exc}); file absent"
 
 
 def main() -> None:
-    dest_dir = Path(sys.argv[1] if len(sys.argv) > 1 else "astro-data")
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    refresh_only = "--refresh-only" in sys.argv[1:]
+    dest_dir = Path(args[0] if args else "astro-data")
     dest_dir.mkdir(exist_ok=True, parents=True)
     manifest = json.loads(MANIFEST.read_text())
     print(f"satkit data {manifest['data_version']} -> {dest_dir}")
-    for entry in manifest["files"]:
-        if not entry.get("default", True):
-            continue
-        src = fetch_verified(entry, dest_dir)
-        print(f"  {entry['name']}: {src}")
+    if not refresh_only:
+        for entry in manifest["files"]:
+            if not entry.get("default", True):
+                continue
+            src = fetch_verified(entry, dest_dir)
+            print(f"  {entry['name']}: {src}")
     for url in manifest.get("refresh", []):
-        fetch_refresh(url, dest_dir)
-        print(f"  {url.rsplit('/', 1)[-1]}: refreshed from {url}")
+        print(f"  {url.rsplit('/', 1)[-1]}: {fetch_refresh(url, dest_dir)}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Rebased onto `main` after #145 merged.

## Problem

The `astro-data` cache in every workflow is keyed on `hashFiles('data/manifest.json')`, and the download step is guarded by `cache-hit != 'true'`. Once the cache is populated, `EOP-All.csv` / `SW-All.csv` are never fetched again. The published Optical Observations tutorial is currently showing `Warning: EOP data ends at 2026-08-23 … all later epochs use the last entry's values held constant`, and the test jobs run on the same stale table (which is exactly the silent-extrapolation case from #125/#133).

## Fix

- `python/test/download_data.py --refresh-only`: skips the manifest-verified static files and re-fetches only the manifest's `refresh` URLs (CelesTrak EOP + SW). A failed refresh now keeps the existing copy and prints a warning instead of failing the job (the `.part` file is removed).
- `build.yml` (×2), `release.yml`, `docs.yml`: new unconditional step "Refresh EOP and space weather (every run, cache hit or not)" right after the cache-guarded download. The refreshed files are not written back to the cache (actions/cache only saves on a miss), so every run refreshes — two ~2 MB downloads per job.

## Verification

- `download_data.py <tmp> --refresh-only` → fresh `EOP-All.csv` ending 2027-02-26 (observed through 2026-08-29).
- Failure path: bogus CelesTrak URL → `WARNING: refresh failed (503 …); keeping existing copy`, old file intact, no `.part` left behind.
- All four workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE