### PR TITLE
ci: one build run per change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
 name: Build
 
+# One run per change: pull requests build on the PR event only (no
+# duplicate run for the branch push), main builds on the squash commit,
+# and a new push to a PR cancels the superseded run.
 on:
   push:
     branches:
-      - "**"
+      - main
     paths-ignore:
       - "docs/**"
       - "mkdocs.yml"
@@ -19,7 +22,6 @@ on:
       - opened
       - synchronize
       - reopened
-      - closed
     paths-ignore:
       - "docs/**"
       - "mkdocs.yml"
@@ -27,6 +29,10 @@ on:
       - "LICENSE*"
       - "recipes/**"
       - ".github/workflows/docs.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 - GMAT validation page and README describe the drag corpus: drag orbits, constant/file-driven force models, measured agreement against the drag-only displacement, anomalous-oxygen and F10.7-timing floors ([#157](https://github.com/ssmichael1/satkit/pull/157))
 
+### CI
+
+- Build workflow runs once per change: pull requests build on the PR event only (branch pushes without a PR no longer build), `main` builds on the merge commit, the redundant run on PR close is gone, and a new push to a PR cancels its superseded run ([#158](https://github.com/ssmichael1/satkit/pull/158))
+
 ## 0.21.1 - 2026-08-30
 
 ### CI


### PR DESCRIPTION
Trims the redundant `build.yml` runs around a PR (each run is 8 jobs). Before: branch push + PR event on every push, a full run again on PR close, and superseded runs kept going — ~48 jobs for a PR with one follow-up push. After: ~17.

- `push` triggers only on `main` (the squash commit); branches build through their PR. A branch with no PR no longer builds — open a draft PR for a WIP run.
- `pull_request` drops `types: closed` (nothing consumed that event).
- `concurrency` group per PR / ref with `cancel-in-progress`, so a new push cancels the run it supersedes (docs.yml already does this).
- `paths-ignore` unchanged. `release.yml` unchanged — its pre-publish test is already a single Ubuntu job.

Process change on the maintainer side, applied starting with this PR: the changelog line is written with the PR number predicted from the issue/PR sequence before the first push, so there is no second "fill PR number" commit and no second CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fhrVLbjyHhmuGzU4ohEXE