### PR TITLE
feat(nrlmsise): feed the 7-element 3-hourly ap history; tighten file-driven drag gates ~20×

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 - CI refreshes `EOP-All.csv` / `SW-All.csv` on every run (also on an `astro-data` cache hit) via `download_data.py --refresh-only`, so docs and tests no longer run on a stale EOP table; a failed refresh keeps the cached copy instead of failing the job ([#147](https://github.com/ssmichael1/satkit/pull/147))
 - GitHub Actions updated to current major versions (checkout v7, setup-python v7, cache v6, upload-artifact v7, download-artifact v8, upload-pages-artifact v5, deploy-pages v5, sccache-action v0.0.11, cibuildwheel v4.2.0; Windows wheel repair explicitly kept off) ([#145](https://github.com/ssmichael1/satkit/pull/145))
 
+### Changed
+
+- NRLMSISE-00 is fed the 7-element 3-hourly geomagnetic ap history from `SW-All.csv` (model switch 9 = −1: current-day daily Ap, the current and three preceding 3-hourly ap, the 12–33 h and 36–57 h means; falls back to the daily Ap when the history is incomplete) instead of the daily Ap alone, so file-driven densities follow storms within hours — along the ISS orbit after the 2023-02-27 storm the 3-day drag residual against GMAT drops from 6.8 km to 0.3 km (gates tightened accordingly); `satkit.density.nrlmsise(itrfcoord, ...)` passed latitude/longitude in radians to the degree-taking model ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+
 ### Fixed
 
 - TLE, OMM and Optical Observations tutorials: the CelesTrak-throttling note is a plain blockquote (mkdocs-jupyter renders notebook markdown with nbconvert, which does not support `!!! note` admonitions) ([#152](https://github.com/ssmichael1/satkit/pull/152))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Changed
 
-- NRLMSISE-00 is fed the 7-element 3-hourly geomagnetic ap history from `SW-All.csv` (model switch 9 = −1: current-day daily Ap, the current and three preceding 3-hourly ap, the 12–33 h and 36–57 h means; falls back to the daily Ap when the history is incomplete) instead of the daily Ap alone, so file-driven densities follow storms within hours — along the ISS orbit after the 2023-02-27 storm the 3-day drag residual against GMAT drops from 6.8 km to 0.3 km (gates tightened accordingly); `satkit.density.nrlmsise(itrfcoord, ...)` passed latitude/longitude in radians to the degree-taking model ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- NRLMSISE-00 is fed the 7-element 3-hourly geomagnetic ap history from `SW-All.csv` (model switch 9 = −1: current-day daily Ap, the current and three preceding 3-hourly ap, the 12–33 h and 36–57 h means; falls back to the daily Ap when the history is incomplete) instead of the daily Ap alone, so file-driven densities follow storms within hours — along the ISS orbit after the 2023-02-27 storm the 3-day drag residual against GMAT drops from 6.8 km to 0.3 km (gates tightened accordingly); `satkit.density.nrlmsise(itrfcoord, ...)` passed latitude/longitude in radians to the degree-taking model ([#154](https://github.com/ssmichael1/satkit/pull/154))
 
 ### Fixed
 

--- a/docs/guide/forces.md
+++ b/docs/guide/forces.md
@@ -88,7 +88,7 @@ $$
 
 with $C_d$ the drag coefficient (typically 1.5–3; [Montenbruck & Gill 2000](references.md#montenbruck2000), §3.5), $A/m$ the area-to-mass ratio, $\rho$ the atmospheric density, and $\vec{v}_r$ the satellite velocity relative to the co-rotating atmosphere (assumed at rest in the Earth-fixed frame).
 
-Density comes from the [NRLMSISE-00](https://ccmc.gsfc.nasa.gov/models/NRLMSIS~00/) thermosphere model ([Picone et al. 2002](references.md#picone2002); a pure-Rust port of Dominik Brodowski's C implementation), which reads space-weather indices (F10.7, Ap) automatically. Disable space-weather lookup with `use_spaceweather=False` to fall back to fixed nominal indices.
+Density comes from the [NRLMSISE-00](https://ccmc.gsfc.nasa.gov/models/NRLMSIS~00/) thermosphere model ([Picone et al. 2002](references.md#picone2002); a pure-Rust port of Dominik Brodowski's C implementation), which reads the space-weather indices from the CelesTrak `SW-All.csv` table automatically, following the model's own interface: the observed F10.7 of the previous UTC day, the observed 81-day centred average F10.7A of the current day, and the 7-element 3-hourly geomagnetic history (the current day's daily Ap, the current 3-hourly ap and the three before it, and the 12–33 h and 36–57 h means — NRLMSISE-00 switch 9 = −1), which lets the density respond to a geomagnetic storm within hours rather than at the next UTC midnight. When that history cannot be assembled (a day missing from the table, or a monthly predicted row without 3-hourly values) the model falls back to the current day's daily Ap. Disable space-weather lookup with `use_spaceweather=False` to fall back to fixed nominal indices (F10.7 = F10.7A = 150, Ap = 4).
 
 Drag is skipped above 700 km regardless of settings.
 

--- a/python/src/pydensity.rs
+++ b/python/src/pydensity.rs
@@ -44,8 +44,8 @@ fn pynrlmsise(args: &Bound<'_, PyTuple>) -> PyResult<(f64, f64)> {
         let itrf = args.get_item(0)?.extract::<PyITRFCoord>().unwrap().0;
         Ok(nrlmsise::nrlmsise(
             itrf.hae() / 1.0e3,
-            Some(itrf.latitude_rad()),
-            Some(itrf.longitude_rad()),
+            Some(itrf.latitude_deg()),
+            Some(itrf.longitude_deg()),
             time.as_ref(),
             true,
         ))

--- a/python/test/test_density.py
+++ b/python/test/test_density.py
@@ -1,0 +1,53 @@
+"""NRLMSISE-00 density bindings: ``satkit.nrlmsise00`` and ``satkit.density.nrlmsise``."""
+
+import math
+
+import satkit as sk
+
+
+def test_density_itrfcoord_matches_degree_call():
+    # density.nrlmsise(itrfcoord, time) must hand the model geodetic latitude
+    # and longitude in degrees, like nrlmsise00(..., latitude_deg, longitude_deg).
+    t = sk.time(2023, 3, 1, 12, 0, 0)
+    coord = sk.itrfcoord(latitude_deg=60.0, longitude_deg=-70.0, altitude=400e3)
+    rho_a, temp_a = sk.density.nrlmsise(coord, t)
+    rho_b, temp_b = sk.nrlmsise00(
+        coord.altitude / 1e3,
+        latitude_deg=coord.latitude_deg,
+        longitude_deg=coord.longitude_deg,
+        time=t,
+    )
+    assert math.isclose(rho_a, rho_b, rel_tol=1e-9)
+    assert math.isclose(temp_a, temp_b, rel_tol=1e-9)
+    # The radians interpretation (lat ~ 1.05 deg) is a different atmosphere.
+    rho_rad, _ = sk.nrlmsise00(
+        400.0,
+        latitude_deg=math.radians(60.0),
+        longitude_deg=math.radians(-70.0),
+        time=t,
+    )
+    assert abs(rho_rad / rho_a - 1.0) > 1e-3
+
+
+def test_spaceweather_feed_changes_density_within_the_day():
+    # 2023-02-27 is a G2 storm day (3-hourly ap 48 -> 111 in the morning, daily
+    # Ap 91); with the 3-hourly history the density at the same place moves
+    # between 01:30 and 13:30 UT beyond what the local-time cycle alone gives.
+    coord = dict(latitude_deg=0.0, longitude_deg=0.0)
+    rho_storm = [
+        sk.nrlmsise00(420.0, time=sk.time(2023, 2, 27, h, 30, 0), **coord)[0]
+        for h in (1, 13)
+    ]
+    rho_quiet = [
+        sk.nrlmsise00(420.0, time=sk.time(2023, 3, 1, h, 30, 0), **coord)[0]
+        for h in (1, 13)
+    ]
+    for r in rho_storm + rho_quiet:
+        assert r > 0.0
+    # Storm day: the 13:30 UT density (after the 111 intervals) exceeds the
+    # 01:30 UT density by clearly more than the quiet day's local-time ratio
+    # (measured: 2.23 vs 1.81).
+    assert rho_storm[1] / rho_storm[0] > 1.1 * rho_quiet[1] / rho_quiet[0]
+    # Fixed indices ignore the file entirely.
+    rho_fixed = sk.nrlmsise00(420.0, time=sk.time(2023, 2, 27, 13, 30, 0), use_spaceweather=False, **coord)[0]
+    assert abs(rho_fixed / rho_storm[1] - 1.0) > 0.05

--- a/src/nrlmsise.rs
+++ b/src/nrlmsise.rs
@@ -4866,6 +4866,76 @@ fn gtd7d(
     }
 }
 
+/// Length of one 3-hourly geomagnetic interval, in seconds.
+const AP_INTERVAL_S: f64 = 10800.0;
+
+/// Assemble the 7-element geomagnetic history NRLMSISE-00 takes when switch 9
+/// is −1 (`ap_a` in `nrlmsise-00.h`):
+///
+/// * `[0]` daily Ap of the current UTC day (also what GMAT's
+///   `CSSISpaceWeatherFile` feed puts there);
+/// * `[1]` 3-hourly ap of the current interval;
+/// * `[2]`, `[3]`, `[4]` the intervals 3, 6 and 9 h earlier;
+/// * `[5]` mean of the eight intervals 12–33 h earlier;
+/// * `[6]` mean of the eight intervals 36–57 h earlier.
+///
+/// Intervals are UT: `AP1` covers 00:00–03:00, …, `AP8` 21:00–24:00, and the
+/// interval is chosen by flooring, so a query at exactly 03:00:00 UT belongs
+/// to the 03–06 interval. `sec_of_day` is the UTC seconds since midnight of
+/// the query day; `day(n)` returns the space-weather record for the UTC day
+/// `n` days before the query day (`0` = query day) or `None` when no record
+/// exists for exactly that day. The oldest interval used (57 h back) lies on
+/// day 3 for queries before 09:00 UT and on day 2 otherwise; only the days
+/// actually needed are requested.
+///
+/// A 3-hourly value CelesTrak has not filled in (`-1`) is replaced by that
+/// day's daily Ap, which is what the daily-Ap formulation assumes anyway. When
+/// a needed day has no record, a slot has neither a 3-hourly nor a daily
+/// value, or the current day's daily Ap is missing, no history can be built
+/// and `None` is returned; the caller then falls back to the daily-Ap
+/// formulation (switch 9 = +1).
+fn ap_history(
+    sec_of_day: f64,
+    day: impl Fn(usize) -> Option<crate::spaceweather::SpaceWeatherRecord>,
+) -> Option<[f64; 7]> {
+    // Current 3-hourly interval, 0..=7 (clamped so a leap second at 23:59:60
+    // still lands in AP8).
+    let interval = ((sec_of_day / AP_INTERVAL_S).floor() as i64).clamp(0, 7);
+    // Global interval index n = interval - j for j intervals back; the record
+    // holding it is `(7 - n).div_euclid(8)` days back at slot `n.rem_euclid(8)`.
+    let oldest_day = (7 - (interval - 19)).div_euclid(8) as usize;
+    let mut recs: [Option<crate::spaceweather::SpaceWeatherRecord>; 4] = [None, None, None, None];
+    for (n, slot) in recs.iter_mut().enumerate().take(oldest_day + 1) {
+        *slot = Some(day(n)?);
+    }
+    let daily = recs[0].as_ref()?.ap_avg;
+    if daily < 0 {
+        return None;
+    }
+    let value = |j: i64| -> Option<f64> {
+        let n = interval - j;
+        let r = recs[(7 - n).div_euclid(8) as usize].as_ref()?;
+        match (r.ap[n.rem_euclid(8) as usize], r.ap_avg) {
+            (a, _) if a >= 0 => Some(a as f64),
+            (_, d) if d >= 0 => Some(d as f64),
+            _ => None,
+        }
+    };
+    let mut v = [0.0_f64; 20];
+    for (j, slot) in v.iter_mut().enumerate() {
+        *slot = value(j as i64)?;
+    }
+    Some([
+        daily as f64,
+        v[0],
+        v[1],
+        v[2],
+        v[3],
+        v[4..12].iter().sum::<f64>() / 8.0,
+        v[12..20].iter().sum::<f64>() / 8.0,
+    ])
+}
+
 /// NRL MSISE-00 model for atmosphere density
 ///
 /// # Arguments
@@ -4875,6 +4945,22 @@ fn gtd7d(
 ///   * `lon_option` - Optional longitude in degrees (default: 0)
 ///   * `time_option` -  Optional time, for when using space weather
 ///   * `use_spaceweather` -  Boolean to use space weather data
+///
+/// # Space weather feed
+///
+/// With `use_spaceweather` and a time, the indices come from the CelesTrak
+/// `SW-All.csv` table following the NRLMSISE-00 interface: F10.7 is the
+/// observed flux of the previous UTC day, F10.7A the observed 81-day average
+/// centred on the current day, and the geomagnetic forcing is the 7-element
+/// 3-hourly ap history (daily Ap of the current day, the current 3-hourly ap
+/// and the three before it, and the 12–33 h and 36–57 h means; model switch
+/// 9 = −1). When that history cannot be assembled — no record for one of the
+/// up-to-four days involved, or a row without either 3-hourly or daily values
+/// (monthly predicted rows) — the model runs on the current day's daily Ap
+/// alone (switch 9 = +1), and when not even that exists on Ap = 4. Without a
+/// usable F10.7 record the NOAA/SWPC solar-cycle forecast supplies F10.7 =
+/// F10.7A and Ap stays at 4; without space weather at all F10.7 = F10.7A = 150,
+/// Ap = 4.
 ///
 /// # Outputs
 ///
@@ -4896,17 +4982,20 @@ pub fn nrlmsise(
     let mut f107a: f64 = 150.0;
     let mut f107: f64 = 150.0;
     let mut ap: f64 = 4.0;
+    let mut ap_a: Option<[f64; 7]> = None;
     if let Some(time) = time_option {
         let time = time.as_instant();
-        let (year, _mon, _day, dhour, dmin, dsec) = time.as_datetime();
+        let (year, mon, day, dhour, dmin, dsec) = time.as_datetime();
         let fday: f64 = (time - Instant::from_date(year, 1, 1).unwrap()).as_days() + 1.0;
         day_of_year = fday.floor() as i32;
         sec_of_day = (dhour as f64).mul_add(3600.0, dmin as f64 * 60.0) + dsec;
         if use_spaceweather {
             // NRLMSISE-00 interface (nrlmsise-00.h): F107 is the *observed*
             // (not 1 AU-adjusted) daily flux of the *previous* day, F107A the
-            // observed 81-day average centred on the current day, and AP the
-            // daily Ap of the *current* day.
+            // observed 81-day average centred on the current day, AP the
+            // daily Ap of the *current* day, and AP_A the 3-hourly history
+            // assembled by `ap_history` (used in preference to AP when it can
+            // be built).
             //
             // Predicted (future) rows in SW-All.csv carry -1 sentinels for
             // fields celestrak has not filled in. Treat a record with an
@@ -4928,6 +5017,17 @@ pub fn nrlmsise(
                     _ if r.ap_avg >= 0 => ap = r.ap_avg as f64,
                     _ => {}
                 }
+                // Record for exactly the UTC day `n` days back (spaceweather::get
+                // returns the most recent *prior* record for a missing day, which
+                // must not masquerade as that day's 3-hourly values).
+                if let Ok(day0) = Instant::from_date(year, mon, day) {
+                    ap_a = ap_history(sec_of_day, |n| {
+                        let d = day0 - Duration::from_days(n as f64);
+                        spaceweather::get(&d)
+                            .ok()
+                            .filter(|rec| (rec.date - d).as_days().abs() < 0.5)
+                    });
+                }
             } else if let Some(predicted) = solar_cycle_forecast::get_predicted_f107(&time) {
                 f107 = predicted;
                 f107a = predicted;
@@ -4946,7 +5046,7 @@ pub fn nrlmsise(
         f107a,
         f107,
         ap,
-        ap_a: None,
+        ap_a,
     };
     let mut flags = NrlmsiseFlags {
         switches: [
@@ -4955,6 +5055,10 @@ pub fn nrlmsise(
         sw: [0.0; 24],
         swc: [0.0; 24],
     };
+    // Switch 9: +1 uses the daily Ap, -1 the 7-element 3-hourly history.
+    if input.ap_a.is_some() {
+        flags.switches[9] = -1;
+    }
     let mut output = NrlmsiseOutput {
         d: [0.0; 9],
         t: [0.0; 2],
@@ -4967,6 +5071,7 @@ pub fn nrlmsise(
 mod tests {
     use super::*;
 
+    #[allow(clippy::too_many_arguments)]
     fn call_model(
         alt: f64,
         lat: f64,
@@ -4976,6 +5081,22 @@ mod tests {
         f107: f64,
         f107a: f64,
         ap: f64,
+    ) -> NrlmsiseOutput {
+        call_model_ap_a(alt, lat, lon, doy, sec, f107, f107a, ap, None)
+    }
+
+    /// `call_model` with an optional 7-element ap history (switch 9 = -1).
+    #[allow(clippy::too_many_arguments)]
+    fn call_model_ap_a(
+        alt: f64,
+        lat: f64,
+        lon: f64,
+        doy: i32,
+        sec: f64,
+        f107: f64,
+        f107a: f64,
+        ap: f64,
+        ap_a: Option<[f64; 7]>,
     ) -> NrlmsiseOutput {
         let mut state = NrlmsiseState::new();
         let mut input = NrlmsiseInput {
@@ -4989,7 +5110,7 @@ mod tests {
             f107a,
             f107,
             ap,
-            ap_a: None,
+            ap_a,
         };
         let mut flags = NrlmsiseFlags {
             switches: [
@@ -4998,6 +5119,9 @@ mod tests {
             sw: [0.0; 24],
             swc: [0.0; 24],
         };
+        if input.ap_a.is_some() {
+            flags.switches[9] = -1;
+        }
         let mut output = NrlmsiseOutput {
             d: [0.0; 9],
             t: [0.0; 2],
@@ -5032,21 +5156,40 @@ mod tests {
 
     /// The space-weather feed must follow the NRLMSISE-00 interface: F107 =
     /// observed flux of the previous day, F107A = observed centred 81-day
-    /// average of the current day, AP = daily Ap of the current day.
-    /// 2023-03-01 (SW-All.csv): F10.7 obs 162.0 (adj 159.0), obs c81 163.4,
-    /// Ap 7; 2023-02-28: F10.7 obs 160.9 (adj 157.9), obs c81 164.4, Ap 26.
+    /// average of the current day, and the 7-element 3-hourly ap history with
+    /// the current day's daily Ap in element 0.
+    /// SW-All.csv rows (AP1..AP8, AP_AVG):
+    ///   2023-02-26: 18,9,15,18,15,6,48,67 / 24
+    ///   2023-02-27: 48,80,111,111,94,111,94,80 / 91
+    ///   2023-02-28: 67,39,15,15,6,5,27,32 / 26   F10.7 obs 160.9, c81 164.4
+    ///   2023-03-01: 15,4,5,12,3,5,7,7 / 7        F10.7 obs 162.0, c81 163.4
     #[test]
     fn test_spaceweather_feed_conventions() {
         let tm = Instant::from_datetime(2023, 3, 1, 12, 0, 0.0).unwrap();
         let (alt, lat, lon) = (420.0, 30.0, 40.0);
         let (rho, _) = nrlmsise(alt, Some(lat), Some(lon), Some(&tm), true);
-        let expect = call_model(alt, lat, lon, 60, 43200.0, 160.9, 163.4, 7.0);
+        // 12:00 UT is interval 4 (AP5) of 03-01; 12-33 h back = AP1 of 03-01
+        // and AP8..AP2 of 02-28; 36-57 h back = AP1 of 02-28 and AP8..AP2 of
+        // 02-27.
+        let ap_a = [
+            7.0,
+            3.0,
+            12.0,
+            5.0,
+            4.0,
+            (15.0 + 32.0 + 27.0 + 5.0 + 6.0 + 15.0 + 15.0 + 39.0) / 8.0,
+            (67.0 + 80.0 + 94.0 + 111.0 + 94.0 + 111.0 + 111.0 + 80.0) / 8.0,
+        ];
+        let expect = call_model_ap_a(alt, lat, lon, 60, 43200.0, 160.9, 163.4, 7.0, Some(ap_a));
         assert!(
             (rho / (expect.d[5] * 1.0e3) - 1.0).abs() < 1.0e-12,
             "space-weather feed does not match the NRLMSISE-00 conventions: {rho:e}"
         );
-        // The wrong-day / adjusted-flux alternatives differ by percent, so the
-        // check above is not vacuous.
+        // The daily-Ap formulation, the wrong-day / adjusted-flux alternatives
+        // and a mis-assembled history all differ by > 0.2 %, so the check
+        // above is not vacuous.
+        let daily = call_model(alt, lat, lon, 60, 43200.0, 160.9, 163.4, 7.0);
+        assert!((rho / (daily.d[5] * 1.0e3) - 1.0).abs() > 2.0e-3);
         for (f107, f107a, ap) in [
             (157.9, 161.5, 26.0),
             (160.9, 163.4, 26.0),
@@ -5055,6 +5198,165 @@ mod tests {
             let other = call_model(alt, lat, lon, 60, 43200.0, f107, f107a, ap);
             assert!((rho / (other.d[5] * 1.0e3) - 1.0).abs() > 2.0e-3);
         }
+        let mut shifted = ap_a;
+        shifted[1..5].rotate_right(1); // one interval off
+        let other = call_model_ap_a(alt, lat, lon, 60, 43200.0, 160.9, 163.4, 7.0, Some(shifted));
+        assert!((rho / (other.d[5] * 1.0e3) - 1.0).abs() > 2.0e-3);
+    }
+
+    /// At Ap = 4 (g0(4) = 0) the daily and 3-hourly formulations coincide
+    /// exactly; away from it they differ, so switch 9 really is honoured.
+    #[test]
+    fn test_ap_array_formulation_coincides_at_ap4() {
+        let (alt, lat, lon) = (400.0, 60.0, -70.0);
+        let daily = call_model(alt, lat, lon, 172, 29000.0, 150.0, 150.0, 4.0);
+        let arr = call_model_ap_a(
+            alt,
+            lat,
+            lon,
+            172,
+            29000.0,
+            150.0,
+            150.0,
+            4.0,
+            Some([4.0; 7]),
+        );
+        assert!((daily.d[5] / arr.d[5] - 1.0).abs() < 1.0e-14);
+        assert!((daily.t[1] / arr.t[1] - 1.0).abs() < 1.0e-14);
+        let daily40 = call_model(alt, lat, lon, 172, 29000.0, 150.0, 150.0, 40.0);
+        let arr40 = call_model_ap_a(
+            alt,
+            lat,
+            lon,
+            172,
+            29000.0,
+            150.0,
+            150.0,
+            40.0,
+            Some([40.0; 7]),
+        );
+        assert!(daily40.d[5] > daily.d[5] && arr40.d[5] > daily.d[5]);
+        assert!((daily40.d[5] / arr40.d[5] - 1.0).abs() > 1.0e-3);
+    }
+
+    /// Synthetic 4-day table: day `n` back has AP1..AP8 = 100n+100 .. 100n+107
+    /// and daily Ap 50 + n, so every hand-computed mean is unambiguous.
+    fn synthetic_day(n: usize) -> Option<crate::spaceweather::SpaceWeatherRecord> {
+        let base = 100 * (n as i32 + 1);
+        Some(crate::spaceweather::SpaceWeatherRecord {
+            date: Instant::from_date(2023, 3, 4).unwrap() - Duration::from_days(n as f64),
+            bsrn: 0,
+            nd: 0,
+            kp: [0; 8],
+            kp_sum: 0,
+            ap: core::array::from_fn(|i| base + i as i32),
+            ap_avg: 50 + n as i32,
+            cp: 0.0,
+            c9: 0,
+            isn: 0,
+            f10p7_obs: 150.0,
+            f10p7_adj: 150.0,
+            f10p7_obs_c81: 150.0,
+            f10p7_obs_l81: 150.0,
+            f10p7_adj_c81: 150.0,
+            f10p7_adj_l81: 150.0,
+        })
+    }
+
+    #[test]
+    fn test_ap_history_assembly() {
+        // Exactly 03:00 UT belongs to the 03-06 interval (AP2 = 101).
+        let h = ap_history(10800.0, synthetic_day).unwrap();
+        assert_eq!(h[..5], [50.0, 101.0, 100.0, 207.0, 206.0]);
+        // 12-33 h back: AP6..AP1 of day 1 and AP8, AP7 of day 2.
+        assert_eq!(
+            h[5],
+            (205.0 + 204.0 + 203.0 + 202.0 + 201.0 + 200.0 + 307.0 + 306.0) / 8.0
+        );
+        // 36-57 h back: AP6..AP1 of day 2 and AP8, AP7 of day 3.
+        assert_eq!(
+            h[6],
+            (305.0 + 304.0 + 303.0 + 302.0 + 301.0 + 300.0 + 407.0 + 406.0) / 8.0
+        );
+
+        // One second earlier is still the 00-03 interval, and everything
+        // shifts one slot into the past.
+        let h = ap_history(10799.0, synthetic_day).unwrap();
+        assert_eq!(h[..5], [50.0, 100.0, 207.0, 206.0, 205.0]);
+        assert_eq!(
+            h[5],
+            (204.0 + 203.0 + 202.0 + 201.0 + 200.0 + 307.0 + 306.0 + 305.0) / 8.0
+        );
+        assert_eq!(
+            h[6],
+            (304.0 + 303.0 + 302.0 + 301.0 + 300.0 + 407.0 + 406.0 + 405.0) / 8.0
+        );
+
+        // 23:59:59 UT: interval 7; day 3 is never touched (must not be needed).
+        let h = ap_history(86399.0, |n| if n == 3 { None } else { synthetic_day(n) }).unwrap();
+        assert_eq!(h[..5], [50.0, 107.0, 106.0, 105.0, 104.0]);
+        assert_eq!(
+            h[5],
+            (103.0 + 102.0 + 101.0 + 100.0 + 207.0 + 206.0 + 205.0 + 204.0) / 8.0
+        );
+        assert_eq!(
+            h[6],
+            (203.0 + 202.0 + 201.0 + 200.0 + 307.0 + 306.0 + 305.0 + 304.0) / 8.0
+        );
+
+        // Midnight: interval 0, 57 h back reaches AP6 of day 3.
+        let h = ap_history(0.0, synthetic_day).unwrap();
+        assert_eq!(h[1], 100.0);
+        assert_eq!(
+            h[6],
+            (304.0 + 303.0 + 302.0 + 301.0 + 300.0 + 407.0 + 406.0 + 405.0) / 8.0
+        );
+    }
+
+    #[test]
+    fn test_ap_history_fallbacks() {
+        // A missing 3-hourly value takes that day's daily Ap.
+        let h = ap_history(10800.0, |n| {
+            let mut r = synthetic_day(n)?;
+            if n == 1 {
+                r.ap[7] = -1;
+            }
+            Some(r)
+        })
+        .unwrap();
+        assert_eq!(h[3], 51.0);
+        // A day with neither 3-hourly nor daily values, a missing day, or a
+        // missing current-day daily Ap: no history (daily-Ap fallback).
+        assert!(ap_history(10800.0, |n| {
+            let mut r = synthetic_day(n)?;
+            if n == 2 {
+                r.ap = [-1; 8];
+                r.ap_avg = -1;
+            }
+            Some(r)
+        })
+        .is_none());
+        assert!(ap_history(10800.0, |n| if n == 3 { None } else { synthetic_day(n) }).is_none());
+        assert!(ap_history(10800.0, |n| {
+            let mut r = synthetic_day(n)?;
+            if n == 0 {
+                r.ap_avg = -1;
+            }
+            Some(r)
+        })
+        .is_none());
+    }
+
+    /// Epochs before the space-weather table starts (1957-10-01) have no
+    /// history and no F10.7 record: the model must still return a density.
+    #[test]
+    fn test_nrlmsise_before_table_start_does_not_panic() {
+        let tm = Instant::from_datetime(1957, 10, 1, 6, 0, 0.0).unwrap();
+        let (rho, t) = nrlmsise(400.0, Some(10.0), Some(20.0), Some(&tm), true);
+        assert!(rho > 0.0 && t > 0.0);
+        let tm = Instant::from_datetime(1950, 1, 1, 0, 0, 0.0).unwrap();
+        let (rho, t) = nrlmsise(400.0, Some(10.0), Some(20.0), Some(&tm), true);
+        assert!(rho > 0.0 && t > 0.0);
     }
 
     #[test]

--- a/src/spaceweather.rs
+++ b/src/spaceweather.rs
@@ -62,10 +62,18 @@ pub struct SpaceWeatherRecord {
     pub bsrn: i32,
     /// Number of day within the bsrn
     pub nd: i32,
-    /// Kp
+    /// 3-hourly planetary Kp (×10 as tabulated by CelesTrak, e.g. 33 = 3+),
+    /// one per UT interval: `[0]` 00–03 UT, …, `[7]` 21–24 UT. `-1` when the
+    /// field is empty (e.g. monthly predicted rows).
     pub kp: [i32; 8],
     pub kp_sum: i32,
+    /// 3-hourly planetary ap (`AP1..AP8`), one per UT interval: `[0]` covers
+    /// 00:00–03:00 UT, `[1]` 03:00–06:00, …, `[7]` 21:00–24:00. `-1` when
+    /// the field is empty (monthly predicted rows). Daily predicted rows
+    /// carry the same value in all eight slots.
     pub ap: [i32; 8],
+    /// Daily Ap (`AP_AVG`, the mean of the eight 3-hourly values); `-1` when
+    /// empty.
     pub ap_avg: i32,
     /// Planetary daily character figure
     pub cp: f64,

--- a/tests/gmat/README.md
+++ b/tests/gmat/README.md
@@ -131,7 +131,7 @@ recorded per case in `cases.py` (and copied into each JSON). The floors:
 | relativity (`gr`) | none | both tools apply Schwarzschild + geodesic precession + Lense–Thirring (IERS 2010 eq. 10.12); `gr` residuals equal the `full` (LEO) or `j2` (high-orbit) floors |
 | NRLMSISE-00 implementation (`drag_*_const`) | 26 m ISS, 293 m at 300 km, 10 m GTO over 3 days = 0.5–2 × 10⁻⁴ of the drag-only displacement | fixed-index density along the ISS orbit agrees to +0.01 % mean / 0.06 % rms (GMAT `AtmosDensity` vs satkit at the same lat/lon/alt/time); the residual is the integrated effect of that plus integration noise |
 | anomalous oxygen (`drag_sso550_const`) | 34 m over 3 days = 1.8 × 10⁻³ of the drag-only displacement | GMAT evaluates NRLMSISE-00 through `gtd7`, whose total density omits the anomalous-oxygen component; satkit uses `gtd7d`, the entry point the model's authors specify for drag. The difference is +0.3 % mean at 550–600 km and +1 % over the high-latitude (southern, in March) polar passes; reproducing `gtd7` in satkit brings the density difference to +0.005 % mean / 0.09 % rms. The ISS orbit at 420 km sees < 0.05 % |
-| space-weather feed (`drag_*_sw`) | 6.8 km ISS, 57 km at 300 km, 1.1 km SSO, 12 km GTO over 3 days = 3.5–4.8 % of the drag-only displacement | GMAT feeds NRLMSISE-00 the 3-hourly ap history (7-element array, switch 9 = −1), interpolates the daily F10.7 linearly between 20:00 UT nodes and switches F10.7A at 08:00 UT; satkit feeds the daily Ap (switch 9 = +1) and steps F10.7 at 00:00 UT. Along the ISS orbit two days after the G2 storm this is −1.5 % mean / 5.3 % rms / 24 % max in density; replicating GMAT's feed inside satkit's model brings it to +0.04 % / 0.5 % / 9.7 %, so the residual is the daily-Ap vs 3-hourly-ap formulation (the largest part) and the F10.7 timing, not the model or the drag force. Adopting the ap-array formulation in `src/nrlmsise.rs` would earn tighter gates |
+| space-weather feed (`drag_*_sw`) | 325 m ISS, 2.3 km at 300 km, 37 m SSO, 307 m GTO peak over 3 days = 1.3–2.3 × 10⁻³ of the drag-only displacement (198 m, 2.1 km, 18 m, 113 m at the end of the arc) | Both tools feed NRLMSISE-00 the 3-hourly ap history (7-element array, switch 9 = −1; satkit since the 3-hourly feed was adopted, current-day daily Ap in element 0 on both sides). What remains is the F10.7 timing: GMAT interpolates the daily F10.7 linearly between 20:00 UT nodes and switches F10.7A at 08:00 UT, satkit steps both at 00:00 UT. The residual oscillates rather than accumulating (it peaks mid-arc and shrinks towards the end), as a timing offset in a daily-stepped index would. Before the 3-hourly feed the same cases sat at 6.8 km / 57 km / 1.1 km / 12 km (3.5–4.8 %): along the ISS orbit two days after the G2 storm the daily-Ap formulation was −1.5 % mean / 5.3 % rms / 24 % max in density against GMAT, and replicating GMAT's whole feed (ap array + F10.7 timing) inside satkit's model brought it to +0.04 % / 0.5 % / 9.7 % |
 
 Everything else — μ's, DE440, the GCRF↔ITRF frame, 36×36 gravity, third-body
 — agrees at the centimetre level. (Building this corpus found that the
@@ -140,7 +140,9 @@ which drifted the ISS case by 50 m; fixed alongside this corpus. The drag cases
 found that `drag.rs` passed geodetic latitude/longitude to NRLMSISE-00 in
 radians instead of degrees — density wrong by up to +200 % pointwise, 8 km over
 3 days at ISS altitude — and that the space-weather feed used the 1 AU-adjusted
-instead of the observed F10.7 and the previous day's Ap; both fixed alongside.)
+instead of the observed F10.7 and the previous day's Ap; both fixed alongside.
+The `drag_*_sw` gates were re-measured when satkit adopted the 3-hourly ap
+history; the GMAT trajectories themselves were not regenerated.)
 
 The drag gates are large in metres because the drag effect itself is large; read
 them against the drag-only displacement listed per case in `cases.py`. The

--- a/tests/gmat/cases.py
+++ b/tests/gmat/cases.py
@@ -111,7 +111,8 @@ ORBITS = {
 # tolerance = dict(pos_m=..., vel_mps=...), gate on max over all samples.
 #
 # Gates are ~3x the residual measured at generation (satkit 0.20.4 + exact
-# frame table, GMAT R2026A).  Measured floors and their known causes:
+# frame table, GMAT R2026A; the drag_*_sw gates were re-measured after satkit
+# adopted the 3-hourly ap history).  Measured floors and their known causes:
 #
 #   * Earth-only / j2 cases: 2-3 cm at LEO, 8 cm MEO, 13 cm GEO, 0.6-1.0 m at
 #     200,000-300,000 km.  This is *GMAT's* integration error: GMAT's own
@@ -160,13 +161,13 @@ CASES = [
     # residual should be read against; see the README floors.
     #                                      measured max |dr| / |dv|   drag-only   ratio
     _d("iss_420", "const",  80.0, 0.10),   # 25.8 m   / 2.9e-2       152 km      1.7e-4
-    _d("iss_420", "sw",    20e3,  25.0),   # 6.84 km  / 7.7          194 km      3.5e-2 (Ap feed)
+    _d("iss_420", "sw",    1.0e3, 1.1),    # 325 m    / 0.37         201 km      1.6e-3 (F10.7 timing; final 198 m)
     _d("leo_300", "const", 900.0, 1.0),    # 293 m    / 0.34         1374 km     2.1e-4
     # GMAT's RK89 cannot hold 1e-14 through the file-driven weather steps at
     # 300 km ("Accuracy settings will be violated"), so this case runs at 1e-13.
-    _d("leo_300", "sw",    170e3, 200.0, gmat_accuracy=1e-13),  # 56.6 km / 66  1643 km  3.4e-2 (Ap feed)
+    _d("leo_300", "sw",    7.0e3, 8.0, gmat_accuracy=1e-13),  # 2.28 km / 2.64  1697 km  1.3e-3 (F10.7 timing; final 2.07 km)
     _d("sso_550", "const", 100.0, 0.12),   # 34.2 m   / 3.7e-2       19.2 km     1.8e-3 (LST, see README)
-    _d("sso_550", "sw",    3.3e3, 4.0),    # 1.09 km  / 1.19         26.8 km     4.1e-2 (Ap feed)
+    _d("sso_550", "sw",    110.0, 0.12),   # 37.0 m   / 4.0e-2       28.0 km     1.3e-3 (F10.7 timing; final 18 m)
     _d("gto_250", "const",  30.0, 2.5e-2), # 9.9 m    / 7.5e-3       106 km      5.5e-5 (final 5.9 m)
-    _d("gto_250", "sw",    36e3,  30.0),   # 12.0 km  / 9.1          126 km      4.8e-2 (Ap feed; final 6.1 km)
+    _d("gto_250", "sw",    1.0e3, 0.7),    # 307 m    / 0.23         132 km      2.3e-3 (F10.7 timing; final 113 m)
 ]

--- a/tests/gmat/cases/drag_gto_sw.json
+++ b/tests/gmat/cases/drag_gto_sw.json
@@ -45,10 +45,10 @@
   }
  },
  "tolerance": {
-  "pos_m": 36000.0,
-  "vel_mps": 30.0
+  "pos_m": 1000.0,
+  "vel_mps": 0.7
  },
- "tolerance_measured_against": "v0.21.0-7-g4a12f1c-dirty",
+ "tolerance_measured_against": "v0.21.0-10-g8c1ab8f-dirty",
  "units": "samples: [elapsed_s, x_km, y_km, z_km, vx_kms, vy_kms, vz_kms] in EarthICRF",
  "samples": [
   [

--- a/tests/gmat/cases/drag_iss_sw.json
+++ b/tests/gmat/cases/drag_iss_sw.json
@@ -45,10 +45,10 @@
   }
  },
  "tolerance": {
-  "pos_m": 20000.0,
-  "vel_mps": 25.0
+  "pos_m": 1000.0,
+  "vel_mps": 1.1
  },
- "tolerance_measured_against": "v0.21.0-7-g4a12f1c-dirty",
+ "tolerance_measured_against": "v0.21.0-10-g8c1ab8f-dirty",
  "units": "samples: [elapsed_s, x_km, y_km, z_km, vx_kms, vy_kms, vz_kms] in EarthICRF",
  "samples": [
   [

--- a/tests/gmat/cases/drag_leo300_sw.json
+++ b/tests/gmat/cases/drag_leo300_sw.json
@@ -45,10 +45,10 @@
   }
  },
  "tolerance": {
-  "pos_m": 170000.0,
-  "vel_mps": 200.0
+  "pos_m": 7000.0,
+  "vel_mps": 8.0
  },
- "tolerance_measured_against": "v0.21.0-7-g4a12f1c-dirty",
+ "tolerance_measured_against": "v0.21.0-10-g8c1ab8f-dirty",
  "units": "samples: [elapsed_s, x_km, y_km, z_km, vx_kms, vy_kms, vz_kms] in EarthICRF",
  "samples": [
   [

--- a/tests/gmat/cases/drag_sso550_sw.json
+++ b/tests/gmat/cases/drag_sso550_sw.json
@@ -45,10 +45,10 @@
   }
  },
  "tolerance": {
-  "pos_m": 3300.0,
-  "vel_mps": 4.0
+  "pos_m": 110.0,
+  "vel_mps": 0.12
  },
- "tolerance_measured_against": "v0.21.0-7-g4a12f1c-dirty",
+ "tolerance_measured_against": "v0.21.0-10-g8c1ab8f-dirty",
  "units": "samples: [elapsed_s, x_km, y_km, z_km, vx_kms, vy_kms, vz_kms] in EarthICRF",
  "samples": [
   [


### PR DESCRIPTION
Follow-up to #150. NRLMSISE-00 was run in daily-Ap mode (switch 9 = +1, `ap_a: None`); GMAT feeds the 7-element 3-hourly ap history, and that difference was the dominant term in the file-driven drag cases (3.5–4.8 % of the drag effect).

## Changes

- **`src/nrlmsise.rs`**: `ap_history(sec_of_day, day)` assembles `[daily Ap (current UTC day), ap now, −3 h, −6 h, −9 h, mean 12–33 h, mean 36–57 h]` from the `AP1…AP8` columns of `SW-All.csv` (already parsed in `SpaceWeatherRecord.ap`) and `nrlmsise()` runs with `switches[9] = −1` whenever the array can be built. Conventions: intervals by floor (03:00:00 UT is in the 03–06 slot); a `-1` 3-hourly field takes that day's daily Ap; whole-array fallback to daily-Ap mode when a needed day (to d−3) has no record or no usable values (e.g. monthly `PRM` rows). Never panics (tested at the start of the file and before it). Fixed-index runs and Ap = 4 are bit-identical to before.
- **`python/src/pydensity.rs`**: found in passing — `satkit.density.nrlmsise(itrfcoord, t)` passed latitude/longitude in radians to the degree-taking model (same bug class as #150's `drag.rs` fix). Fixed, with a Python test.
- **Gates**: the four `drag_*_sw` cases re-measured and tightened to ~3× the new maxima (`generate.py --update-tolerances`; GMAT trajectories untouched, constant cases unchanged to the printed digit).
- **Docs**: `tests/gmat/README.md` floor row, `docs/guide/forces.md` feed paragraph.

## Before / after (end-of-arc |Δr| vs GMAT, 3-day arcs)

| case | before | after (final / max) | ratio to drag displacement | gate (pos / vel) |
|---|---|---|---|---|
| drag_iss_sw | 6.84 km | 198 m / 325 m | 3.5e-2 → 1.6e-3 | 20 km / 25 m/s → 1 km / 1.1 m/s |
| drag_leo300_sw | 56.6 km | 2.07 km / 2.28 km | 3.4e-2 → 1.3e-3 | 170 km / 200 → 7 km / 8 |
| drag_sso550_sw | 1.09 km | 18 m / 37 m | 4.1e-2 → 1.3e-3 | 3.3 km / 4 → 110 m / 0.12 |
| drag_gto_sw | 6.1 km | 113 m / 307 m | 4.8e-2 → 2.3e-3 | 36 km / 30 → 1 km / 0.7 |

The residual now peaks mid-arc and shrinks toward the end — the signature of the remaining F10.7 timing difference (GMAT interpolates between 20:00 UT nodes; satkit steps at 00:00 UT), not an accumulating density bias. That ~1e-3 floor is documented and left for later.

## Behaviour change

Every file-driven density changes. Along an ISS-like track at 420 km (new/old − 1): 2023-03-01 +3 d mean +2.0 %, rms 5.5 %, max 29 %; a quiet month (2023-06) mean +0.9 %, rms 4.8 %; 2024-05-09 G5 storm +5 d mean +3.2 %, rms 16 %, max 58 %.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings`, full `cargo test --features chrono` (GMAT 26/26), `pytest python/test/` 193 passed / 1 skipped. Unit tests: hand-computed synthetic 4-day table at 03:00:00, 02:59:59, 23:59:59, 00:00 (window crossings), fallback cases, exact coincidence of both formulations at Ap = 4, and the 2023-03-01 `SW-All.csv` row pin extended to the array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE