### PR TITLE
docs: propagation page names the three propagators and links SGP4 and Kepler

### DIFF
--- a/docs/api/satprop.md
+++ b/docs/api/satprop.md
@@ -1,6 +1,18 @@
 # High-Precision Orbit Propagator
 
-API reference for the numerical (force-model) propagator. For background, see:
+API reference for the numerical (force-model) propagator: `satkit.propagate`
+integrates a Cartesian state under a configurable force model (gravity field,
+Sun/Moon, drag, radiation pressure, tides, relativity). It is one of three
+ways to move a satellite forward in time in satkit — pick by what you have and
+how accurate you need to be:
+
+| you have | use | what it does |
+|---|---|---|
+| a Cartesian state and a force model | **this page** — `satkit.propagate` / `satstate.propagate` | numerical integration, the most accurate; needs the ephemeris and EOP data files |
+| a TLE / OMM element set | [`satkit.sgp4`](tle.md) | the analytic SGP4/SDP4 theory the elements were fitted with; km-level accuracy for days; no data files |
+| classical elements and an unperturbed (two-body) model | [`satkit.kepler.propagate`](kepler.md) | advances the anomaly only; instantaneous, no data files; see the [Keplerian Elements guide](../guide/kepler.md) |
+
+For background on the numerical propagator, see:
 
 - [Force Model](../guide/forces.md) — modeled forces and physical motivation
 - [Empirical SRP: ECOM](../guide/ecom.md) — the experimental ECOM solar-radiation-pressure model behind `satproperties.ecom`


### PR DESCRIPTION
The High-Precision Orbit Propagator page opens with a short "which propagator" table — numerical (`satkit.propagate`), SGP4 (`satkit.sgp4`, for TLE/OMM sets) and two-body (`kepler.propagate`) — saying what each does, when it applies, and which need data files, with links to the SGP4 and Kepler API pages and the Keplerian Elements guide. This was the remaining ask on #95 after the docs overhaul.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG969yapJ84DJceKt21Wen