### PR TITLE
conda: bump recipe to satkit 0.21.2

### DIFF
--- a/recipes/conda/satkit/recipe.yaml
+++ b/recipes/conda/satkit/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: satkit
-  version: "0.21.1"
+  version: "0.21.2"
 
 package:
   name: ${{ name|lower }}
@@ -13,7 +13,7 @@ source:
   # compiled into the extension (data/manifest.json and data/embedded/*.gz —
   # see MANIFEST.in upstream). No network access is needed at build time.
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 6d0f97888f44ed19f34914098690602038803f4f28359e8395268aedd4365058
+  sha256: 436cbdd36191624568c130304a9d4b2736faadeaec289d7485014013b436cdc9
 
 build:
   number: 0


### PR DESCRIPTION
Recipe version 0.21.1 → 0.21.2 with the published sdist's sha256 (`436cbdd3…6cdc9`), matching the bump pushed to the conda-forge staged-recipes PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG969yapJ84DJceKt21Wen