### PR TITLE
Release 0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## 0.21.2 - 2026-08-30
 
+### Changed
+
+- **Breaking (Rust):** `utils::download::Error` and its field-carrying variants are `#[non_exhaustive]`: downstream matches need a wildcard arm and struct patterns a `..`, so future variants and fields (this release alone added `Request`, `ContentRejected`, and `AllSourcesFailed.hint`) land without breaking compiles ([#161](https://github.com/ssmichael1/satkit/pull/161))
+
 ### Fixed
 
 - Downloads verify servers against the operating system's trust store (macOS keychain, Windows certificate store, `/etc/ssl` on Unix) instead of the Mozilla root list compiled into the HTTP client: on a network whose TLS is inspected by a corporate proxy every download failed with `io: invalid peer certificate: UnknownIssuer`, because such a proxy re-signs traffic with a private CA that can only ever live in the system store. `SATKIT_CA_BUNDLE` overrides the choice with a PEM file, `platform`, or `webpki` (the compiled-in roots, for a container with no system store); `SSL_CERT_FILE` is deliberately not consulted. Download errors also name the URL that failed and, for a certificate failure, say what to do about it once (`download::Error` gains a `Request` variant, and `AllSourcesFailed` a `hint` field) ([#160](https://github.com/ssmichael1/satkit/pull/160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Only recent releases are listed. Older entries are in this file's git history (`git show vX.Y.Z:CHANGELOG.md`) and on the [GitHub Releases](https://github.com/ssmichael1/satkit/releases) page.
 
-## Unreleased
+## 0.21.2 - 2026-08-30
 
 ### Fixed
 
@@ -220,18 +220,3 @@ typed `sgp4::Error::SatRecInit` API cleanups (PR #123) and the stubtest CI
 check (PR #122). Those entries were recorded under 0.20.4 above when 0.20.4
 followed a week later; see that section for details.
 
-## 0.20.2 - 2026-07-03
-
-### Fixed
-
-- **`Kepler` mean→eccentric anomaly conversion was inaccurate for
-  high-eccentricity orbits with unwrapped mean anomalies** (e.g.
-  `Kepler::propagate` beyond one revolution at e ≳ 0.85): the naive
-  `E₀ = M ± e` Newton starting guess lands in a near-flat region of Kepler's
-  equation, the iteration turns chaotic, and the (0.20.0-introduced)
-  iteration cap could exit with a badly wrong anomaly — up to ~0.24 rad of
-  true-anomaly error observed. `mean2eccentric` now range-reduces M to
-  [0, 2π) and uses Danby's initial guess, converging in <10 iterations for
-  all e < 1. Found by the new property-based test suite in CI
-  (`kepler_period_closure`, fresh random seed); the counterexample is pinned
-  as a permanent regression test.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "python"]
 
 [package]
 name = "satkit"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 description = "Satellite Toolkit"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">= 3.10"
 authors = [{ name = "Steven Michael", email = "ssmichael@gmail.com" }]
 maintainers = [{ name = "Steven Michael", email = "ssmichael@gmail.com" }]
 readme = "README.md"
-version = "0.21.1"
+version = "0.21.2"
 license = "MIT OR Apache-2.0"
 description = "Satellite Orbital Dynamics Toolkit"
 keywords = [

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "satkit-python"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 publish = false
 

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -3,7 +3,13 @@ use thiserror::Error;
 
 /// Errors produced by the [`utils::download`](crate::utils::download) and
 /// [`utils::manifest`](crate::utils::manifest) helpers.
+///
+/// `#[non_exhaustive]`: variants (and, over time, fields on them) are added
+/// as failure modes gain dedicated diagnoses — 0.21.2 alone added
+/// [`Error::Request`] and [`Error::ContentRejected`]. Downstream matches
+/// must carry a wildcard arm so those additions are not breaking changes.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// Returned by all download helpers when satkit was built without the
     /// `download` Cargo feature.
@@ -14,6 +20,7 @@ pub enum Error {
     /// missing on disk and satkit was built without the `download` feature
     /// to fetch it.
     #[error("File {path} not found and satkit was built without the `download` feature")]
+    #[non_exhaustive]
     FileNotFoundNoDownload { path: String },
 
     /// A download was needed but is forbidden: either `SATKIT_OFFLINE=1` is
@@ -26,6 +33,7 @@ pub enum Error {
          sources: {}",
         if urls.is_empty() { "(none listed)".to_string() } else { urls.join(", ") }
     )]
+    #[non_exhaustive]
     Offline {
         name: String,
         reason: &'static str,
@@ -36,10 +44,12 @@ pub enum Error {
     /// single-component file name (e.g. ends in `/`, is absolute, or contains
     /// `..`).
     #[error("Path or URL has no valid file name: {path}")]
+    #[non_exhaustive]
     InvalidFileName { path: String },
 
     /// The embedded (or a supplied) data manifest failed validation.
     #[error("Data manifest is invalid: {reason}")]
+    #[non_exhaustive]
     ManifestInvalid { reason: String },
 
     /// A downloaded file's size or SHA-256 did not match the manifest.
@@ -47,6 +57,7 @@ pub enum Error {
         "{name} from {url}: {what} mismatch (expected {expected}, got {actual}); \
          the partial download was discarded"
     )]
+    #[non_exhaustive]
     HashMismatch {
         name: String,
         url: String,
@@ -65,6 +76,7 @@ pub enum Error {
         attempts.join("\n  "),
         hint.as_deref().unwrap_or("")
     )]
+    #[non_exhaustive]
     AllSourcesFailed {
         name: String,
         attempts: Vec<String>,
@@ -81,6 +93,7 @@ pub enum Error {
          The partial download was discarded and any existing {name} left in place \
          (a proxy that answers with an HTML notice instead of the file looks like this)"
     )]
+    #[non_exhaustive]
     ContentRejected {
         name: String,
         url: String,
@@ -91,6 +104,7 @@ pub enum Error {
     /// Windows a file another process has open cannot be renamed over; on
     /// any platform this also covers a directory that became read-only.
     #[error("could not replace {path} (is another process using it?): {source}")]
+    #[non_exhaustive]
     ReplaceFailed {
         path: String,
         #[source]
@@ -106,6 +120,7 @@ pub enum Error {
          Delete or replace the file, or allow downloads so it can be re-fetched",
         .values.1, .values.0
     )]
+    #[non_exhaustive]
     CorruptFile {
         name: String,
         path: String,
@@ -130,6 +145,7 @@ pub enum Error {
     /// proxy), appends guidance on how to fix it.
     #[cfg(feature = "download")]
     #[error("could not fetch {url}: {source}{}", hint.as_deref().unwrap_or(""))]
+    #[non_exhaustive]
     Request {
         url: String,
         /// Boxed to keep this enum — and every error type that carries it,


### PR DESCRIPTION
Version bump to 0.21.2 (`Cargo.toml`, `python/Cargo.toml`, `pyproject.toml`); changelog rolled (`Unreleased` → `0.21.2 - 2026-08-30`, 0.20.2 pruned to keep five releases). Also marks `utils::download::Error` `#[non_exhaustive]` (see below).

## Highlights since 0.21.1

- **TLS behind intercepting proxies** (#160): downloads verify servers against the operating system's trust store instead of the compiled-in Mozilla root list, so networks whose TLS is inspected by a corporate proxy work with no configuration; `SATKIT_CA_BUNDLE` overrides with a PEM file / `platform` / `webpki`. Download errors name the URL and explain certificate failures once. Before this fix, wheel users on such networks had no workaround at all.
- **Feed integrity** (#160): `EOP-All.csv` / `SW-All.csv` are validated with their own parsers (and every unverified download checked for HTML) before replacing the copy on disk — a proxy notice page served `200 OK` can no longer overwrite a good EOP table.
- **Breaking (Rust):** `utils::download::Error` and its field-carrying variants are now `#[non_exhaustive]`. #160 had already added variants (`Request`, `ContentRejected`) and a field (`AllSourcesFailed.hint`) to an enum cargo treats as patch-compatible; with the attribute, downstream matches carry a wildcard arm / `..` and future additions stop being breaking changes. In-crate exhaustive `Frame` matching is unaffected.
- Docs: GMAT drag corpus on the validation page and README (#157, #159).
- CI: one build run per change (#158).

After merge: tag `v0.21.2` on the squash commit to trigger `release.yml` (crates.io + PyPI), then pin the sdist sha256 in `recipes/conda/satkit/recipe.yaml` and push the bump to the staged-recipes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG969yapJ84DJceKt21Wen