### PR TITLE
dist: arm64-only macOS wheels (0.22, do not merge yet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+### Distribution
+
+- **Breaking (Python packaging):** macOS wheels are arm64 (Apple silicon) only; the `x86_64-apple-darwin` wheels are no longer built, matching SciPy/Polars and the arm64-only GitHub runners, and the macOS deployment target moves from 10.12 to 11.0. Intel-Mac users install from source (`pip install --no-binary satkit satkit`, stable Rust toolchain required) or from conda-forge, which builds `osx-64` ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+
 ### Fixed
 
 - `satkit.density.nrlmsise(altitude_m, latitude_rad, longitude_rad, time)` converts its radian latitude/longitude to the degrees the model takes; the values were passed through unchanged, so a caller following the stub at 60° N was evaluated at 1.05° N (the `itrfcoord` overload and `nrlmsise00(latitude_deg=...)` were already correct) ([#171](https://github.com/ssmichael1/satkit/pull/171))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ### Distribution
 
-- **Breaking (Python packaging):** macOS wheels are arm64 (Apple silicon) only; the `x86_64-apple-darwin` wheels are no longer built, matching SciPy/Polars and the arm64-only GitHub runners, and the macOS deployment target moves from 10.12 to 11.0. Intel-Mac users install from source (`pip install --no-binary satkit satkit`, stable Rust toolchain required) or from conda-forge, which builds `osx-64` ([#TBD](https://github.com/ssmichael1/satkit/pull/TBD))
+- **Breaking (Python packaging):** macOS wheels are arm64 (Apple silicon) only; the `x86_64-apple-darwin` wheels are no longer built, matching SciPy/Polars and the arm64-only GitHub runners, and the macOS deployment target moves from 10.12 to 11.0. Intel-Mac users install from source (`pip install --no-binary satkit satkit`, stable Rust toolchain required) or from conda-forge, which builds `osx-64` ([#172](https://github.com/ssmichael1/satkit/pull/172))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cargo add satkit
 pip install satkit
 ```
 
-Pre-built wheels are available for Linux, macOS, and Windows on Python 3.10--3.14.
+Pre-built wheels are available for Linux (x86_64, aarch64), macOS (Apple silicon), and Windows (x86_64) on Python 3.10--3.14; Intel Macs build from source (`pip install --no-binary satkit satkit`) or use conda-forge.
 
 The IERS nutation tables and gravity models are compiled in, so frames, gravity, SGP4 and time work with no data files. The JPL ephemeris (~100 MB) downloads on first use (SHA-256 verified) into the user data directory; Earth orientation and space weather are fetched on first use and should be refreshed periodically:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,7 +4,7 @@ The `satkit` package is hosted at <https://github.com/ssmichael1/satkit/>. The p
 
 ## PIP
 
-Pre-built Python binary packages are provided by the [PyPI](https://pypi.org) package manager, and are the simplest to install. Binary packages are provided for 64-bit x86 platforms running Windows, Linux, and macOS, as well as macOS systems on the ARM platform. To install via PyPI:
+Pre-built Python binary packages are provided by the [PyPI](https://pypi.org) package manager, and are the simplest to install. Binary packages are provided for Linux (x86_64 and aarch64), Windows (x86_64), and macOS on Apple silicon (arm64). Intel-based Macs are not shipped a wheel since 0.22: install from source with `pip install --no-binary satkit satkit` (needs a stable Rust toolchain) or via conda-forge, which builds `osx-64`. To install via PyPI:
 
 ```bash
 python -m pip install satkit

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
 
 SatKit is a high-performance orbital mechanics library written in Rust with complete Python bindings via PyO3. It handles coordinate transforms, orbit propagation, time systems, gravity models, atmospheric density, and JPL ephemerides -- everything needed for satellite astrodynamics work.
 
-Pre-built wheels are available for **Linux**, **macOS**, and **Windows** on Python 3.10--3.14.
+Pre-built wheels are available for **Linux** (x86_64, aarch64), **macOS** (Apple silicon), and **Windows** (x86_64) on Python 3.10--3.14; Intel Macs build from source or use conda-forge.
 
 ## Quick Start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,18 +66,16 @@ skip = ["pp*", "*_i686", "*_s390x", "*_ppc64le", "*-musllinux*"]
 # cross-compiled on the arm64 runner and cannot be executed there.
 test-requires = ["numpy"]
 test-command = "python -c \"import satkit as sk; t = sk.time(2024, 1, 1, 12, 0, 0); q = sk.quaternion.rotz(0.5); assert abs(q.angle - 0.5) < 1e-12; print('wheel OK:', sk.__version__, t)\""
-test-skip = "*-macosx_x86_64"
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64", "arm64"]
+archs = ["arm64"]
 before-build = [
     "pip install -U setuptools-rust",
     "rustup default stable",
     "rustup target add aarch64-apple-darwin",
-    "rustup target add x86_64-apple-darwin",
     "rustup show",
 ]
-environment = { PATH = "$PATH:$HOME/.cargo/bin", MACOSX_DEPLOYMENT_TARGET = "10.12" }
+environment = { PATH = "$PATH:$HOME/.cargo/bin", MACOSX_DEPLOYMENT_TARGET = "11.0" }
 
 [tool.cibuildwheel.linux]
 archs = ["native"]


### PR DESCRIPTION
Implements #112: macOS wheels are built for `arm64` only. The `x86_64-apple-darwin` arch, its `rustup target add`, and the `test-skip` for the cross-compiled wheel are removed from `[tool.cibuildwheel.macos]`; `MACOSX_DEPLOYMENT_TARGET` moves from 10.12 to 11.0 (arm64 macOS began with Big Sur). A release drops from 26 files to 21.

Rationale as in #112: the scientific-Python ecosystem is arm64-only on macOS (SciPy since 1.13, Polars), Apple stopped selling Intel Macs in 2023, `macos-latest` runners are arm64 so the x86_64 build is a cross-compile on a deprecation track, and it costs 5 wheel builds per release. Intel-Mac users: `pip install --no-binary satkit satkit` (stable Rust toolchain) or conda-forge, which builds `osx-64` (staged-recipes PR pending).

Docs: platform statements in `README.md`, `docs/index.md` and the installation page now list Linux (x86_64, aarch64), macOS (Apple silicon), Windows (x86_64) and give the Intel-Mac path. CHANGELOG has a **Distribution** entry marked breaking for Python packaging.

Parked for the **0.22** milestone with the Kepler API change (#168) so the one breaking release carries both. CI on this PR exercises the build matrix but not cibuildwheel (that runs on tag); the change is confined to cibuildwheel config, so the release workflow's macOS job is the real test — `python -m cibuildwheel --platform macos --print-build-identifiers` locally confirms only `*-macosx_arm64` identifiers remain.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG969yapJ84DJceKt21Wen