### PR TITLE
ci: skip the build/test workflow for pure documentation changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,11 @@ on:
       - "**"
     paths-ignore:
       - "docs/**"
-      - "README.md"
-      - "CHANGELOG.md"
-      - "CONTRIBUTING.md"
-      - "LICENSE"
+      - "mkdocs.yml"
+      - "**/*.md"
+      - "LICENSE*"
+      - "recipes/**"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches:
       - "**"
@@ -21,10 +22,11 @@ on:
       - closed
     paths-ignore:
       - "docs/**"
-      - "README.md"
-      - "CHANGELOG.md"
-      - "CONTRIBUTING.md"
-      - "LICENSE"
+      - "mkdocs.yml"
+      - "**/*.md"
+      - "LICENSE*"
+      - "recipes/**"
+      - ".github/workflows/docs.yml"
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### CI
 
-- Build/test workflow skips pure documentation changes: `mkdocs.yml`, any `*.md`, `LICENSE*`, `recipes/**` and the docs workflow file, in addition to `docs/**` ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- Build/test workflow skips pure documentation changes: `mkdocs.yml`, any `*.md`, `LICENSE*`, `recipes/**` and the docs workflow file, in addition to `docs/**` ([#153](https://github.com/ssmichael1/satkit/pull/153))
 - Docs build uses an absolute `SATKIT_DATA` and no longer installs the `satkit-data` bundle: notebooks executed from `docs/tutorials/` could not resolve the relative path and fell back to the bundle's frozen `EOP-All.csv` (ending 2026-08-23), which produced the stale-EOP warning on satkit.dev ([#148](https://github.com/ssmichael1/satkit/pull/148))
 - `on_disk_file_is_verified_once_via_sidecar_marker` test sets the restored file's mtime explicitly; Windows file-time granularity (~1–15 ms) let a rewrite reuse the marker's mtime and fail intermittently ([#149](https://github.com/ssmichael1/satkit/pull/149))
 - CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### CI
 
+- Build/test workflow skips pure documentation changes: `mkdocs.yml`, any `*.md`, `LICENSE*`, `recipes/**` and the docs workflow file, in addition to `docs/**` ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
 - Docs build uses an absolute `SATKIT_DATA` and no longer installs the `satkit-data` bundle: notebooks executed from `docs/tutorials/` could not resolve the relative path and fell back to the bundle's frozen `EOP-All.csv` (ending 2026-08-23), which produced the stale-EOP warning on satkit.dev ([#148](https://github.com/ssmichael1/satkit/pull/148))
 - `on_disk_file_is_verified_once_via_sidecar_marker` test sets the restored file's mtime explicitly; Windows file-time granularity (~1–15 ms) let a rewrite reuse the marker's mtime and fail intermittently ([#149](https://github.com/ssmichael1/satkit/pull/149))
 - CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))


### PR DESCRIPTION
`build.yml` already ignored `docs/**`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md` and `LICENSE`. This widens the `paths-ignore` (both `push` and `pull_request`) so that any documentation-only change skips the Rust/Python test matrix:

- `mkdocs.yml`
- `**/*.md` (covers the root files plus `data/README.md`, `recipes/conda/README.md`, `tests/gmat/README.md`)
- `LICENSE*`
- `recipes/**` (conda recipe; not exercised by the test matrix)
- `.github/workflows/docs.yml`

Behaviour: a PR touching only those paths reports no checks (as #152 does today) and is mergeable under the current branch rules. `docs.yml` is unchanged — it still deploys on every push to `main`, including source changes (API reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE