### PR TITLE
density.nrlmsise: float overload takes radians as documented (was passing them through as degrees)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Fixed
 
+- `satkit.density.nrlmsise(altitude_m, latitude_rad, longitude_rad, time)` converts its radian latitude/longitude to the degrees the model takes; the values were passed through unchanged, so a caller following the stub at 60° N was evaluated at 1.05° N (the `itrfcoord` overload and `nrlmsise00(latitude_deg=...)` were already correct) ([#171](https://github.com/ssmichael1/satkit/pull/171))
 - A corrupt or truncated `tab5.2*.txt` in a data directory no longer panics the first frame transform: satkit warns and uses the compiled-in copy of the same IERS table (exact, not an approximation), and the parser now rejects text with no table header or fewer rows than declared — an HTML notice page saved under the table's name previously loaded as six empty series and silently dropped the nutation terms ([#166](https://github.com/ssmichael1/satkit/pull/166))
 
 ### Changed

--- a/python/src/pydensity.rs
+++ b/python/src/pydensity.rs
@@ -51,16 +51,19 @@ fn pynrlmsise(args: &Bound<'_, PyTuple>) -> PyResult<(f64, f64)> {
         ))
     } else if args.get_item(0)?.is_instance_of::<PyFloat>() {
         let altitude = args.get_item(0)?.extract::<f64>().unwrap();
+        // The stub documents these as radians (satkit's convention without a
+        // `_deg` suffix); the model takes degrees, as the itrfcoord branch
+        // above and `nrlmsise00(latitude_deg=...)` already supply.
         let latitude: Option<f64> = {
             if args.len() > 1 && args.get_item(1)?.is_instance_of::<PyFloat>() {
-                Some(args.get_item(1)?.extract::<f64>().unwrap())
+                Some(args.get_item(1)?.extract::<f64>().unwrap().to_degrees())
             } else {
                 None
             }
         };
         let longitude: Option<f64> = {
             if args.len() > 2 && args.get_item(2)?.is_instance_of::<PyFloat>() {
-                Some(args.get_item(2)?.extract::<f64>().unwrap())
+                Some(args.get_item(2)?.extract::<f64>().unwrap().to_degrees())
             } else {
                 None
             }

--- a/python/test/test_density.py
+++ b/python/test/test_density.py
@@ -51,3 +51,17 @@ def test_spaceweather_feed_changes_density_within_the_day():
     # Fixed indices ignore the file entirely.
     rho_fixed = sk.nrlmsise00(420.0, time=sk.time(2023, 2, 27, 13, 30, 0), use_spaceweather=False, **coord)[0]
     assert abs(rho_fixed / rho_storm[1] - 1.0) > 0.05
+
+
+def test_density_float_form_takes_radians():
+    # density.nrlmsise(altitude_m, latitude_rad, longitude_rad, time) is
+    # documented in radians; it must land on the same atmosphere as the
+    # itrfcoord form (which hands the model degrees) for the same point.
+    t = sk.time(2023, 3, 1, 12, 0, 0)
+    coord = sk.itrfcoord(latitude_deg=60.0, longitude_deg=-70.0, altitude=400e3)
+    rho_coord, temp_coord = sk.density.nrlmsise(coord, t)
+    rho_float, temp_float = sk.density.nrlmsise(
+        400e3, math.radians(60.0), math.radians(-70.0), t
+    )
+    assert math.isclose(rho_float, rho_coord, rel_tol=1e-6)
+    assert math.isclose(temp_float, temp_coord, rel_tol=1e-6)


### PR DESCRIPTION
`satkit.density.nrlmsise(altitude_m, latitude_rad, longitude_rad, time)` is documented in radians (satkit's convention without a `_deg` suffix) but handed the two floats unchanged to `nrlmsise::nrlmsise`, which takes degrees — the slot the `itrfcoord` overload fills with `latitude_deg()` (fixed in #154) and `satkit.nrlmsise00(latitude_deg=...)` fills explicitly. A caller following the stub at 60° N was evaluated at 1.05° N. Found by the #90 units sweep (#169).

Fix is a `.to_degrees()` on each value in the float branch of `python/src/pydensity.rs`; stub and docs were already right. New test `test_density_float_form_takes_radians` checks the float form with radians lands on the same density and temperature as the `itrfcoord` form at the same point (rel 1e-6).

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG969yapJ84DJceKt21Wen