### PR TITLE
docs: GMAT drag corpus on the validation page and in the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+
+### Docs
+
+- GMAT validation page and README describe the drag corpus: drag orbits, constant/file-driven force models, measured agreement against the drag-only displacement, anomalous-oxygen and F10.7-timing floors ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+
 ## 0.21.1 - 2026-08-30
 
 ### CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,9 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
-
 ### Docs
 
-- GMAT validation page and README describe the drag corpus: drag orbits, constant/file-driven force models, measured agreement against the drag-only displacement, anomalous-oxygen and F10.7-timing floors ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- GMAT validation page and README describe the drag corpus: drag orbits, constant/file-driven force models, measured agreement against the drag-only displacement, anomalous-oxygen and F10.7-timing floors ([#157](https://github.com/ssmichael1/satkit/pull/157))
 
 ## 0.21.1 - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Plus satellite-local RTN, NTW, and LVLH frames (maneuvers, covariance), and ENU,
 - **Earth gravity**: JGM2, JGM3, EGM96, ITU GRACE16 (spherical harmonics up to degree/order 40; Montenbruck & Gill 2000, §3.2)
 - **Solid Earth tides**: IERS Conventions 2010 §6.2.1 Step-1 corrections to the gravity field
 - **Third-body gravity**: Sun and Moon via JPL DE440/441 ephemerides
-- **Atmospheric drag**: NRLMSISE-00 (Picone et al. 2002) with automatic space weather data
+- **Atmospheric drag**: NRLMSISE-00 (Picone et al. 2002) fed automatically from CelesTrak space-weather data — observed F10.7 / centred F10.7A and the 7-element 3-hourly geomagnetic ap history, so density responds to storms within hours; validated against GMAT (below)
 - **Solar radiation pressure**: Cannonball model with shadow function
 - **Relativity**: IERS 2010 Eq. 10.12 — Schwarzschild, geodesic (de Sitter) precession, and Lense–Thirring
 
@@ -196,9 +196,11 @@ Around 300 Rust tests and 150 Python tests run on every commit across Linux, mac
 
 ### GMAT comparison
 
-The numerical propagator is regression-tested against NASA's General Mission Analysis Tool (GMAT R2026A). The corpus in `tests/gmat/` holds 17 seven-day reference trajectories -- ISS-like LEO, sun-synchronous, GPS MEO, Molniya, GEO, the lunar-resonant TESS orbit, and a 300,000 km cislunar orbit -- each with a low-degree gravity model, a 36×36 EGM96 + solid tides model, and (for three orbits) relativity. GMAT cannot run in CI, so the trajectories are generated offline (`tests/gmat/generate.py`, SPICE DE440, `EarthICRF`) and committed; `tests/gmat_regression.rs` and `python/test/test_gmat.py` replay them hour by hour and gate on the worst residual.
+The numerical propagator is regression-tested against NASA's General Mission Analysis Tool (GMAT R2026A). The corpus in `tests/gmat/` holds 25 reference trajectories: 17 seven-day gravity/third-body cases -- ISS-like LEO, sun-synchronous, GPS MEO, Molniya, GEO, the lunar-resonant TESS orbit, and a 300,000 km cislunar orbit -- each with a low-degree gravity model, a 36×36 EGM96 + solid tides model, and (for three orbits) relativity; plus 8 three-day atmospheric-drag cases (ISS altitude, 300 km, 550 km sun-synchronous, GTO with a 250 km perigee), each run with fixed space-weather indices and with the CelesTrak space-weather file driving NRLMSISE-00 on both sides. GMAT cannot run in CI, so the trajectories are generated offline (`tests/gmat/generate.py`, SPICE DE440, `EarthICRF`) and committed; `tests/gmat_regression.rs` and `python/test/test_gmat.py` replay them hour by hour and gate on the worst residual.
 
 With matched force models the two agree to 3 cm (ISS), 2 cm (SSO), 8 cm (GPS), and 13 cm (GEO, Molniya) over 7 days. At 200,000 km and beyond the residual is ~1 m, which is GMAT's own integration floor (its point-mass runs differ from the analytic Kepler solution by the same amount). The remaining differences with tides and relativity enabled are documented with the tolerances in `tests/gmat/README.md`: GMAT omits the anelastic phase lag in its solid-tide Love numbers that satkit includes, while the relativity cases sit at the same floors (both tools apply the full IERS 2010 Eq. 10.12 correction).
+
+With drag the two agree to 1–2 × 10⁻⁴ of the drag-induced displacement when the space-weather indices are fixed (26 m against 152 km of drag decay over 3 days at ISS altitude; the two NRLMSISE-00 implementations agree to 0.06 % rms in density) and to 1–2 × 10⁻³ when both read the CelesTrak file (198 m at ISS altitude), the residual being the F10.7 timing convention -- GMAT interpolates between 20:00 UT nodes, satkit steps at 00:00 UT. Building the drag corpus found and fixed a radians-for-degrees error in satkit's NRLMSISE-00 inputs (8 km over 3 days at ISS altitude) and moved the space-weather feed to the observed F10.7 and the 3-hourly ap history (0.21.1); details on the [GMAT validation page](https://satkit.dev/guide/gmat_validation/).
 
 ### Running Tests Locally
 

--- a/docs/guide/gmat_validation.md
+++ b/docs/guide/gmat_validation.md
@@ -16,12 +16,13 @@ GMAT is a large GUI-oriented application that cannot run inside a CI job. The co
 | ephemeris | SPICE `de440.bsp` | GMAT bundles only DE405/421/424; satkit uses DE440 ([Park et al. 2021](references.md#park2021)) |
 | body GMs | pinned to the DE440 values satkit uses and recorded in the JSON | a wrong constant in satkit shows up as a residual against a reviewable reference value |
 | gravity file | `EGM96.cof` | coefficients identical to satkit's `EGM96.gfc`; the field's $GM$ comes from the file on both sides |
+| drag (`drag_*` cases) | `AtmosphereModel = 'NRLMSISE00'`, `DragModel = 'Spherical'`; constant weather via `ConstantFluxAndGeoMag` (F10.7 = F10.7A = 150, `MagneticIndex` Kp = 1 ⇒ Ap = 4) or file-driven via `CSSISpaceWeatherFile` pointing at CelesTrak's `SW-All.txt` | the same model satkit uses ([Picone et al. 2002](references.md#picone2002)), fed either fixed indices or the `.txt` twin of satkit's `SW-All.csv`; `drag_leo300_sw` needs `Accuracy = 1e-13` (GMAT's RK89 refuses 1e-14 through the weather steps at 300 km) |
 
 The last point is what makes the corpus a *constants* test as well as a *dynamics* test: the erroneous `MU_MOON` that motivated this work (a $4 \times 10^{-4}$ relative error, 1.3 km over 7 days on a lunar-resonant orbit) would fail the `tess` cases immediately.
 
 ## Orbital regimes
 
-All cases share the epoch 2023-05-16 20:00:00 UTC and run for 7 days with hourly samples.
+The gravity/third-body cases share the epoch 2023-05-16 20:00:00 UTC and run for 7 days with hourly samples.
 
 | orbit | $a$ (km) | $e$ | $i$ (°) | period | what it stresses |
 |---|---|---|---|---|---|
@@ -33,6 +34,15 @@ All cases share the epoch 2023-05-16 20:00:00 UTC and run for 7 days with hourly
 | `tess` | (Cartesian) | ~0.55 | ~37 | 13.7 d | 2:1 lunar-resonant HEO — the case that exposed the `MU_MOON` error |
 | `cislunar` | 300000 | 0.0 | 20.0 | 19 d | third-body dominated; closest approach to the Moon ~85,000 km |
 
+The drag orbits start at 2023-03-01 00:00:00 UTC — inside the *observed* block of the CelesTrak space-weather file on both sides, two days after a G2 storm (Ap 91 on 2023-02-27) so the 3-hourly ap history still matters on day 1 — and run for 3 days: drag error grows roughly as $t^2$, and 7 days at 300 km would be dominated by it. All carry the same spacecraft, $C_d = 2.2$, area 10 m², mass 1000 kg ($C_d A/m = 0.022$ m²/kg).
+
+| orbit | $a$ (km) | $e$ | $i$ (°) | perigee altitude | what it stresses |
+|---|---|---|---|---|---|
+| `iss_420` | 6798 | 0.0005 | 51.6 | 420 km | ISS regime; every local solar time sampled |
+| `leo_300` | 6678 | 0.0005 | 45.0 | 300 km | strongest drag: 1,400 km along-track over 3 days |
+| `sso_550` | 6928 | 0.001 | 97.6 | 550 km | sun-synchronous: fixed local time, polar passes, helium / anomalous-oxygen regime |
+| `gto_250` | 24396 | 0.728 | 27.0 | 250 km | drag as a perigee impulse; adaptive step through a ~1,000 s drag pass |
+
 ## Force models
 
 Each orbit is run under two or three force models so that a discrepancy can be attributed to a component:
@@ -41,17 +51,21 @@ Each orbit is run under two or three force models so that a discrepancy can be a
 |---|---|---|---|---|---|
 | `j2` | EGM96 2×2 | on | off | off | isolates $GM$ values, ephemeris, frame orientation and time |
 | `full` | EGM96 36×36 | on | on | off | everything both tools model the same way |
-| `gr` | EGM96 36×36 | on | on | on | exercises the relativistic correction (a known model gap, below) |
+| `gr` | EGM96 36×36 | on | on | on | exercises the relativistic correction (below) |
+| `drag_const` | as `full` | on | on | off | + NRLMSISE-00 drag with fixed F10.7 = F10.7A = 150, Ap = 4: the density model and drag force alone |
+| `drag_sw` | as `full` | on | on | off | + NRLMSISE-00 drag driven by the CelesTrak space-weather file on both sides: the whole chain, including each tool's F10.7 / Ap feed conventions |
 
-Every orbit is run with `j2` and `full`; `leo_iss`, `tess` and `cislunar` are also run with `gr` — 17 cases in total. Drag and solar radiation pressure are off in all cases: their inputs (atmosphere model variant, space-weather source, shadow model) cannot be matched closely enough between the two tools for the residual to say anything about satkit.
+Every gravity orbit is run with `j2` and `full`; `leo_iss`, `tess` and `cislunar` are also run with `gr` (17 cases); every drag orbit is run with `drag_const` and `drag_sw` (8 cases) — 25 in total. Solar radiation pressure is off throughout: its inputs (shadow model, reflectivity conventions) cannot be matched closely enough between the two tools for the residual to say anything about satkit.
+
+The constant-weather values are exactly what satkit's NRLMSISE-00 assumes with `use_spaceweather = false`, so no special API is needed to isolate the density model from the feed. Ap = 4 (GMAT's `MagneticIndex` is Kp; Kp = 1 maps to Ap = 4 exactly) is also where the daily-Ap and 3-hourly-ap formulations of NRLMSISE-00 coincide, so the feed formulation cannot leak into the constant cases.
 
 ## How the test works
 
 The test is implemented twice — `tests/gmat_regression.rs` (one `#[test]` per case) and `python/test/test_gmat.py` (parametrized over the same files) — so both the Rust core and the Python bindings are exercised.
 
-For each case the test takes GMAT's state at $t = 0$, propagates with satkit to the next hourly sample and compares position and velocity, then continues **from its own propagated state** to the next sample. Errors therefore accumulate over the full 7 days exactly as they would in a real propagation; the gate is the maximum residual over all 168 samples. When a case fails, the whole residual history is printed so the log shows *when* the divergence begins — a lunar perigee passage or a resonance — rather than only that it happened.
+For each case the test takes GMAT's state at $t = 0$, propagates with satkit to the next hourly sample and compares position and velocity, then continues **from its own propagated state** to the next sample. Errors therefore accumulate over the full arc (7 days, or 3 days for the drag cases) exactly as they would in a real propagation; the gate is the maximum residual over all samples. When a case fails, the whole residual history is printed so the log shows *when* the divergence begins — a lunar perigee passage or a resonance — rather than only that it happened.
 
-The replay uses `rkv98_nointerp` with `abs_error = rel_error = 1e-13`, so satkit's own integration error is negligible against the gates.
+The replay uses `rkv98_nointerp` with `abs_error = rel_error = 1e-13`, so satkit's own integration error is negligible against the gates. The drag cases pass `SatPropertiesSimple(Cd·A/m)` from the case's `spacecraft` block; only the file-driven ones turn on `use_spaceweather`.
 
 ## Measured agreement
 
@@ -69,6 +83,21 @@ With matched force models (`j2`: low-degree gravity, Sun and Moon), satkit and G
 
 The 36×36 field adds nothing measurable (36×36 without tides agrees to 2 cm at LEO); the increases under `full` and `gr` are the two model differences described next.
 
+For the drag cases the residual has to be read against the size of the drag effect itself — the along-track displacement between a satkit run with and without drag — because the metres are large only because drag is:
+
+| case | drag-only displacement | end-of-arc residual | max residual | fraction of the drag effect |
+|---|---|---|---|---|
+| `drag_iss_const` | 152 km | 26 m | 26 m | 1.7 × 10⁻⁴ |
+| `drag_leo300_const` | 1374 km | 293 m | 293 m | 2.1 × 10⁻⁴ |
+| `drag_sso550_const` | 19 km | 34 m | 34 m | 1.8 × 10⁻³ |
+| `drag_gto_const` | 106 km | 6 m | 10 m | 5.5 × 10⁻⁵ |
+| `drag_iss_sw` | 194 km | 198 m | 325 m | 1.6 × 10⁻³ |
+| `drag_leo300_sw` | 1643 km | 2.1 km | 2.3 km | 1.3 × 10⁻³ |
+| `drag_sso550_sw` | 27 km | 18 m | 37 m | 1.3 × 10⁻³ |
+| `drag_gto_sw` | 126 km | 113 m | 307 m | 2.3 × 10⁻³ |
+
+With fixed indices the two NRLMSISE-00 implementations agree to +0.01 % mean / 0.06 % rms in density along the ISS orbit (GMAT's `AtmosDensity` report against satkit at the same latitude, longitude, altitude and time); the residual is the integrated effect of that plus integration noise. The remaining differences are the model-level ones described next.
+
 ## Known differences and the gates
 
 Gates are set at roughly three times the residual measured when the corpus was generated, so a real regression trips them while the following documented floors do not.
@@ -79,8 +108,14 @@ Gates are set at roughly three times the residual measured when the corpus was g
 
 **Relativity.** Both tools apply the full IERS 2010 Eq. 10.12 correction ([Petit & Luzum 2010](references.md#petit2010); [GMAT Mathematical Specifications](references.md#gmatspec), §4.2.6) — Schwarzschild, geodesic (de Sitter) precession and Lense–Thirring (see [Force Model](forces.md#general-relativistic-correction)). The `gr` cases therefore add no residual of their own: they sit at the `full` floor at LEO and at GMAT's integration floor at 200,000 km and beyond. (Before the geodesic and Lense–Thirring terms were added, satkit's Schwarzschild-only model left ~1 m over 7 days at 200,000 km, where the geodesic term is the dominant relativistic acceleration.)
 
+**Anomalous oxygen.** GMAT evaluates NRLMSISE-00 through `gtd7`, whose total density omits the anomalous-oxygen component; satkit uses `gtd7d`, the entry point the model's authors specify for drag ([Picone et al. 2002](references.md#picone2002)). The difference is +0.3 % mean at 550–600 km and +1 % over the high-latitude polar passes, which is why `drag_sso550_const` sits at 1.8 × 10⁻³ while the other constant cases are at 10⁻⁴; reproducing `gtd7` in satkit brings the density difference to +0.005 % mean / 0.09 % rms. At 420 km the effect is below 0.05 %.
+
+**Space-weather feed.** Both tools feed NRLMSISE-00 the 7-element 3-hourly ap history (model switch 9 = −1, current-day daily Ap in element 0). What remains is the F10.7 timing: GMAT interpolates the daily F10.7 linearly between 20:00 UT nodes and switches F10.7A at 08:00 UT, while satkit steps both at 00:00 UT. The residual oscillates rather than accumulating — it peaks mid-arc and shrinks toward the end — as a timing offset in a daily-stepped index would. Before satkit adopted the 3-hourly history the same cases sat at 6.8 km / 57 km / 1.1 km / 12 km (3.5–4.8 % of the drag effect): along the ISS orbit two days after the G2 storm the daily-Ap formulation was −1.5 % mean / 5.3 % rms / 24 % max in density against GMAT, and replicating GMAT's whole feed inside satkit's own model brought it to +0.04 % / 0.5 % / 9.7 %.
+
 !!! note "What the corpus found"
     Building this comparison uncovered a defect in the propagator itself. The precomputed table of GCRF→ITRF rotations used by the force model was built from the IAU-76/FK5 approximation (`qgcrf2itrf_approx`; [Vallado 2013](references.md#vallado2013), §3.7), which neglects polar motion and is accurate to about 1 arcsecond. A 1″ tilt of the axis about which J2 makes the orbit precess is not small when integrated over a hundred revolutions: the ISS case drifted 50 m over 7 days relative to GMAT, and Molniya 117 m. The table is now the full IAU 2006/2000A chain ([Petit & Luzum 2010](references.md#petit2010), Ch. 5) — precession-nutation with EOP corrections and polar motion sampled hourly, the Earth rotation angle evaluated exactly — at the same cost as the old approximation. Those cases now agree to 3 cm and 13 cm.
+
+    The drag cases found two more. `drag.rs` passed geodetic latitude and longitude to NRLMSISE-00 in radians where the model takes degrees — density wrong by up to +200 % pointwise (+14 % mean, 64 % rms along the ISS orbit), 8 km over 3 days at ISS altitude — and the Python `density.nrlmsise` binding had the same defect. The space-weather feed also used the 1 AU-adjusted instead of the observed F10.7 and the previous day's Ap, and ran the model in daily-Ap mode; it now feeds the observed F10.7, the centred 81-day mean and the 3-hourly ap history (see [Force Model](forces.md#atmospheric-drag)). All fixed alongside the corpus.
 
 ## Regenerating the corpus
 
@@ -91,7 +126,7 @@ python tests/gmat/generate.py --gmat "~/Projects/GMAT R2026A" --spk ./de440.bsp
 cargo test --test gmat_regression
 ```
 
-All 17 cases regenerate in under a minute. The case matrix, gates and the measured floors live in `tests/gmat/cases.py`; operational details — adding a case, evaluating ad-hoc cases against a scratch directory, the JSON format — are in `tests/gmat/README.md` in the repository.
+All 25 cases regenerate in a few minutes (the drag cases also need CelesTrak's `SW-All.txt`, which like the kernel is not committed). The case matrix, gates and the measured floors live in `tests/gmat/cases.py`; operational details — adding a case, evaluating ad-hoc cases against a scratch directory, the JSON format — are in `tests/gmat/README.md` in the repository.
 
 ## See Also
 


### PR DESCRIPTION
The drag corpus (#150, #154) only updated `tests/gmat/README.md`; the mkdocs *Validation: GMAT Comparison* page still said "17 cases, drag off", and the README's GMAT paragraph and drag bullet predated the work.

## `docs/guide/gmat_validation.md`
- Configuration row for the drag setup (NRLMSISE00 / Spherical, constant vs `CSSISpaceWeatherFile`, the `Accuracy = 1e-13` exception).
- Drag orbit table (epoch choice two days after a G2 storm, 3-day arcs, spacecraft), `drag_const` / `drag_sw` force models, 25-case count, why Ap = 4 isolates the density model from the feed formulation.
- Measured-agreement table for the 8 drag cases against the drag-only displacement (const 1–2 × 10⁻⁴ of the effect; sw 1–2 × 10⁻³).
- Floors: anomalous oxygen (`gtd7` vs `gtd7d`), space-weather feed (both use the 3-hourly ap history; residual = F10.7 timing), with the before/after numbers.
- "What the corpus found" extended with the radians-for-degrees inputs and the feed fixes.

## `README.md`
- Drag bullet: how the space-weather feed works and that it is validated against GMAT.
- GMAT paragraph: 25 cases including the 8 drag cases, the drag agreement numbers, and a pointer to the page.

Docs-only; no CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE