### PR TITLE
docs: absolute SATKIT_DATA in the docs workflow; drop satkit-data from docs requirements

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -68,12 +68,12 @@ jobs:
 
       - name: Generate static plots
         env:
-          SATKIT_DATA: astro-data
+          SATKIT_DATA: ${{ github.workspace }}/astro-data
         run: python docs/examples/gen_plots.py
 
       - name: Build docs
         env:
-          SATKIT_DATA: astro-data
+          SATKIT_DATA: ${{ github.workspace }}/astro-data
         run: mkdocs build
 
       - name: Upload pages artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### CI
 
-- Docs build uses an absolute `SATKIT_DATA` and no longer installs the `satkit-data` bundle: notebooks executed from `docs/tutorials/` could not resolve the relative path and fell back to the bundle's frozen `EOP-All.csv` (ending 2026-08-23), which produced the stale-EOP warning on satkit.dev ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- Docs build uses an absolute `SATKIT_DATA` and no longer installs the `satkit-data` bundle: notebooks executed from `docs/tutorials/` could not resolve the relative path and fell back to the bundle's frozen `EOP-All.csv` (ending 2026-08-23), which produced the stale-EOP warning on satkit.dev ([#148](https://github.com/ssmichael1/satkit/pull/148))
 - CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### CI
 
+- Docs build uses an absolute `SATKIT_DATA` and no longer installs the `satkit-data` bundle: notebooks executed from `docs/tutorials/` could not resolve the relative path and fell back to the bundle's frozen `EOP-All.csv` (ending 2026-08-23), which produced the stale-EOP warning on satkit.dev ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
 - CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,6 @@ mkdocstrings[python]>=0.27
 mkdocs-jupyter>=0.25
 
 # Notebook execution dependencies
-satkit-data>=0.9.0
 numpy
 matplotlib
 scienceplots


### PR DESCRIPTION
Follow-up to #147, which refreshed `astro-data/EOP-All.csv` on every docs run — but the tutorial page still warned that EOP ended 2026-08-23.

## Cause

`docs.yml` sets `SATKIT_DATA: astro-data` (relative). mkdocs-jupyter executes notebooks with `docs/tutorials/` as the working directory, so the path doesn't resolve there and satkit walks the rest of its search list. `docs/requirements.txt` installed `satkit-data>=0.9.0`, whose `EOP-All.csv` is a snapshot from when the wheel was built — 0.9.0 (the current PyPI release) ends 2026-08-23 with observations through 2026-02-23. That is the table the notebooks were using, on every build, regardless of the refresh.

## Fix

- `SATKIT_DATA: ${{ github.workspace }}/astro-data` (absolute) in both docs steps.
- Remove `satkit-data` from `docs/requirements.txt`; the docs build populates `astro-data` itself via `download_data.py` (verified static files + daily EOP/SW refresh), so the bundle only served as a stale fallback.

## Note for users

The same silent fallback applies to anyone with `pip install satkit[data]`: the bundle's EOP table freezes at the bundle's build date and satkit extrapolates past it with the one-time warning. That is the #125 discussion; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE