### PR TITLE
Verify downloads against the OS trust store, and check the CelesTrak feeds before they replace the file on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 - Downloads verify servers against the operating system's trust store (macOS keychain, Windows certificate store, `/etc/ssl` on Unix) instead of the Mozilla root list compiled into the HTTP client: on a network whose TLS is inspected by a corporate proxy every download failed with `io: invalid peer certificate: UnknownIssuer`, because such a proxy re-signs traffic with a private CA that can only ever live in the system store. `SATKIT_CA_BUNDLE` overrides the choice with a PEM file, `platform`, or `webpki` (the compiled-in roots, for a container with no system store); `SSL_CERT_FILE` is deliberately not consulted. Download errors also name the URL that failed and, for a certificate failure, say what to do about it once (`download::Error` gains a `Request` variant, and `AllSourcesFailed` a `hint` field) ([#160](https://github.com/ssmichael1/satkit/pull/160))
 
+- The daily CelesTrak files are checked before they replace the copy on disk: `EOP-All.csv` and `SW-All.csv` are run through the parser that will later read them, and any unverified download is rejected if it opens with an HTML document. A filtering proxy or captive portal that answers `200 OK` with a notice page can no longer overwrite a good EOP table with a web page — the partial download is discarded and the existing file left in place (`download::Error::ContentRejected`) ([#160](https://github.com/ssmichael1/satkit/pull/160))
+
 ### Docs
 
 - GMAT validation page: removed the "What the corpus found" note ([#159](https://github.com/ssmichael1/satkit/pull/159))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+### Fixed
+
+- Downloads verify servers against the operating system's trust store (macOS keychain, Windows certificate store, `/etc/ssl` on Unix) instead of the Mozilla root list compiled into the HTTP client: on a network whose TLS is inspected by a corporate proxy every download failed with `io: invalid peer certificate: UnknownIssuer`, because such a proxy re-signs traffic with a private CA that can only ever live in the system store. `SATKIT_CA_BUNDLE` overrides the choice with a PEM file, `platform`, or `webpki` (the compiled-in roots, for a container with no system store); `SSL_CERT_FILE` is deliberately not consulted. Download errors also name the URL that failed and, for a certificate failure, say what to do about it once (`download::Error` gains a `Request` variant, and `AllSourcesFailed` a `hint` field) ([#160](https://github.com/ssmichael1/satkit/pull/160))
+
 ### Docs
 
 - GMAT validation page: removed the "What the corpus found" note ([#159](https://github.com/ssmichael1/satkit/pull/159))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "satkit"
 [dependencies]
 numeris = { version = "0.5.18", features = ["serde", "ode"] }
 thiserror = "2.0"
-ureq = { version = "3.1.2", optional = true }
+ureq = { version = "3.1.2", features = ["platform-verifier"], optional = true }
 process_path = "0.1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docs/getting-started/datafiles.md
+++ b/docs/getting-started/datafiles.md
@@ -84,6 +84,12 @@ Either the private CA is not installed system-wide — install it, or point
 really is untrusted and the download should not be forced through. satkit has no
 "skip verification" switch.
 
+A proxy that answers with a notice page instead of blocking outright cannot
+corrupt the data either: `EOP-All.csv` and `SW-All.csv` are parsed before they
+replace the copy on disk, and any download that opens with an HTML document is
+rejected. The partial file is discarded and the existing one left in place, so a
+blocked refresh degrades to a stale table rather than a broken one.
+
 Note that `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` are deliberately ignored:
 Python tooling routinely points them at a stock public bundle, which is the one
 trust store guaranteed to fail on an intercepting network.

--- a/docs/getting-started/datafiles.md
+++ b/docs/getting-started/datafiles.md
@@ -53,6 +53,7 @@ A file is used from the first directory that contains it. The ephemeris is also 
 | `SATKIT_DATA=/path` | search first and write here (created if needed) |
 | `SATKIT_DATA_URL=https://mirror/base` | try `"$SATKIT_DATA_URL/<name>"` before the manifest's sources for every download (plain `http://` accepted; still hash-verified) |
 | `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` / `NO_PROXY` | honoured for every download (standard proxy environment variables; read by the HTTP client) |
+| `SATKIT_CA_BUNDLE=/path/bundle.pem` | verify servers against the certificates in this PEM file instead of the operating system's trust store. The file replaces the trust store outright, so it must also carry the public roots (`python -m certifi` with the private CA appended). Also accepts `platform` (the default) and `webpki` (the Mozilla list compiled into satkit, for a container with no system trust store). See [Downloads behind a TLS-inspecting proxy](#downloads-behind-a-tls-inspecting-proxy) |
 | `SATKIT_OFFLINE=1` / `satkit.utils.set_offline(True)` | forbid **downloads** — `update_datafiles()`, the lazy ephemeris fetch, the EOP/SW refresh, any non-embedded file — with a `RuntimeError` naming the file and its sources; no connection is opened. Search locations and the compiled-in data are unaffected. The setter wins once called; otherwise the variable is read. `satkit.utils.is_offline()` reports the effective state |
 | `SATKIT_JPLEPHEM_FILE=name-or-path` | which ephemeris to load — see [below](#selecting-a-jpl-ephemeris-file) |
 | `SATKIT_QUIET=1` | suppress the one-time note printed when a compiled-in file is used |
@@ -60,6 +61,32 @@ A file is used from the first directory that contains it. The ephemeris is also 
 | `satkit.utils.data_search_dirs()` | the search list, in order |
 | `satkit.utils.set_datadir(path)` / `add_search_dir(path)` | add an override / a read-only search location |
 | `satkit.utils.datafiles_exist()` | whether an ephemeris file is present in any search directory (the marker of a provisioned data location) |
+
+### Downloads behind a TLS-inspecting proxy
+
+Organisations that inspect outbound TLS put a gateway between satkit and the
+data servers: it terminates the connection and re-signs every certificate with
+a private CA. satkit verifies servers against the **operating system's trust
+store** — the keychain on macOS, the certificate store on Windows, `/etc/ssl`
+and friends on Unix — which is exactly where such a CA is installed, so those
+downloads work with no configuration.
+
+If they do not, the failure looks like this:
+
+```
+RuntimeError: could not fetch https://celestrak.org/SpaceData/SW-All.csv: io: invalid peer certificate: UnknownIssuer
+```
+
+The certificate presented is signed by something the machine does not trust.
+Either the private CA is not installed system-wide — install it, or point
+`SATKIT_CA_BUNDLE` at a PEM file containing it *together with* the public roots
+— or no interception is expected on that network, in which case the certificate
+really is untrusted and the download should not be forced through. satkit has no
+"skip verification" switch.
+
+Note that `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` are deliberately ignored:
+Python tooling routinely points them at a stock public bundle, which is the one
+trust store guaranteed to fail on an intercepting network.
 
 ### Where the files come from, and how downloads are verified
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -30,6 +30,7 @@ sk.utils.update_datafiles()   # ephemeris + IERS tables + gravity files + EOP/SW
 - `SATKIT_DATA_URL=https://mirror.example/satkit-data` makes satkit fetch from a mirror first (plain `http://` is accepted for an internal mirror; downloads are still verified).
 - `pip install satkit[data]` installs the optional **`satkit-data`** bundle (the ephemeris and full-degree gravity files, ~110 MB) into `site-packages`; satkit finds it automatically as a read-only source. Use it where a first-use download is unwelcome.
 - `SATKIT_DATA=/path` names a directory that is both searched first and written to.
+- `SATKIT_CA_BUNDLE=/path/bundle.pem` verifies downloads against that PEM file instead of the system trust store — for a network whose TLS is inspected by a proxy whose CA is not installed system-wide, or a container with no trust store at all (`SATKIT_CA_BUNDLE=webpki` uses the roots compiled into satkit). See [Data Files](datafiles.md#downloads-behind-a-tls-inspecting-proxy).
 
 See [Data Files](datafiles.md) for the full search order per platform.
 

--- a/src/earth_orientation_params.rs
+++ b/src/earth_orientation_params.rs
@@ -139,6 +139,23 @@ fn parse_csv(text: &str) -> Result<Vec<EOPEntry>> {
         .collect()
 }
 
+/// Check that the file at `path` is a parsable `EOP-All.csv`, without
+/// touching the loaded table.
+///
+/// Used by the downloader to reject a response that is not the file it
+/// claims to be — a proxy notice page served with `200 OK`, or a truncated
+/// transfer — before it replaces a good table on disk. The check is the real
+/// parser, so anything that would later fail to load fails here instead,
+/// while the previous file is still in place.
+pub(crate) fn validate_file(path: &std::path::Path) -> std::result::Result<(), String> {
+    let text = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    match parse_csv(&text) {
+        Ok(rows) if rows.is_empty() => Err("the file holds no EOP rows".to_string()),
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("not a parsable EOP-All.csv ({e})")),
+    }
+}
+
 /// Lazy default load from `EOP-All.csv` under [`datadir`], with auto-download.
 fn load_eop_file_csv() -> Result<Vec<EOPEntry>> {
     // Found in any search directory, else downloaded into the write location.

--- a/src/spaceweather.rs
+++ b/src/spaceweather.rs
@@ -179,6 +179,20 @@ fn parse_csv(text: &str) -> Result<Vec<SpaceWeatherRecord>> {
         .collect()
 }
 
+/// Check that the file at `path` is a parsable `SW-All.csv`, without touching
+/// the loaded records. Same role as
+/// [`earth_orientation_params::validate_file`](crate::earth_orientation_params::validate_file):
+/// let the downloader reject a proxy notice page or a truncated transfer
+/// before it replaces a good file on disk.
+pub(crate) fn validate_file(path: &std::path::Path) -> std::result::Result<(), String> {
+    let text = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    match parse_csv(&text) {
+        Ok(rows) if rows.is_empty() => Err("the file holds no space-weather rows".to_string()),
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!("not a parsable SW-All.csv ({e})")),
+    }
+}
+
 fn load_default_path() -> Result<PathBuf> {
     // Found in any search directory, else downloaded into the write location.
     Ok(crate::utils::datadir::path_for("SW-All.csv")?)

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -56,9 +56,20 @@ pub enum Error {
     },
 
     /// Every candidate URL for a manifest file failed; `attempts` holds one
-    /// `"<url>: <error>"` line per URL tried.
-    #[error("Could not download {name} from any source:\n  {}", attempts.join("\n  "))]
-    AllSourcesFailed { name: String, attempts: Vec<String> },
+    /// `"<url>: <error>"` line per URL tried and `hint`, when the failures
+    /// have a common actionable cause (a TLS trust failure behind an
+    /// intercepting proxy), says what to do about it — once, rather than
+    /// repeated under every URL.
+    #[error(
+        "Could not download {name} from any source:\n  {}{}",
+        attempts.join("\n  "),
+        hint.as_deref().unwrap_or("")
+    )]
+    AllSourcesFailed {
+        name: String,
+        attempts: Vec<String>,
+        hint: Option<String>,
+    },
 
     /// Replacing an existing data file failed even after retries. On
     /// Windows a file another process has open cannot be renamed over; on
@@ -96,6 +107,21 @@ pub enum Error {
     #[cfg(feature = "download")]
     #[error(transparent)]
     Http(#[from] ureq::Error),
+
+    /// An HTTP request failed. Unlike [`Error::Http`] this names the URL that
+    /// was being fetched and, when the failure is one whose underlying message
+    /// is too terse to act on (a TLS trust failure behind an intercepting
+    /// proxy), appends guidance on how to fix it.
+    #[cfg(feature = "download")]
+    #[error("could not fetch {url}: {source}{}", hint.as_deref().unwrap_or(""))]
+    Request {
+        url: String,
+        #[source]
+        source: ureq::Error,
+        /// Guidance appended to the message, already formatted with a leading
+        /// newline; `None` when the underlying error speaks for itself.
+        hint: Option<String>,
+    },
 }
 
 /// Convenient type alias used throughout the `download` module.
@@ -188,15 +214,148 @@ pub(crate) const USER_AGENT: &str = concat!(
     " (+https://github.com/ssmichael1/satkit)"
 );
 
+/// Environment variable that chooses the root certificates satkit verifies
+/// download servers against. Three accepted values:
+///
+/// * a path to a PEM file — trust exactly the certificates in it. It may
+///   hold any number of concatenated certificates and it *replaces* the
+///   trust store, so it must also cover satkit's other download hosts
+///   (GitHub, JPL, CelesTrak): the usual recipe is a public bundle
+///   (`python -m certifi`) with the private CA appended.
+/// * `platform` — the operating system's own trust store: the macOS keychain,
+///   the Windows certificate store, `/etc/ssl` and friends on Unix. This is
+///   the default, and it is where a TLS-inspecting proxy's private CA is
+///   installed.
+/// * `webpki` — the Mozilla root list compiled into the binary, ignoring the
+///   machine entirely. For a minimal container with no system trust store,
+///   and for anyone who would rather not trust whatever an administrator has
+///   added to that store.
+///
+/// Set it to a PEM path where TLS is intercepted by a proxy whose CA is not
+/// installed system-wide.
+///
+/// Deliberately not `SSL_CERT_FILE`: Python tooling routinely points that at
+/// a stock public bundle, which is exactly the trust store that fails on an
+/// intercepting network — honouring it would break the case this variable
+/// exists to fix.
+pub const CA_BUNDLE_ENV: &str = "SATKIT_CA_BUNDLE";
+
+/// The root certificates satkit verifies servers against: those in
+/// [`CA_BUNDLE_ENV`] when it names a readable PEM file, otherwise the
+/// platform's own trust store (macOS keychain, Windows certificate store,
+/// `/etc/ssl` and friends on Unix).
+///
+/// The platform store rather than ureq's default of the Mozilla root list
+/// compiled into the binary: an organisation whose gateway inspects TLS
+/// re-signs every certificate with a private CA, which is installed in the
+/// platform store and can never be in the Mozilla list. Against the
+/// compiled-in list every download on such a network fails with
+/// `invalid peer certificate: UnknownIssuer`. The trade-off is deliberate —
+/// trusting the platform store means trusting whatever an administrator has
+/// added to it.
+#[cfg(feature = "download")]
+fn root_certs() -> ureq::tls::RootCerts {
+    let setting = match std::env::var_os(CA_BUNDLE_ENV) {
+        Some(v) if !v.is_empty() => v,
+        _ => return ureq::tls::RootCerts::PlatformVerifier,
+    };
+    if setting.eq_ignore_ascii_case("platform") {
+        return ureq::tls::RootCerts::PlatformVerifier;
+    }
+    if setting.eq_ignore_ascii_case("webpki") {
+        return ureq::tls::RootCerts::WebPki;
+    }
+    let path = std::path::PathBuf::from(setting);
+    match load_ca_bundle(&path) {
+        Ok(roots) => roots,
+        Err(reason) => {
+            eprintln!(
+                "Warning: ignoring {CA_BUNDLE_ENV}={}: {reason}; \
+                 verifying against the platform trust store instead",
+                path.display()
+            );
+            ureq::tls::RootCerts::PlatformVerifier
+        }
+    }
+}
+
+/// Every certificate in the PEM file at `path`, as a root-certificate set.
+/// `Err` carries the reason for the warning [`root_certs`] prints: the file
+/// is unreadable, is not valid PEM, or holds no certificate.
+#[cfg(feature = "download")]
+fn load_ca_bundle(path: &Path) -> std::result::Result<ureq::tls::RootCerts, String> {
+    let pem = std::fs::read(path).map_err(|e| e.to_string())?;
+    let mut certs = Vec::new();
+    for item in ureq::tls::parse_pem(&pem) {
+        match item {
+            Ok(ureq::tls::PemItem::Certificate(cert)) => certs.push(cert),
+            // A bundle that also carries a private key is odd but harmless.
+            Ok(_) => {}
+            Err(e) => return Err(format!("not a valid PEM file ({e})")),
+        }
+    }
+    if certs.is_empty() {
+        return Err("no certificate found in the file".to_string());
+    }
+    Ok(ureq::tls::RootCerts::from(certs))
+}
+
 /// Build the HTTP agent used for all satkit downloads: ureq's defaults
 /// (proxy settings from `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY`, redirects,
-/// timeouts) plus the [`USER_AGENT`] string.
+/// timeouts) plus the [`USER_AGENT`] string and the [`root_certs`] trust
+/// store.
 #[cfg(feature = "download")]
 pub(crate) fn http_agent() -> ureq::Agent {
     ureq::Agent::config_builder()
         .user_agent(USER_AGENT)
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .root_certs(root_certs())
+                .build(),
+        )
         .build()
         .into()
+}
+
+/// For a TLS trust failure — what an intercepting proxy produces when its CA
+/// is not in the trust store satkit is using — an actionable message.
+/// `None` for any other error.
+#[cfg(feature = "download")]
+pub(crate) fn tls_trust_hint(err: &ureq::Error) -> Option<String> {
+    let trust_failure = match err {
+        ureq::Error::Io(e) => {
+            let msg = e.to_string();
+            msg.contains("invalid peer certificate") || msg.contains("UnknownIssuer")
+        }
+        ureq::Error::Tls(_) => true,
+        _ => false,
+    };
+    if !trust_failure {
+        return None;
+    }
+    Some(format!(
+        "The server's certificate is not trusted by this machine's certificate store. \
+         This is what a TLS-inspecting proxy looks like: it re-signs traffic with a private \
+         CA that must be installed in the system trust store. Install that CA system-wide, \
+         or set {CA_BUNDLE_ENV} to a PEM file holding it together with the public roots. \
+         If no such proxy is expected on this network, the certificate really is untrusted \
+         and the download should not be forced through."
+    ))
+}
+
+/// Wrap a failed request as [`Error::Request`]: the URL that was being
+/// fetched, plus a hint for the failures whose own message does not say what
+/// to do about them.
+#[cfg(feature = "download")]
+pub(crate) fn request_error(url: &str, source: ureq::Error) -> Error {
+    let hint = celestrak_throttle_hint(url, &source)
+        .or_else(|| tls_trust_hint(&source))
+        .map(|h| format!("\n{h}"));
+    Error::Request {
+        url: url.to_string(),
+        source,
+        hint,
+    }
 }
 
 /// For an HTTP error from a `celestrak.org` request, an actionable message
@@ -217,12 +376,18 @@ pub(crate) fn celestrak_throttle_hint(url: &str, err: &ureq::Error) -> Option<St
     if !host_ok {
         return None;
     }
+    let proxy_note = if status == 403 {
+        " A 403 can also come from a filtering proxy between you and CelesTrak rather than from \
+         CelesTrak itself — check whether the body is an HTML block page."
+    } else {
+        ""
+    };
     Some(format!(
         "CelesTrak returned HTTP {status} for {url}. CelesTrak throttles repeated identical \
          GP queries: it asks for at most one request per object every ~2 hours (satkit already \
          sends a descriptive User-Agent). Do not retry in a loop — cache the response (save the \
          TLE/OMM text and parse it with `TLE::from_lines` / the OMM parsers) and re-fetch only \
-         when a newer element set is needed."
+         when a newer element set is needed.{proxy_note}"
     ))
 }
 
@@ -430,7 +595,10 @@ pub fn download_if_not_exist(fname: &Path, seturl: Option<&str>) -> Result<()> {
     // Try to set proxy, if any, from environment variables
     let agent = http_agent();
 
-    let mut resp = agent.get(url.as_str()).call()?;
+    let mut resp = agent
+        .get(url.as_str())
+        .call()
+        .map_err(|e| request_error(&url, e))?;
 
     write_atomic(&mut resp.body_mut().as_reader(), fname)?;
     Ok(())
@@ -470,7 +638,7 @@ pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -
     check_online(fname)?;
 
     let agent = http_agent();
-    let mut resp = agent.get(url).call()?;
+    let mut resp = agent.get(url).call().map_err(|e| request_error(url, e))?;
 
     println!("Downloading {}", fname);
     write_atomic(&mut resp.body_mut().as_reader(), &fullpath)?;
@@ -507,7 +675,7 @@ pub fn download_file_async(
 pub fn download_to_string(url: &str) -> Result<String> {
     check_online(url)?;
     let agent = http_agent();
-    let mut resp = agent.get(url).call()?;
+    let mut resp = agent.get(url).call().map_err(|e| request_error(url, e))?;
     let thestring = std::io::read_to_string(resp.body_mut().as_reader())?;
     Ok(thestring)
 }
@@ -687,6 +855,131 @@ mod agent_tests {
         }
         assert!(USER_AGENT.starts_with("satkit/"));
         assert!(USER_AGENT.contains("github.com/ssmichael1/satkit"));
+    }
+
+    /// A self-signed certificate, generated for these tests only, used to
+    /// check that a PEM bundle is read and every certificate in it kept.
+    const TEST_CERT_PEM: &str = "\
+-----BEGIN CERTIFICATE-----\n\
+MIICtjCCAZ4CCQD+TdvyxtLNoDANBgkqhkiG9w0BAQsFADAdMRswGQYDVQQDDBJz\n\
+YXRraXQgdGVzdCByb290IDEwHhcNMjYwODMwMTkxNjMyWhcNMzYwODI3MTkxNjMy\n\
+WjAdMRswGQYDVQQDDBJzYXRraXQgdGVzdCByb290IDEwggEiMA0GCSqGSIb3DQEB\n\
+AQUAA4IBDwAwggEKAoIBAQC8KtMusQe6lwq6iV46RqCYg7fXePr+hiPs0oV5z4xo\n\
+Mae9oZ3Sz/C9Vu2hwk+WhACelNYMA9FKkeRJzN4DOH3PKvsqELFW2mZRzV9iwYn/\n\
+68p//+SVLgKXjjf+dFUt1QJin27OCfnSREgbclf50+V/1ZtntVSW5laCBkrrvIR0\n\
+ro1xDqjopt8vSODmkYyO/bGnmTYP2w+n/7imCSJ0SsjNHHTSG1r9SQtm7jqfF/lb\n\
+EeY+8J6j2zFEJ+XC+WSYbVrCrsthE/FEoEg3XBexX2gDbty4xABFdSQJ4vqOaoA5\n\
+Re3pAsYCEa6ZT19JXtPX77DZ+6qcaHjAKna+LhCrpfV1AgMBAAEwDQYJKoZIhvcN\n\
+AQELBQADggEBADW+76NDtE6/dyYoBaxQXtRo4pBMBLKm6hY6EVCF6n+X+0egAG2q\n\
+igGwSNYhf/4bkreX2WJSMWz2aTQwKRIcERGoHy22ftBQbtkNWmdsUazf4Wt8h2cW\n\
++G3iY4j7trhc5wf5vQxSGzKJpUArWmslQzezYsOJXcaVIBi0ib3c8bWxU51fy7TQ\n\
+EJ2v6j5DChUCY06hOu2Nc+uc1rt8JoPMspPKyWBup18RQAuJ2vHoS0Do++nhKN/0\n\
+nqylLCIo7Z6QSP2wB/zARZQB9OLch0Fp5N3QsmtQpj+MQ3z9QYhySjE/ABNz8XHG\n\
+19lkXVD84ByEe7n7YsO0klDklCd5NPsFtj4=\n\
+-----END CERTIFICATE-----";
+
+    /// Serialised access to [`CA_BUNDLE_ENV`] plus a scratch directory: the
+    /// harness runs tests in parallel threads and the variable is process-wide.
+    fn with_ca_bundle_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = crate::utils::manifest::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        match value {
+            Some(v) => std::env::set_var(CA_BUNDLE_ENV, v),
+            None => std::env::remove_var(CA_BUNDLE_ENV),
+        }
+        let out = f();
+        std::env::remove_var(CA_BUNDLE_ENV);
+        out
+    }
+
+    #[test]
+    fn root_certs_default_to_the_platform_trust_store() {
+        // The point of the platform store: a TLS-inspecting proxy's private CA
+        // is installed there and can never be in a compiled-in Mozilla list.
+        with_ca_bundle_env(None, || {
+            assert!(matches!(
+                root_certs(),
+                ureq::tls::RootCerts::PlatformVerifier
+            ));
+        });
+        with_ca_bundle_env(Some("PLATFORM"), || {
+            assert!(matches!(
+                root_certs(),
+                ureq::tls::RootCerts::PlatformVerifier
+            ));
+        });
+    }
+
+    #[test]
+    fn ca_bundle_env_can_select_the_compiled_in_roots() {
+        with_ca_bundle_env(Some("webpki"), || {
+            assert!(matches!(root_certs(), ureq::tls::RootCerts::WebPki));
+        });
+    }
+
+    #[test]
+    fn ca_bundle_env_loads_every_certificate_in_the_file() {
+        let dir = std::env::temp_dir().join(format!("satkit_ca_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("bundle.pem");
+        std::fs::write(&path, format!("{TEST_CERT_PEM}\n{TEST_CERT_PEM}\n")).unwrap();
+
+        let roots = with_ca_bundle_env(Some(path.to_str().unwrap()), root_certs);
+        match roots {
+            ureq::tls::RootCerts::Specific(certs) => assert_eq!(certs.len(), 2),
+            other => panic!("expected the file's certificates, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unusable_ca_bundle_falls_back_to_the_platform_store() {
+        let dir = std::env::temp_dir().join(format!("satkit_ca_bad_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let empty = dir.join("empty.pem");
+        std::fs::write(&empty, b"no certificates here\n").unwrap();
+
+        assert!(load_ca_bundle(Path::new("/satkit/no/such/bundle.pem")).is_err());
+        assert!(load_ca_bundle(&empty)
+            .unwrap_err()
+            .contains("no certificate"));
+        // A misconfigured variable must not turn into a failed download: warn
+        // and verify against the platform store, which is what would have been
+        // used had the variable never been set.
+        for bad in [empty.to_str().unwrap(), "/satkit/no/such/bundle.pem"] {
+            assert!(matches!(
+                with_ca_bundle_env(Some(bad), root_certs),
+                ureq::tls::RootCerts::PlatformVerifier
+            ));
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn tls_trust_hint_only_for_certificate_failures() {
+        let cert_err = ureq::Error::Io(std::io::Error::other(
+            "invalid peer certificate: UnknownIssuer",
+        ));
+        let hint = tls_trust_hint(&cert_err).unwrap();
+        assert!(hint.contains(CA_BUNDLE_ENV) && hint.contains("proxy"));
+        assert!(
+            tls_trust_hint(&ureq::Error::Io(std::io::Error::other("connection reset"))).is_none()
+        );
+        assert!(tls_trust_hint(&ureq::Error::StatusCode(500)).is_none());
+
+        // The wrapper names the URL and carries the hint into the message.
+        let err = request_error("https://example.org/f.bin", cert_err);
+        let msg = err.to_string();
+        assert!(matches!(err, Error::Request { .. }), "{msg}");
+        assert!(msg.contains("https://example.org/f.bin") && msg.contains(CA_BUNDLE_ENV));
+        // An error that speaks for itself gets no hint, only the URL.
+        let plain = request_error(
+            "https://example.org/f.bin",
+            ureq::Error::Io(std::io::Error::other("connection reset")),
+        );
+        assert!(matches!(plain, Error::Request { hint: None, .. }));
+        assert!(plain.to_string().contains("connection reset"));
     }
 
     #[test]

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -132,8 +132,11 @@ pub enum Error {
     #[error("could not fetch {url}: {source}{}", hint.as_deref().unwrap_or(""))]
     Request {
         url: String,
+        /// Boxed to keep this enum — and every error type that carries it,
+        /// up to `orbitprop::Error` — small; `ureq::Error` is 64 bytes on its
+        /// own, which is most of the budget `clippy::result_large_err` allows.
         #[source]
-        source: ureq::Error,
+        source: Box<ureq::Error>,
         /// Guidance appended to the message, already formatted with a leading
         /// newline; `None` when the underlying error speaks for itself.
         hint: Option<String>,
@@ -369,7 +372,7 @@ pub(crate) fn request_error(url: &str, source: ureq::Error) -> Error {
         .map(|h| format!("\n{h}"));
     Error::Request {
         url: url.to_string(),
-        source,
+        source: Box::new(source),
         hint,
     }
 }

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -71,6 +71,22 @@ pub enum Error {
         hint: Option<String>,
     },
 
+    /// A download completed, but its content is not what the file is meant
+    /// to hold — a captive portal or proxy interstitial answering `200 OK`
+    /// with an HTML page, or a truncated feed. The partial download is
+    /// discarded and any existing copy left in place, so a good data file is
+    /// never replaced by a bad one.
+    #[error(
+        "{name} downloaded from {url} was rejected: {reason}. \
+         The partial download was discarded and any existing {name} left in place \
+         (a proxy that answers with an HTML notice instead of the file looks like this)"
+    )]
+    ContentRejected {
+        name: String,
+        url: String,
+        reason: String,
+    },
+
     /// Replacing an existing data file failed even after retries. On
     /// Windows a file another process has open cannot be renamed over; on
     /// any platform this also covers a directory that became read-only.
@@ -464,12 +480,60 @@ fn rename_into_place(part: &Path, final_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// `Err` if the file at `path` opens with an HTML document rather than the
+/// data that was asked for. A filtering proxy or captive portal that answers
+/// `200 OK` with a notice page is otherwise indistinguishable from a
+/// successful download for the files satkit fetches unverified.
+#[cfg(feature = "download")]
+fn reject_html(path: &Path) -> std::result::Result<(), String> {
+    use std::io::Read;
+    let mut head = [0u8; 256];
+    let n = std::fs::File::open(path)
+        .and_then(|mut f| f.read(&mut head))
+        .map_err(|e| e.to_string())?;
+    let start = String::from_utf8_lossy(&head[..n])
+        .trim_start_matches(['\u{feff}', ' ', '\n', '\r', '\t'])
+        .to_ascii_lowercase();
+    if start.starts_with("<!doctype html") || start.starts_with("<html") {
+        return Err("the response is an HTML page, not the data file".to_string());
+    }
+    Ok(())
+}
+
+/// Check a freshly downloaded, *unverified* file before it replaces the copy
+/// on disk. The manifest-pinned files are covered by their SHA-256; these are
+/// the ones with nothing to compare against — so the daily CelesTrak feeds
+/// are parsed with the same parser that will later read them, and anything
+/// else is at least checked for not being an HTML notice page.
+///
+/// `name` is the file's base name; `path` is the completed `.part` file.
+#[cfg(feature = "download")]
+fn check_content(name: &str, path: &Path) -> std::result::Result<(), String> {
+    let is_html_file = std::path::Path::new(name)
+        .extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("html") || e.eq_ignore_ascii_case("htm"));
+    if !is_html_file {
+        reject_html(path)?;
+    }
+    match name {
+        "EOP-All.csv" => crate::earth_orientation_params::validate_file(path),
+        "SW-All.csv" => crate::spaceweather::validate_file(path),
+        _ => Ok(()),
+    }
+}
+
 /// Stream `reader` to `final_path` atomically: write to a sibling `.part` file
 /// and rename it into place on success. An interrupted transfer (network drop,
 /// Ctrl-C) then leaves only the discardable `.part` file rather than a truncated
 /// final file that later runs would trust as complete.
+///
+/// The completed `.part` file is passed through [`check_content`] before the
+/// rename: these downloads carry no hash to verify, and replacing a good
+/// `EOP-All.csv` with a proxy's notice page would turn a failed download into
+/// a silently wrong table days later. `url` only names the source in
+/// [`Error::ContentRejected`].
 #[cfg(feature = "download")]
-fn write_atomic(reader: &mut impl std::io::Read, final_path: &Path) -> Result<()> {
+fn write_atomic(reader: &mut impl std::io::Read, final_path: &Path, url: &str) -> Result<()> {
     let part = part_path(final_path);
     let mut write = || -> Result<()> {
         let mut dest = std::fs::File::create(&part)?;
@@ -477,13 +541,23 @@ fn write_atomic(reader: &mut impl std::io::Read, final_path: &Path) -> Result<()
         dest.sync_all()?;
         Ok(())
     };
-    match write() {
-        Ok(()) => rename_into_place(&part, final_path),
-        Err(e) => {
-            let _ = std::fs::remove_file(&part);
-            Err(e)
-        }
+    if let Err(e) = write() {
+        let _ = std::fs::remove_file(&part);
+        return Err(e);
     }
+    let name = final_path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or_default();
+    if let Err(reason) = check_content(name, &part) {
+        let _ = std::fs::remove_file(&part);
+        return Err(Error::ContentRejected {
+            name: name.to_string(),
+            url: url.to_string(),
+            reason,
+        });
+    }
+    rename_into_place(&part, final_path)
 }
 
 /// Like [`write_atomic`], but the stream is hashed as it is written and the
@@ -600,7 +674,7 @@ pub fn download_if_not_exist(fname: &Path, seturl: Option<&str>) -> Result<()> {
         .call()
         .map_err(|e| request_error(&url, e))?;
 
-    write_atomic(&mut resp.body_mut().as_reader(), fname)?;
+    write_atomic(&mut resp.body_mut().as_reader(), fname, &url)?;
     Ok(())
 }
 
@@ -641,7 +715,7 @@ pub fn download_file(url: &str, downloaddir: &Path, overwrite_if_exists: bool) -
     let mut resp = agent.get(url).call().map_err(|e| request_error(url, e))?;
 
     println!("Downloading {}", fname);
-    write_atomic(&mut resp.body_mut().as_reader(), &fullpath)?;
+    write_atomic(&mut resp.body_mut().as_reader(), &fullpath, url)?;
     Ok(true)
 }
 
@@ -699,7 +773,7 @@ mod tests {
         let _ = std::fs::remove_file(&part_path);
 
         let data = b"hello satkit";
-        write_atomic(&mut Cursor::new(&data[..]), &final_path).unwrap();
+        write_atomic(&mut Cursor::new(&data[..]), &final_path, "test").unwrap();
 
         assert!(
             final_path.is_file(),
@@ -793,6 +867,52 @@ mod tests {
         assert!(matches!(err, Error::ReplaceFailed { .. }), "{err}");
         assert!(err.to_string().contains("f.bin"));
         assert!(!part.exists(), "temporary file is cleaned up");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// One header line and one row, in the columns `parse_csv` reads.
+    const EOP_CSV: &str = "DATE,MJD,X,Y,UT1-UTC,LOD,dPSI,dEPS,DX,DY,DAT,DATA_TYPE\n\
+                           2026-08-30,61282,0.10,0.20,0.30,0.0004,0,0,0.0001,0.0002,37,O\n";
+
+    #[test]
+    fn a_proxy_notice_page_never_replaces_a_good_data_file() {
+        let dir = std::env::temp_dir().join(format!("satkit_notice_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("EOP-All.csv");
+
+        // A good table on disk, as a machine that has been online would have.
+        write_atomic(&mut Cursor::new(EOP_CSV.as_bytes()), &path, "test").unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), EOP_CSV);
+
+        // The daily refresh comes back as a proxy interstitial with HTTP 200.
+        let page = b"<!DOCTYPE html>\n<html><body>Review Usage Policy</body></html>";
+        let err = write_atomic(
+            &mut Cursor::new(&page[..]),
+            &path,
+            "https://celestrak.org/SpaceData/EOP-All.csv",
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, Error::ContentRejected { ref name, .. } if name == "EOP-All.csv"),
+            "{err}"
+        );
+        assert!(err.to_string().contains("HTML page"), "{err}");
+        // The table that was there is still there, and nothing is left over.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), EOP_CSV);
+        assert!(!part_path(&path).exists());
+
+        // A body that is not HTML but does not parse is rejected just as well.
+        let err = write_atomic(&mut Cursor::new(&b"1,2,3\n"[..]), &path, "test").unwrap_err();
+        assert!(matches!(err, Error::ContentRejected { .. }), "{err}");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), EOP_CSV);
+
+        // A file with no content check of its own only has to not be a page.
+        let other = dir.join("notes.txt");
+        write_atomic(&mut Cursor::new(&b"1,2,3\n"[..]), &other, "test").unwrap();
+        assert!(other.is_file());
+        let err = write_atomic(&mut Cursor::new(&page[..]), &other, "test").unwrap_err();
+        assert!(matches!(err, Error::ContentRejected { .. }), "{err}");
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src/utils/manifest.rs
+++ b/src/utils/manifest.rs
@@ -403,15 +403,27 @@ pub fn fetch_static_file(
     }
 
     let mut attempts: Vec<String> = Vec::new();
+    let mut hint: Option<String> = None;
     for url in entry.candidate_urls() {
         match download_verified(&url, entry, &dest) {
             Ok(()) => return Ok(FetchOutcome::Downloaded { url }),
-            Err(e) => attempts.push(format!("{url}: {e}")),
+            Err(e) => {
+                // Every source fails the same way behind an intercepting
+                // proxy; carry the explanation out once instead of leaving
+                // four bare `invalid peer certificate` lines.
+                if hint.is_none() {
+                    if let Error::Http(ref http) = e {
+                        hint = download::tls_trust_hint(http).map(|h| format!("\n{h}"));
+                    }
+                }
+                attempts.push(format!("{url}: {e}"));
+            }
         }
     }
     Err(Error::AllSourcesFailed {
         name: entry.name.clone(),
         attempts,
+        hint,
     })
 }
 

--- a/src/utils/update_data.rs
+++ b/src/utils/update_data.rs
@@ -454,9 +454,15 @@ mod tests {
         let e = entry("f.bin", b"right", vec![a.url("f.bin"), b.url("f.bin")]);
         let err = manifest::fetch_static_file(&e, &dir, false).unwrap_err();
         match &err {
-            download::Error::AllSourcesFailed { name, attempts } => {
+            download::Error::AllSourcesFailed {
+                name,
+                attempts,
+                hint,
+            } => {
                 assert_eq!(name, "f.bin");
                 assert_eq!(attempts.len(), 2);
+                // Plain HTTP failures speak for themselves; no hint appended.
+                assert!(hint.is_none(), "{hint:?}");
                 assert!(attempts[0].starts_with(&a.url("f.bin")), "{}", attempts[0]);
                 assert!(attempts[1].starts_with(&b.url("f.bin")), "{}", attempts[1]);
                 assert!(attempts[1].contains("mismatch"), "{}", attempts[1]);


### PR DESCRIPTION
On a network whose TLS is inspected by a corporate proxy, every satkit download failed:

```
RuntimeError: io: invalid peer certificate: UnknownIssuer
```

ureq verified servers against the Mozilla root list compiled into the binary (`webpki-roots`), which is the one trust store guaranteed to fail there: the gateway re-signs every certificate with a private CA that is installed system-wide and can never be in the Mozilla list. The message named neither the URL nor anything to do about it. Reproduced against `celestrak.org`, whose chain arrives issued by `CN=McAfee Web Gateway 2022, O=MIT Lincoln Laboratory` — `curl` (macOS Secure Transport, so the keychain) verifies it; satkit did not.

## Trust store

Verify against the **platform trust store** instead — the macOS keychain, the Windows certificate store, `/etc/ssl` on Unix — via ureq's `platform-verifier` feature. That is where an administrator installs such a CA, so these downloads now work with no configuration. The trade-off is deliberate and is stated in the docs: trusting the platform store means trusting whatever has been added to it.

`SATKIT_CA_BUNDLE` overrides the choice at runtime — important because most users get a wheel and cannot recompile:

| value | effect |
|---|---|
| `/path/bundle.pem` | trust exactly these certificates (replaces the store, so include the public roots) |
| `platform` | the system trust store (default) |
| `webpki` | the Mozilla list compiled into satkit — a container with no system store, or a deliberate refusal to trust the machine's |

`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` are deliberately **not** consulted: Python tooling routinely points them at a stock public bundle, which is exactly the trust store that fails on an intercepting network.

Download failures now name the URL, and a certificate failure explains intercepting proxies and `SATKIT_CA_BUNDLE` — once per file rather than repeated under each of the four candidate sources (`Error::Request`; `AllSourcesFailed` gains a `hint` field). A CelesTrak 403 also notes that a filtering proxy, not CelesTrak, may be the one answering.

## Content check

The same environment exposed a second problem. `EOP-All.csv` and `SW-All.csv` carry no hash — they change daily, so the manifest cannot pin them — and were streamed straight over the copy on disk. A proxy that answers `200 OK` with a notice page instead of blocking outright would therefore overwrite a good EOP table with a web page, and the breakage would surface days later.

The completed `.part` file is now checked before the rename: the two feeds go through the same `parse_csv` that will later read them, and any unverified download is rejected if it opens with an HTML document. On rejection the partial file is discarded and the existing file left in place, so a blocked refresh degrades to a stale table rather than a broken one (`Error::ContentRejected`).

## Dependency cost

Platform-local, and no C toolchain: macOS +6 crates (`security-framework` / `core-foundation` bindings), Linux +3 (`rustls-native-certs`, `openssl-probe` — no OpenSSL linkage), Windows +4 (`windows-sys`).

## Testing

- 6 new unit tests: root-cert selection for each `SATKIT_CA_BUNDLE` value, PEM bundle loading, fallback when the variable is unusable, the TLS hint and its absence on unrelated errors, and a proxy notice page failing to replace a good `EOP-All.csv`.
- Verified live from an intercepted network: `celestrak.org` now completes the TLS handshake (and returns the gateway's own HTML notice, which is rejected as above); `raw.githubusercontent.com` fetches normally; pointing `SATKIT_CA_BUNDLE` at a stock certifi bundle reproduces `UnknownIssuer` with the new guidance attached.
- `cargo clippy --all-targets`, `cargo fmt`, `cargo doc` clean; the full suite shows the same 74 failures as `main` on this machine, all from a data directory with no `EOP-All.csv` / `SW-All.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNLmgj3nJXuTpiEUHqrZmY