### PR TITLE
conda: bump recipe to satkit 0.21.1

### DIFF
--- a/recipes/conda/satkit/recipe.yaml
+++ b/recipes/conda/satkit/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: satkit
-  version: "0.21.0"
+  version: "0.21.1"
 
 package:
   name: ${{ name|lower }}
@@ -13,7 +13,7 @@ source:
   # compiled into the extension (data/manifest.json and data/embedded/*.gz —
   # see MANIFEST.in upstream). No network access is needed at build time.
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 2d1a23c097ba8ca5c9b93f7a0764d0cfa3a65c2b2b0a9a41f86ca807f8029ece
+  sha256: 6d0f97888f44ed19f34914098690602038803f4f28359e8395268aedd4365058
 
 build:
   number: 0


### PR DESCRIPTION
Version and sdist sha256 (`6d0f97888f44ed19f34914098690602038803f4f28359e8395268aedd4365058`, verified against the downloaded PyPI sdist) for 0.21.1. Same change pushed to the staged-recipes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE